### PR TITLE
fix: do not remove last identity provider

### DIFF
--- a/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
@@ -93,6 +93,7 @@ const ProfileMenu = ({ hideLogin, allowAvatarChange, isPopover, changeActiveMenu
     (authState.linkedin && !oauthConnectedState.linkedin) ||
     (authState.twitter && !oauthConnectedState.twitter)
 
+  /**allow removing social logins if there are at least 2 social logins connected*/
   const removeSocial = Object.values(oauthConnectedState).filter((value) => value).length > 1
 
   // const loadCredentialHandler = async () => {

--- a/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
@@ -93,13 +93,7 @@ const ProfileMenu = ({ hideLogin, allowAvatarChange, isPopover, changeActiveMenu
     (authState.linkedin && !oauthConnectedState.linkedin) ||
     (authState.twitter && !oauthConnectedState.twitter)
 
-  const removeSocial =
-    (authState?.discord && oauthConnectedState.discord) ||
-    (authState.facebook && oauthConnectedState.facebook) ||
-    (authState.github && oauthConnectedState.github) ||
-    (authState.google && oauthConnectedState.google) ||
-    (authState.linkedin && oauthConnectedState.linkedin) ||
-    (authState.twitter && oauthConnectedState.twitter)
+  const removeSocial = Object.values(oauthConnectedState).filter((value) => value).length > 1
 
   // const loadCredentialHandler = async () => {
   //   try {
@@ -557,51 +551,53 @@ const ProfileMenu = ({ hideLogin, allowAvatarChange, isPopover, changeActiveMenu
                 </div>
 
                 {!selfUser?.isGuest.value && removeSocial && (
-                  <Text align="center" variant="body2" mb={1} mt={2}>
-                    {t('user:usermenu.profile.removeSocial')}
-                  </Text>
-                )}
+                  <>
+                    <Text align="center" variant="body2" mb={1} mt={2}>
+                      {t('user:usermenu.profile.removeSocial')}
+                    </Text>
 
-                <div className={styles.socialContainer}>
-                  {authState?.discord && oauthConnectedState.discord && (
-                    <IconButton
-                      id="discord"
-                      icon={<DiscordIcon viewBox="0 0 40 40" />}
-                      onClick={handleRemoveOAuthServiceClick}
-                    />
-                  )}
-                  {authState?.google && oauthConnectedState.google && (
-                    <IconButton
-                      id="google"
-                      icon={<GoogleIcon viewBox="0 0 40 40" />}
-                      onClick={handleRemoveOAuthServiceClick}
-                    />
-                  )}
-                  {authState?.facebook && oauthConnectedState.facebook && (
-                    <IconButton
-                      id="facebook"
-                      icon={<Icon type="Facebook" viewBox="0 0 40 40" />}
-                      onClick={handleRemoveOAuthServiceClick}
-                    />
-                  )}
-                  {authState?.linkedin && oauthConnectedState.linkedin && (
-                    <IconButton
-                      id="linkedin"
-                      icon={<LinkedInIcon viewBox="0 0 40 40" />}
-                      onClick={handleRemoveOAuthServiceClick}
-                    />
-                  )}
-                  {authState?.twitter && oauthConnectedState.twitter && (
-                    <IconButton
-                      id="twitter"
-                      icon={<Icon type="Twitter" viewBox="0 0 40 40" />}
-                      onClick={handleRemoveOAuthServiceClick}
-                    />
-                  )}
-                  {authState?.github && oauthConnectedState.github && (
-                    <IconButton id="github" icon={<Icon type="GitHub" />} onClick={handleRemoveOAuthServiceClick} />
-                  )}
-                </div>
+                    <div className={styles.socialContainer}>
+                      {authState?.discord && oauthConnectedState.discord && (
+                        <IconButton
+                          id="discord"
+                          icon={<DiscordIcon viewBox="0 0 40 40" />}
+                          onClick={handleRemoveOAuthServiceClick}
+                        />
+                      )}
+                      {authState?.google && oauthConnectedState.google && (
+                        <IconButton
+                          id="google"
+                          icon={<GoogleIcon viewBox="0 0 40 40" />}
+                          onClick={handleRemoveOAuthServiceClick}
+                        />
+                      )}
+                      {authState?.facebook && oauthConnectedState.facebook && (
+                        <IconButton
+                          id="facebook"
+                          icon={<Icon type="Facebook" viewBox="0 0 40 40" />}
+                          onClick={handleRemoveOAuthServiceClick}
+                        />
+                      )}
+                      {authState?.linkedin && oauthConnectedState.linkedin && (
+                        <IconButton
+                          id="linkedin"
+                          icon={<LinkedInIcon viewBox="0 0 40 40" />}
+                          onClick={handleRemoveOAuthServiceClick}
+                        />
+                      )}
+                      {authState?.twitter && oauthConnectedState.twitter && (
+                        <IconButton
+                          id="twitter"
+                          icon={<Icon type="Twitter" viewBox="0 0 40 40" />}
+                          onClick={handleRemoveOAuthServiceClick}
+                        />
+                      )}
+                      {authState?.github && oauthConnectedState.github && (
+                        <IconButton id="github" icon={<Icon type="GitHub" />} onClick={handleRemoveOAuthServiceClick} />
+                      )}
+                    </div>
+                  </>
+                )}
               </>
             )}
 

--- a/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
@@ -93,8 +93,8 @@ const ProfileMenu = ({ hideLogin, allowAvatarChange, isPopover, changeActiveMenu
     (authState.linkedin && !oauthConnectedState.linkedin) ||
     (authState.twitter && !oauthConnectedState.twitter)
 
-  /**allow removing social logins if there are at least 2 social logins connected*/
-  const removeSocial = Object.values(oauthConnectedState).filter((value) => value).length > 1
+  /**allow removing social logins if there is at least 1 social logins connected*/
+  const removeSocial = Object.values(oauthConnectedState).filter((value) => value).length >= 1
 
   // const loadCredentialHandler = async () => {
   //   try {

--- a/packages/server-core/src/user/identity-provider/identity-provider.hooks.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.hooks.ts
@@ -46,9 +46,17 @@ const checkIdentityProvider = (): any => {
 
 const checkOnlyIdentityProvider = () => {
   return async (context: HookContext): Promise<HookContext> => {
+    if (!context.id) {
+      // If trying to delete multiple providers, do not check if only 1 identity provider exists
+      return context
+    }
+
+    const thisIdentityProvider = await (context.app.service('identity-provider') as any).Model.findByPk(context.id)
+
     const providers = await context.app
       .service('identity-provider')
-      .find({ query: { userId: context.params.query.userId } })
+      .find({ query: { userId: thisIdentityProvider.userId } })
+
     if (providers.total <= 1) {
       throw new MethodNotAllowed('Cannot remove the only provider')
     }


### PR DESCRIPTION
## Summary

- Do not show the OAuth Identity Provider for removal if it is the only one present.
- Also, added the check in server-core along with corresponding tests.
- Refactored `identity-provider service` tests to use `userId` instead of `providers` array. ([assert should not be done inside a loop](https://stackoverflow.com/questions/41832594/should-you-do-an-assert-statement-inside-a-loop))

## References

Closes #7575 

## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

