### PR TITLE
add condition to allow guests to log in while not having any identity provider

### DIFF
--- a/packages/server-core/src/user/identity-provider/identity-provider.test.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.test.ts
@@ -127,8 +127,23 @@ describe('identity-provider service', () => {
     )
   })
 
-  it('should not be able to remove the only identity provider', async () => {
+  it('should be able to remove the only identity provider as a guest', async () => {
     const type = 'guest'
+    const token = v1()
+
+    const item = await app.service('identity-provider').create(
+      {
+        type,
+        token
+      },
+      {}
+    )
+
+    assert.ok(() => app.service('identity-provider').remove(item.id))
+  })
+
+  it('should not be able to remove the only identity provider as a user', async () => {
+    const type = 'user'
     const token = v1()
 
     const item = await app.service('identity-provider').create(


### PR DESCRIPTION
## Summary

Due to a recent PR ensuring users cannot remove their last identity provider, we did not take into account guest users being able to remove their last identity provider, which happens as part of the login process if a user logs in from a guest account.

This PR re-enables guest users removing their last identity provider.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

