### PR TITLE
Fixed some missing app.setup()'s in scripts.

### DIFF
--- a/packages/client-core/src/admin/components/Avatars/AvatarDrawer.tsx
+++ b/packages/client-core/src/admin/components/Avatars/AvatarDrawer.tsx
@@ -120,8 +120,8 @@ const AvatarDrawerContent = ({ open, mode, selectedAvatar, onClose }: Props) => 
         ...defaultState,
         name: selectedAvatar.name || '',
         source: 'url',
-        avatarUrl: selectedAvatar.modelResource?.LOD0_url || '',
-        thumbnailUrl: selectedAvatar.thumbnailResource?.LOD0_url || '',
+        avatarUrl: selectedAvatar.modelResource?.LOD0_url || selectedAvatar.modelResource?.url || '',
+        thumbnailUrl: selectedAvatar.thumbnailResource?.LOD0_url || selectedAvatar.thumbnailResource?.url || '',
         avatarFile: undefined,
         thumbnailFile: undefined
       })

--- a/packages/client-core/src/user/components/UserMenu/menus/AvatarModifyMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/AvatarModifyMenu.tsx
@@ -93,8 +93,8 @@ const AvatarModifyMenu = ({ selectedAvatar, changeActiveMenu }: Props) => {
       setState({
         ...defaultState,
         name: selectedAvatar.name || '',
-        avatarUrl: selectedAvatar.modelResource?.LOD0_url || '',
-        thumbnailUrl: selectedAvatar.thumbnailResource?.LOD0_url || '',
+        avatarUrl: selectedAvatar.modelResource?.LOD0_url || selectedAvatar.modelResource?.url || '',
+        thumbnailUrl: selectedAvatar.thumbnailResource?.LOD0_url || selectedAvatar.thumbnailResource?.url || '',
         avatarFile: undefined,
         thumbnailFile: undefined
       })

--- a/packages/client-core/src/user/components/UserMenu/menus/AvatarSelectMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/AvatarSelectMenu.tsx
@@ -55,8 +55,8 @@ const AvatarMenu = ({ changeActiveMenu }: Props) => {
     if (selectedAvatarId && selectedAvatar && userAvatarId !== selectedAvatarId) {
       setAvatar(
         selectedAvatarId,
-        selectedAvatar.modelResource?.LOD0_url || '',
-        selectedAvatar.thumbnailResource?.LOD0_url || ''
+        selectedAvatar.modelResource?.LOD0_url || selectedAvatar.modelResource?.url || '',
+        selectedAvatar.thumbnailResource?.LOD0_url || selectedAvatar.thumbnailResource?.url || ''
       )
       changeActiveMenu(Views.Closed)
     }

--- a/packages/server-core/src/user/avatar/avatar-helper.ts
+++ b/packages/server-core/src/user/avatar/avatar-helper.ts
@@ -106,7 +106,6 @@ export const uploadAvatarStaticResource = async (
   data: AvatarUploadArguments,
   params?: UserParams
 ) => {
-  console.log('uploadAvatarStaticResource', data)
   const name = data.avatarName ? data.avatarName : 'Avatar-' + Math.round(Math.random() * 100000)
 
   const key = `static-resources/avatar/${data.isPublic ? 'public' : params?.user!.id}/${name}`

--- a/scripts/convert-avatars.ts
+++ b/scripts/convert-avatars.ts
@@ -31,6 +31,7 @@ cli.enable('status')
 cli.main(async () => {
   try {
     const app = createFeathersExpressApp(ServerMode.API)
+    await app.setup()
     const sequelizeClient = new Sequelize({
       ...db,
       logging: console.log,

--- a/scripts/convert-static-resource-url.ts
+++ b/scripts/convert-static-resource-url.ts
@@ -31,15 +31,7 @@ cli.enable('status')
 cli.main(async () => {
     try {
         const app = createFeathersExpressApp(ServerMode.API)
-        const sequelizeClient = new Sequelize({
-            ...db,
-            logging: console.log,
-            define: {
-                freezeTableName: true
-            }
-        })
-
-        await sequelizeClient.sync()
+        await app.setup()
 
         const staticResources = await app.service('static-resource').Model.findAll({
             paginate: false,


### PR DESCRIPTION
## Summary

The install-projects script was not calling app.setup() after creating the feathers
app. With the new creation of assets when default-project is uploaded, this was
causing the resulting find's with associations to fail because the associations
were not set up.

Saw a couple other scripts that had this problem as well, added there too.

Added some support for legacy avatar url location on resources.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

