### PR TITLE
Fix BuildStatusDrawer

### DIFF
--- a/packages/client-core/src/admin/components/Project/BuildStatusDrawer.tsx
+++ b/packages/client-core/src/admin/components/Project/BuildStatusDrawer.tsx
@@ -32,7 +32,7 @@ const defaultBuildStatus = {
 const BuildStatusDrawer = ({ open, onClose }: Props) => {
   const page = useHookstate(0)
   const rowsPerPage = useHookstate(10)
-  const selectedStatus = useHookstate(defaultBuildStatus)
+  const selectedStatusId = useHookstate(0)
   const logsModalOpen = useHookstate(false)
 
   const fieldOrder = useHookstate('desc')
@@ -42,7 +42,7 @@ const BuildStatusDrawer = ({ open, onClose }: Props) => {
   const buildStatuses = buildStatusState.buildStatuses.value
 
   const handleOpenLogsModal = (buildStatus: BuildStatus) => {
-    selectedStatus.set(buildStatus)
+    selectedStatusId.set(buildStatus.id)
     logsModalOpen.set(true)
   }
 
@@ -52,7 +52,7 @@ const BuildStatusDrawer = ({ open, onClose }: Props) => {
 
   const handleCloseLogsModal = () => {
     logsModalOpen.set(false)
-    selectedStatus.set(defaultBuildStatus)
+    selectedStatusId.set(0)
   }
   const createData = (el: BuildStatus) => {
     return {
@@ -118,6 +118,8 @@ const BuildStatusDrawer = ({ open, onClose }: Props) => {
     return createData(el)
   })
 
+  const selectedStatus = buildStatuses.find((el) => el.id === selectedStatusId.value) || defaultBuildStatus
+
   const handlePageChange = (event: unknown, newPage: number) => {
     BuildStatusService.fetchBuildStatus(newPage * 10)
     page.set(newPage)
@@ -149,11 +151,7 @@ const BuildStatusDrawer = ({ open, onClose }: Props) => {
           handlePageChange={handlePageChange}
           handleRowsPerPageChange={handleRowsPerPageChange}
         />
-        <BuildStatusLogsModal
-          open={logsModalOpen.value}
-          onClose={handleCloseLogsModal}
-          buildStatus={selectedStatus.value}
-        />
+        <BuildStatusLogsModal open={logsModalOpen.value} onClose={handleCloseLogsModal} buildStatus={selectedStatus} />
       </Container>
     </DrawerView>
   )


### PR DESCRIPTION
## Summary

This solves the hookstate-102 exception which was preventing logs from showing;

Unfortunatley I'm still seeing this warning from React:

```
react.development.js:209 Warning: Failed prop type: Invalid prop `children` supplied to `ForwardRef(Modal2)`. Expected an element that can hold a ref. Did you accidentally use a plain function component for an element instead? For more information see https://mui.com/r/caveat-with-refs-guide
    at Modal2 (https://gheric.shetland-turtle.ts.net:3000/node_modules/.vite/deps/@mui_material.js?v=dcc885bf:10130:17)
    at Modal (https://gheric.shetland-turtle.ts.net:3000/@fs/Users/gheric/GitHub/etherealengine/packages/ui/src/Modal/index.tsx:3:18)
    at BuildStatusLogsModal (https://gheric.shetland-turtle.ts.net:3000/@fs/Users/gheric/GitHub/etherealengine/packages/client-core/src/admin/components/Project/BuildStatusLogsModal.tsx:8:33)
```