### PR TITLE
improve: do not allow to bulk remove identity providers

### DIFF
--- a/packages/server-core/src/user/identity-provider/identity-provider.hooks.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.hooks.ts
@@ -47,8 +47,8 @@ const checkIdentityProvider = (): any => {
 const checkOnlyIdentityProvider = () => {
   return async (context: HookContext): Promise<HookContext> => {
     if (!context.id) {
-      // If trying to delete multiple providers, do not check if only 1 identity provider exists
-      return context
+      // do not allow to remove identity providers in bulk
+      throw new MethodNotAllowed('Cannot remove multiple providers together')
     }
 
     const thisIdentityProvider = await (context.app.service('identity-provider') as any).Model.findByPk(context.id)

--- a/packages/server-core/src/user/identity-provider/identity-provider.test.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.test.ts
@@ -113,20 +113,18 @@ describe('identity-provider service', () => {
     assert.equal((item as any).total, 0)
   })
 
-  it('should remove identity providers by user id', async () => {
-    await app.service('identity-provider').remove(null, {
-      query: {
-        userId
+  it('should not be able to remove identity providers by user id', async () => {
+    assert.rejects(
+      () =>
+        app.service('identity-provider').remove(null, {
+          query: {
+            userId
+          }
+        }),
+      {
+        name: 'MethodNotAllowed'
       }
-    })
-
-    const item = await app.service('identity-provider').find({
-      query: {
-        userId
-      }
-    })
-
-    assert.equal((item as any).total, 0)
+    )
   })
 
   it('should not be able to remove the only identity provider', async () => {
@@ -144,7 +142,5 @@ describe('identity-provider service', () => {
     assert.rejects(() => app.service('identity-provider').remove(item.id), {
       name: 'MethodNotAllowed'
     })
-
-    assert.ok(true)
   })
 })


### PR DESCRIPTION
## Summary

Identity Providers should not be allowed to be removed in bulk via API.
Remove identity provider only if _id_ is present (i.e. only allow single remove)
Made corresponding changes for the unit tests


## References

Refs https://github.com/EtherealEngine/etherealengine/pull/7739#discussion_r1137978204


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps


