### PR TITLE
Improve i18n IDE tooling

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "lokalise.i18n-ally"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,10 @@
   },
   "editor.tabSize": 2,
   "scm.alwaysShowRepositories": true,
-  "scm.repositories.visible": 0
+  "scm.repositories.visible": 0,
+  "i18n-ally.localesPaths": [
+    "packages/client-core/i18n"
+  ],
+  "i18n-ally.keystyle": "nested",
+  "i18n-ally.namespace": true
 }

--- a/packages/client-core/src/admin/components/Project/BuildStatusDrawer.tsx
+++ b/packages/client-core/src/admin/components/Project/BuildStatusDrawer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { BuildStatus } from '@etherealengine/common/src/interfaces/BuildStatus'
 import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
@@ -30,6 +31,7 @@ const defaultBuildStatus = {
 }
 
 const BuildStatusDrawer = ({ open, onClose }: Props) => {
+  const { t } = useTranslation()
   const page = useHookstate(0)
   const rowsPerPage = useHookstate(10)
   const selectedStatusId = useHookstate(0)
@@ -137,7 +139,7 @@ const BuildStatusDrawer = ({ open, onClose }: Props) => {
   return (
     <DrawerView open={open} onClose={handleClose}>
       <Container maxWidth="sm" className={styles.mt20}>
-        <DialogTitle className={styles.textAlign}></DialogTitle>
+        <DialogTitle className={styles.textAlign}>{t('admin:components.project.buildStatus')}</DialogTitle>
         <TableComponent
           allowSort={false}
           fieldOrder={fieldOrder.value}


### PR DESCRIPTION
Adds a recommended VSCode extension for better i18n IDE support, with appropriate settings. 

<img width="510" alt="image" src="https://user-images.githubusercontent.com/507127/226735341-2e102a94-089c-4035-8591-09755a755e60.png">

<img width="452" alt="image" src="https://user-images.githubusercontent.com/507127/226736213-9492c546-52e4-40c1-9422-9cf77201276c.png">


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> #### What Changed
> Added
> - Added i18n-ally extension to recommendations in extensions.json
> - Added i18n-ally configuration to settings.json
> - Imported useTranslation from react-i18next in BuildStatusDrawer.tsx
> #### Testing
> Test that the i18n-ally extension is installed and configured correctly. 
> #### Reasoning
> This change adds support for internationalization (i18n) to the project. The i18n-ally extension provides a convenient way to manage translations, and the configuration in settings.json sets up the extension to work with the project's i18n files. 
</details>