### PR TITLE
Created Mediasoup transport for ffmpeg-only

### DIFF
--- a/packages/instanceserver/src/MediaRecording.ts
+++ b/packages/instanceserver/src/MediaRecording.ts
@@ -1,0 +1,624 @@
+import * as Config from "./config"
+import FFmpegStatic from "ffmpeg-static"
+import Express from "express"
+import Fs from "fs";
+import Https from "https";
+import Mediasoup from "mediasoup";
+import SocketServer from "socket.io";
+const Socketserver = (SocketServer as any)
+import Process from "child_process";
+import Util from "util";
+
+const global:any = {
+  server: {
+    expressApp: null,
+    https: null,
+    socket: null,
+    socketServer: null,
+  },
+
+  mediasoup: {
+    worker: null,
+    router: null,
+
+    // WebRTC connection with the browser
+    webrtc: {
+      recvTransport: null,
+      audioProducer: null,
+      videoProducer: null,
+    },
+
+    // RTP connection with recording process
+    rtp: {
+      audioTransport: null,
+      audioConsumer: null,
+      videoTransport: null,
+      videoConsumer: null,
+    },
+  },
+
+  recProcess: null,
+};
+
+// Sending all logging to both console and WebSocket
+for (const name of ["log", "info", "warn", "error"]) {
+  const method = console[name];
+  console[name] = function (...args) {
+    method(...args);
+    if (global.server.socket) {
+      global.server.socket.emit("LOG", Util.format(...args));
+    }
+  };
+}
+
+// Creating HTTPS server
+{
+  const expressApp = Express();
+  global.server.expressApp = expressApp;
+  expressApp.use("/", Express.static(__dirname));
+
+  const https = Https.createServer(
+    {
+      cert: Fs.readFileSync(Config.default.https.cert),
+      key: Fs.readFileSync(Config.default.https.certKey),
+    },
+    expressApp
+  );
+  global.server.https = https;
+
+  https.on("listening", () => {
+    console.log(
+      `Web server is listening on https://localhost:${Config.default.https.port}`
+    );
+  });
+  https.on("error", (err) => {
+    console.error("HTTPS error:", err.message);
+  });
+  https.on("tlsClientError", (err) => {
+    if (err.message.includes("alert number 46")) {
+      // Ignore: this is the client browser rejecting our self-signed certificate
+    } else {
+      console.error("TLS error:", err);
+    }
+  });
+  https.listen(Config.default.https.port);
+}
+
+// Creating WebSocket server
+{
+  const socketServer = Socketserver(global.server.https, {
+    path: Config.default.https.wsPath,
+    serveClient: false,
+    pingTimeout: Config.default.https.wsPingTimeout,
+    pingInterval: Config.default.https.wsPingInterval,
+    transports: ["websocket"],
+  });
+  global.server.socketServer = socketServer;
+
+  socketServer.on("connect", (socket) => {
+    console.log(
+      "WebSocket server connected, port: %s",
+      socket.request.connection.remotePort
+    );
+    global.server.socket = socket;
+
+    // Events sent by the client's "socket.io-promise" have the fixed name
+    // "request", and a field "type" that we use as identifier
+    socket.on("request", handleRequest);
+
+    // Events sent by the client's "socket.io-client" have a name
+    // that we use as identifier
+    socket.on("WEBRTC_RECV_CONNECT", handleWebrtcRecvConnect);
+    socket.on("WEBRTC_RECV_PRODUCE", handleWebrtcRecvProduce);
+    socket.on("START_RECORDING", handleStartRecording);
+    socket.on("STOP_RECORDING", handleStopRecording);
+  });
+}
+
+async function handleRequest(request, callback) {
+  let responseData:any = null;
+
+  switch (request.type) {
+    case "START_MEDIASOUP":
+      responseData = await handleStartMediasoup(request.vCodecName);
+      break;
+    case "WEBRTC_RECV_START":
+      responseData = await handleWebrtcRecvStart();
+      break;
+    default:
+      console.warn("Invalid request type:", request.type);
+      break;
+  }
+
+  callback({ type: request.type, data: responseData });
+}
+
+// Util functions
+function audioEnabled() {
+  return global.mediasoup.webrtc.audioProducer !== null;
+}
+
+function videoEnabled() {
+  return global.mediasoup.webrtc.videoProducer !== null;
+}
+
+function h264Enabled() {
+  const codec = global.mediasoup.router.rtpCapabilities.codecs.find(
+    (c) => c.mimeType === "video/H264"
+  );
+  return codec !== undefined;
+}
+
+// ----------------------------------------------------------------------------
+
+/*
+ * Creating a mediasoup worker and router.
+ * vCodecName: One of "VP8", "H264".
+ */
+async function handleStartMediasoup(vCodecName) {
+  const worker: any = await Mediasoup.createWorker(Config.default.mediasoup.worker as any);
+  global.mediasoup.worker = worker;
+
+  worker.on("died", () => {
+    console.error(
+      "mediasoup worker died, exit in 3 seconds... [pid:%d]",
+      worker.pid
+    );
+    setTimeout(() => process.exit(1), 3000);
+  });
+
+  console.log("mediasoup worker created [pid:%d]", worker.pid);
+
+  // Building a RouterOptions based on 'CONFIG.mediasoup.router' and the
+  // requested 'vCodecName'
+  const routerOptions:any = {
+    mediaCodecs: [],
+  };
+
+  const audioCodec = Config.default.mediasoup.router.mediaCodecs.find(
+    (c) => c.mimeType === "audio/opus"
+  );
+  if (!audioCodec) {
+    console.error("Undefined codec mime type: audio/opus -- Check config.js");
+    process.exit(1);
+  }
+  routerOptions.mediaCodecs.push(audioCodec);
+
+  const videoCodec = Config.default.mediasoup.router.mediaCodecs.find(
+    (c) => c.mimeType === `video/${vCodecName}`
+  );
+  if (!videoCodec) {
+    console.error(
+      `Undefined codec mime type: video/${vCodecName} -- Check config.js`
+    );
+    process.exit(1);
+  }
+  routerOptions.mediaCodecs.push(videoCodec);
+
+  let router;
+  try {
+    router = await worker.createRouter(routerOptions);
+  } catch (err) {
+    console.error("BUG:", err);
+    process.exit(1);
+  }
+  global.mediasoup.router = router;
+
+  // At this point, the computed "router.rtpCapabilities" includes the
+  // router codecs enhanced with retransmission and RTCP capabilities,
+  // and the list of RTP header extensions supported by mediasoup.
+
+  console.log("mediasoup router created");
+
+  console.log("mediasoup router RtpCapabilities:\n%O", router.rtpCapabilities);
+
+  return router.rtpCapabilities;
+}
+
+// Creating a mediasoup WebRTC RECV transport
+
+async function handleWebrtcRecvStart() {
+  const router = global.mediasoup.router;
+
+  const transport = await router.createWebRtcTransport(
+    Config.default.mediasoup.webrtcTransport
+  );
+  global.mediasoup.webrtc.recvTransport = transport;
+
+  console.log("mediasoup WebRTC RECV transport created");
+
+  const webrtcTransportOptions = {
+    id: transport.id,
+    iceParameters: transport.iceParameters,
+    iceCandidates: transport.iceCandidates,
+    dtlsParameters: transport.dtlsParameters,
+    sctpParameters: transport.sctpParameters,
+  };
+
+  console.log(
+    "mediasoup WebRTC RECV TransportOptions:\n%O",
+    webrtcTransportOptions
+  );
+
+  return webrtcTransportOptions;
+}
+
+// Calls WebRtcTransport.connect() whenever the browser client part is ready
+
+async function handleWebrtcRecvConnect(dtlsParameters) {
+  const transport = global.mediasoup.webrtc.recvTransport;
+
+  await transport.connect({ dtlsParameters });
+
+  console.log("mediasoup WebRTC RECV transport connected");
+}
+
+// Calls WebRtcTransport.produce() to start receiving media from the browser
+
+async function handleWebrtcRecvProduce(produceParameters, callback) {
+  const transport = global.mediasoup.webrtc.recvTransport;
+
+  const producer = await transport.produce(produceParameters);
+  switch (producer.kind) {
+    case "audio":
+      global.mediasoup.webrtc.audioProducer = producer;
+      break;
+    case "video":
+      global.mediasoup.webrtc.videoProducer = producer;
+      break;
+  }
+
+  global.server.socket.emit("WEBRTC_RECV_PRODUCER_READY", producer.kind);
+
+  console.log(
+    "mediasoup WebRTC RECV producer created, kind: %s, type: %s, paused: %s",
+    producer.kind,
+    producer.type,
+    producer.paused
+  );
+
+  console.log(
+    "mediasoup WebRTC RECV producer RtpParameters:\n%O",
+    producer.rtpParameters
+  );
+
+  callback(producer.id);
+}
+
+async function handleStartRecording(recorder) {
+  const router = global.mediasoup.router;
+
+  const useAudio = audioEnabled();
+  const useVideo = videoEnabled();
+
+  // Start mediasoup's RTP consumer(s)
+
+  if (useAudio) {
+    const rtpTransport = await router.createPlainTransport({
+      // No RTP will be received from the remote side
+      comedia: false,
+
+      // FFmpeg don't support RTP/RTCP multiplexing ("a=rtcp-mux" in SDP)
+      rtcpMux: false,
+
+      ...Config.default.mediasoup.plainTransport,
+    });
+    global.mediasoup.rtp.audioTransport = rtpTransport;
+
+    await rtpTransport.connect({
+      ip: Config.default.mediasoup.recording.ip,
+      port: Config.default.mediasoup.recording.audioPort,
+      rtcpPort: Config.default.mediasoup.recording.audioPortRtcp,
+    });
+
+    console.log(
+      "mediasoup AUDIO RTP SEND transport connected: %s:%d <--> %s:%d (%s)",
+      rtpTransport.tuple.localIp,
+      rtpTransport.tuple.localPort,
+      rtpTransport.tuple.remoteIp,
+      rtpTransport.tuple.remotePort,
+      rtpTransport.tuple.protocol
+    );
+
+    console.log(
+      "mediasoup AUDIO RTCP SEND transport connected: %s:%d <--> %s:%d (%s)",
+      rtpTransport.rtcpTuple.localIp,
+      rtpTransport.rtcpTuple.localPort,
+      rtpTransport.rtcpTuple.remoteIp,
+      rtpTransport.rtcpTuple.remotePort,
+      rtpTransport.rtcpTuple.protocol
+    );
+
+    const rtpConsumer = await rtpTransport.consume({
+      producerId: global.mediasoup.webrtc.audioProducer.id,
+      rtpCapabilities: router.rtpCapabilities, // Assume the recorder supports same formats as mediasoup's router
+      paused: true,
+    });
+    global.mediasoup.rtp.audioConsumer = rtpConsumer;
+
+    console.log(
+      "mediasoup AUDIO RTP SEND consumer created, kind: %s, type: %s, paused: %s, SSRC: %s CNAME: %s",
+      rtpConsumer.kind,
+      rtpConsumer.type,
+      rtpConsumer.paused,
+      rtpConsumer.rtpParameters.encodings[0].ssrc,
+      rtpConsumer.rtpParameters.rtcp.cname
+    );
+  }
+
+  if (useVideo) {
+    const rtpTransport = await router.createPlainTransport({
+      // No RTP will be received from the remote side
+      comedia: false,
+
+      // FFmpeg don't support RTP/RTCP multiplexing ("a=rtcp-mux" in SDP)
+      rtcpMux: false,
+
+      ...Config.default.mediasoup.plainTransport,
+    });
+    global.mediasoup.rtp.videoTransport = rtpTransport;
+
+    await rtpTransport.connect({
+      ip: Config.default.mediasoup.recording.ip,
+      port: Config.default.mediasoup.recording.videoPort,
+      rtcpPort: Config.default.mediasoup.recording.videoPortRtcp,
+    });
+
+    console.log(
+      "mediasoup VIDEO RTP SEND transport connected: %s:%d <--> %s:%d (%s)",
+      rtpTransport.tuple.localIp,
+      rtpTransport.tuple.localPort,
+      rtpTransport.tuple.remoteIp,
+      rtpTransport.tuple.remotePort,
+      rtpTransport.tuple.protocol
+    );
+
+    console.log(
+      "mediasoup VIDEO RTCP SEND transport connected: %s:%d <--> %s:%d (%s)",
+      rtpTransport.rtcpTuple.localIp,
+      rtpTransport.rtcpTuple.localPort,
+      rtpTransport.rtcpTuple.remoteIp,
+      rtpTransport.rtcpTuple.remotePort,
+      rtpTransport.rtcpTuple.protocol
+    );
+
+    const rtpConsumer = await rtpTransport.consume({
+      producerId: global.mediasoup.webrtc.videoProducer.id,
+      rtpCapabilities: router.rtpCapabilities, // Assume the recorder supports same formats as mediasoup's router
+      paused: true,
+    });
+    global.mediasoup.rtp.videoConsumer = rtpConsumer;
+
+    console.log(
+      "mediasoup VIDEO RTP SEND consumer created, kind: %s, type: %s, paused: %s, SSRC: %s CNAME: %s",
+      rtpConsumer.kind,
+      rtpConsumer.type,
+      rtpConsumer.paused,
+      rtpConsumer.rtpParameters.encodings[0].ssrc,
+      rtpConsumer.rtpParameters.rtcp.cname
+    );
+  }
+
+  switch (recorder) {
+    case "ffmpeg":
+      await startRecordingFfmpeg();
+      break;
+    case "external":
+      await startRecordingExternal();
+      break;
+    default:
+      console.warn("Invalid recorder:", recorder);
+      break;
+  }
+
+  if (useAudio) {
+    const consumer = global.mediasoup.rtp.audioConsumer;
+    console.log(
+      "Resume mediasoup RTP consumer, kind: %s, type: %s",
+      consumer.kind,
+      consumer.type
+    );
+    consumer.resume();
+  }
+  if (useVideo) {
+    const consumer = global.mediasoup.rtp.videoConsumer;
+    console.log(
+      "Resume mediasoup RTP consumer, kind: %s, type: %s",
+      consumer.kind,
+      consumer.type
+    );
+    consumer.resume();
+  }
+}
+
+// ----
+
+/* FFmpeg recording
+ * ================
+ *
+ * The intention here is to record the RTP stream as is received from
+ * the media server, i.e. WITHOUT TRANSCODING. Hence the "codec copy"
+ * commands in FFmpeg.
+ *
+ * ffmpeg \
+ *     -nostdin \
+ *     -protocol_whitelist file,rtp,udp \
+ *     -fflags +genpts \
+ *     -i recording/input-vp8.sdp \
+ *     -map 0:a:0 -c:a copy -map 0:v:0 -c:v copy \
+ *     -f webm -flags +global_header \
+ *     -y recording/output-ffmpeg-vp8.webm
+ *
+ * NOTES:
+ *
+ * '-map 0:x:0' ensures that one media of each type is used.
+ *
+ * FFmpeg 2.x (Ubuntu 16.04 "Xenial") does not support the option
+ * "protocol_whitelist", but it is mandatory for FFmpeg 4.x (newer systems).
+ */
+function startRecordingFfmpeg() {
+  // Return a Promise that can be awaited
+  let recResolve;
+  const promise = new Promise((res, _rej) => {
+    recResolve = res;
+  });
+
+  const useAudio = audioEnabled();
+  const useVideo = videoEnabled();
+  const useH264 = h264Enabled();
+
+  // const cmdProgram = "ffmpeg"; // Found through $PATH
+  const cmdProgram:any = FFmpegStatic; // From package "ffmpeg-static"
+
+  let cmdInputPath = `${__dirname}/recording/input-vp8.sdp`;
+  let cmdOutputPath = `${__dirname}/recording/output-ffmpeg-vp8.webm`;
+  let cmdCodec = "";
+  let cmdFormat = "-f webm -flags +global_header";
+
+  // Ensure correct FFmpeg version is installed
+  const ffmpegOut = Process.execSync(cmdProgram + " -version", {
+    encoding: "utf8",
+  });
+  const ffmpegVerMatch = /ffmpeg version (\d+)\.(\d+)\.(\d+)/.exec(ffmpegOut);
+  let ffmpegOk = false;
+  if (ffmpegOut.startsWith("ffmpeg version git")) {
+    // Accept any Git build (it's up to the developer to ensure that a recent
+    // enough version of the FFmpeg source code has been built)
+    ffmpegOk = true;
+  } else if (ffmpegVerMatch) {
+    const ffmpegVerMajor = parseInt(ffmpegVerMatch[1], 10);
+    if (ffmpegVerMajor >= 4) {
+      ffmpegOk = true;
+    }
+  }
+
+  if (!ffmpegOk) {
+    console.error("FFmpeg >= 4.0.0 not found in $PATH; please install it");
+    process.exit(1);
+  }
+
+  if (useAudio) {
+    cmdCodec += " -map 0:a:0 -c:a copy";
+  }
+  if (useVideo) {
+    cmdCodec += " -map 0:v:0 -c:v copy";
+
+    if (useH264) {
+      cmdInputPath = `${__dirname}/recording/input-h264.sdp`;
+      cmdOutputPath = `${__dirname}/recording/output-ffmpeg-h264.mp4`;
+
+      // "-strict experimental" is required to allow storing
+      // OPUS audio into MP4 container
+      cmdFormat = "-f mp4 -strict experimental";
+    }
+  }
+
+  // Run process
+  const cmdArgStr = [
+    "-nostdin",
+    "-protocol_whitelist file,rtp,udp",
+    "-fflags +genpts",
+    `-i ${cmdInputPath}`,
+    cmdCodec,
+    cmdFormat,
+    `-y ${cmdOutputPath}`,
+  ]
+    .join(" ")
+    .trim();
+
+  console.log(`Run command: ${cmdProgram} ${cmdArgStr}`);
+
+  let recProcess = Process.spawn(cmdProgram, cmdArgStr.split(/\s+/));
+  global.recProcess = recProcess;
+
+  recProcess.on("error", (err) => {
+    console.error("Recording process error:", err);
+  });
+
+  recProcess.on("exit", (code, signal) => {
+    console.log("Recording process exit, code: %d, signal: %s", code, signal);
+
+    global.recProcess = null;
+    stopMediasoupRtp();
+
+    if (!signal || signal === "SIGINT") {
+      console.log("Recording stopped");
+    } else {
+      console.warn(
+        "Recording process didn't exit cleanly, output file might be corrupt"
+      );
+    }
+  });
+
+  // FFmpeg writes its logs to stderr
+  recProcess.stderr.on("data", (chunk) => {
+    chunk
+      .toString()
+      .split(/\r?\n/g)
+      .filter(Boolean) // Filter out empty strings
+      .forEach((line) => {
+        console.log(line);
+        if (line.startsWith("ffmpeg version")) {
+          setTimeout(() => {
+            recResolve();
+          }, 1000);
+        }
+      });
+  });
+
+  return promise;
+}
+
+async function startRecordingExternal() {
+  // Return a Promise that can be awaited
+  let resolve;
+  const promise = new Promise((res, _rej) => {
+    resolve = res;
+  });
+
+  // Countdown to let the user start the external process
+  const timeout = 10;
+  const sleep = (ms) => {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  };
+  for (let time = timeout; time > 0; time--) {
+    console.log(`Recording starts in ${time} seconds...`);
+
+    await sleep(1000);
+  }
+
+  resolve();
+
+  return promise;
+}
+
+// ----------------------------------------------------------------------------
+
+async function handleStopRecording() {
+  if (global.recProcess) {
+    global.recProcess.kill("SIGINT");
+  } else {
+    stopMediasoupRtp();
+  }
+}
+
+// ----
+
+function stopMediasoupRtp() {
+  console.log("Stop mediasoup RTP transport and consumer");
+
+  const useAudio = audioEnabled();
+  const useVideo = videoEnabled();
+
+  if (useAudio) {
+    global.mediasoup.rtp.audioConsumer.close();
+    global.mediasoup.rtp.audioTransport.close();
+  }
+
+  if (useVideo) {
+    global.mediasoup.rtp.videoConsumer.close();
+    global.mediasoup.rtp.videoTransport.close();
+  }
+}
+
+export {};

--- a/packages/instanceserver/src/client.ts
+++ b/packages/instanceserver/src/client.ts
@@ -1,0 +1,238 @@
+import { onStartRecording, onStopRecording } from './ServerRecordingSystem'
+import { handleWebRtcReceiveTrack } from './WebRTCFunctions'
+import CONFIG from "./config";
+import MediasoupClient from "mediasoup-client";
+import SocketClient from "socket.io-client";
+const SocketPromise = require("socket.io-promise").default;
+
+const global = {
+  server: {
+    socket: null,
+  },
+
+  mediasoup: {
+    device: null,
+
+    webrtc: {
+      transport: null,
+      audioProducer: null,
+      videoProducer: null,
+    },
+  },
+
+  recording: {
+    waitForAudio: false,
+    waitForVideo: false,
+  },
+};
+
+
+async function startWebrtcSend() {
+  const device:any = global.mediasoup.device;
+  const socket:any = global.server.socket;
+
+  // mediasoup WebRTC transport
+
+
+  const socketRequest = SocketPromise(socket);
+  const response = await socketRequest({ type: "WEBRTC_RECV_START" });
+  const webrtcTransportOptions = response.data;
+
+  console.log("[server] WebRTC RECV transport created");
+
+  let transport;
+  try {
+    transport = device.createSendTransport(webrtcTransportOptions);
+  } catch (err) {
+    console.error(err);
+    return;
+  }
+  global.mediasoup.webrtc.transport = transport;
+
+  console.log("[client] WebRTC SEND transport created");
+
+  // "connect" is emitted upon the first call to transport.produce()
+  transport.on("connect", ({ dtlsParameters }, callback, _errback) => {
+    // Signal local DTLS parameters to the server side transport
+    socket.emit("WEBRTC_RECV_CONNECT", dtlsParameters);
+    callback();
+  });
+
+  // "produce" is emitted upon each call to transport.produce()
+  transport.on("produce", (produceParameters, callback, _errback) => {
+    socket.emit("WEBRTC_RECV_PRODUCE", produceParameters, (producerId) => {
+      console.log("[server] WebRTC RECV producer created");
+      callback({ producerId });
+    });
+  });
+
+  // mediasoup WebRTC producer
+  // Getting user media as required
+
+  const uiMedia = (document.querySelector("input[name='uiMedia']:checked")as HTMLInputElement)?.value;
+
+  let useAudio = false;
+  let useVideo = false;
+  if (uiMedia.indexOf("audio") !== -1) {
+    useAudio = true;
+    global.recording.waitForAudio = true;
+  }
+  if (uiMedia.indexOf("video") !== -1) {
+    useVideo = true;
+    global.recording.waitForVideo = true;
+  }
+
+  let stream;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({
+      audio: useAudio,
+      video: useVideo,
+    });
+  } catch (err) {
+    console.error(err);
+    return;
+  }
+
+  ui.localVideo.srcObject= stream;
+
+  // Start mediasoup-client's WebRTC producer(s)
+
+  if (useAudio) {
+    const audioTrack = stream.getAudioTracks()[0];
+    const audioProducer = await transport.produce({ track: audioTrack });
+    global.mediasoup.webrtc.audioProducer = audioProducer;
+  }
+
+  if (useVideo) {
+    const videoTrack = stream.getVideoTracks()[0];
+    const videoProducer = await transport.produce({
+      track: videoTrack,
+      ...CONFIG.mediasoup.client.videoProducer,
+    });
+    global.mediasoup.webrtc.videoProducer = videoProducer;
+  }
+}
+
+function startRecording():any {
+  const uiRecorder = (document.querySelector("input[name='uiRecorder']:checked")as HTMLInputElement).value;
+  console.log("START_RECORDING", uiRecorder);
+
+}
+
+function stopRecording():any {
+  console.log("STOP_RECORDING");
+
+}
+
+// HTML UI elements
+
+async function startMediasoup():Promise<undefined> {
+  const socket = global.server.socket;
+
+  const socketRequest = SocketPromise(socket);
+  const uiVCodecName = (document.querySelector(
+    "input[name='uiVCodecName']:checked"
+  )as HTMLInputElement).value;
+  const response = await socketRequest({
+    type: "START_MEDIASOUP",
+    vCodecName: uiVCodecName,
+  });
+  const routerRtpCapabilities = response.data;
+
+  console.log("[server] mediasoup router created");
+
+  let device:any = null;
+  try {
+    device = new MediasoupClient.Device();
+  } catch (err) {
+    console.error(err);
+    return;
+  }
+  global.mediasoup.device = device;
+
+  try {
+    await device.load({ routerRtpCapabilities });
+  } catch (err) {
+    console.error(err);
+    return;
+  }
+
+  console.log(
+    "mediasoup device created, handlerName: %s, use audio: %s, use video: %s",
+    device.handlerName,
+    device.canProduce("audio"),
+    device.canProduce("video")
+  );
+
+  console.log("rtpCapabilities:\n%O", device.rtpCapabilities);
+}
+
+async function startWebRTC() {
+  console.log("Start WebRTC transmission from browser to mediasoup");
+
+  await startMediasoup();
+  await startWebrtcSend();
+}
+
+const ui = {
+  console: document.getElementById("uiConsole"),
+  // <button>
+  startWebRTC: handleWebRtcReceiveTrack,
+  startRecording: onStartRecording,
+  stopRecording: onStopRecording,
+
+  // <video>
+  localVideo: (document.getElementById("uiLocalVideo") as HTMLMediaElement),
+};
+
+ui.startWebRTC = startWebRTC;
+ui.startRecording = startRecording;
+ui.stopRecording = stopRecording;
+
+window.addEventListener("load", function () {
+  console.log("Page loaded, connect WebSocket");
+  connectSocket();
+
+  if ("adapter" in window) {
+    console.log("Adapter code not working");
+  } else {
+    console.warn("webrtc-adapter is not loaded! an install or config issue?");
+  }
+});
+
+window.addEventListener("beforeunload", function () {
+  console.log("Page unloading, close WebSocket");
+});
+// ----
+
+function connectSocket() {
+  const serverUrl = `https://${window.location.host}`;
+
+  console.log("Connect with Application Server:", serverUrl);
+
+  const socket = SocketClient(serverUrl, {
+    path: CONFIG.https.wsPath,
+    transports: ["websocket"],
+  });
+  global.server.socket = socket;
+
+  socket.on("connect", () => {
+    console.log("WebSocket connected");
+  });
+
+  socket.on("error", (err) => {
+    console.error("WebSocket error:", err);
+  });
+
+  socket.on("WEBRTC_RECV_PRODUCER_READY", (kind) => {
+    console.log(`Server producer is ready, kind: ${kind}`);
+    switch (kind) {
+      case "audio":
+        global.recording.waitForAudio = false;
+        break;
+      case "video":
+        global.recording.waitForVideo = false;
+        break;
+    }
+  });
+}

--- a/packages/instanceserver/src/config.ts
+++ b/packages/instanceserver/src/config.ts
@@ -1,0 +1,109 @@
+export default {
+    https: {
+      cert: "../../../certs/cert.pem", //pem files are from the etherealengine certs folder
+      certKey: "../../../certs/key.pem",
+      port: 8080,
+      wsPath: "/server",
+      wsPingInterval: 25000,
+      wsPingTimeout: 5000,
+    },
+  
+    mediasoup: {
+      // WorkerSettings
+      worker: {
+        logLevel: "debug",
+        logTags: [
+          "dtls",
+          "ice",
+          "info",
+          "rtcp",
+          "rtp",
+          "srtp",
+        ],
+        rtcMinPort: 32256,
+        rtcMaxPort: 65535,
+      },
+  
+      router: {
+        mediaCodecs: [
+          {
+            kind: "audio",
+            mimeType: "audio/opus",
+            preferredPayloadType: 111,
+            clockRate: 48000,
+            channels: 2,
+            parameters: {
+              minptime: 10,
+              useinbandfec: 1,
+            },
+          },
+          {
+            kind: "video",
+            mimeType: "video/VP8",
+            preferredPayloadType: 96,
+            clockRate: 90000,
+          },
+          {
+            kind: "video",
+            mimeType: "video/H264",
+            preferredPayloadType: 125,
+            clockRate: 90000,
+            parameters: {
+              "level-asymmetry-allowed": 1,
+              "packetization-mode": 1,
+              "profile-level-id": "42e01f",
+            },
+          },
+        ],
+      },
+  
+      // WebRtcTransportOptions
+      webrtcTransport: {
+        listenIps: [{ ip: "127.0.0.1", announcedIp: null }],
+        enableUdp: true,
+        enableTcp: true,
+        preferUdp: true,
+        initialAvailableOutgoingBitrate: 300000,
+      },
+  
+      // PlainTransportOptions
+      plainTransport: {
+        listenIp: { ip: "127.0.0.1", announcedIp: null },
+      },
+  
+      client: {
+        // ProducerOptions
+        videoProducer: {
+          // Sending video with 3 simulcast streams
+          // RTCRtpEncodingParameters[]
+          encodings: [
+            {
+              maxBitrate: 100000,
+              // maxFramerate: 15.0,
+              // scaleResolutionDownBy: 1.5,
+            },
+            {
+              maxBitrate: 300000,
+            },
+            {
+              maxBitrate: 900000,
+            },
+          ],
+          codecOptions: {
+            videoGoogleStartBitrate: 1000,
+          },
+        },
+      },
+  
+      // Target IP and port for RTP recording
+      recording: {
+        ip: "127.0.0.1",
+  
+        // FFmpeg's sdpdemux only supports RTCP = RTP + 1
+        audioPort: 5004,
+        audioPortRtcp: 5005,
+        videoPort: 5006,
+        videoPortRtcp: 5007,
+      },
+    },
+};

--- a/packages/instanceserver/src/recording/input-h264.sdp
+++ b/packages/instanceserver/src/recording/input-h264.sdp
@@ -1,0 +1,13 @@
+v=0
+o=- 0 0 IN IP4 127.0.0.1
+s=-
+c=IN IP4 127.0.0.1
+t=0 0
+m=audio 5004 RTP/AVPF 111
+a=rtcp:5005
+a=rtpmap:111 opus/48000/2
+a=fmtp:111 minptime=10;useinbandfec=1
+m=video 5006 RTP/AVPF 125
+a=rtcp:5007
+a=rtpmap:125 H264/90000
+a=fmtp:125 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f

--- a/packages/instanceserver/src/recording/input-vp8.sdp
+++ b/packages/instanceserver/src/recording/input-vp8.sdp
@@ -1,0 +1,12 @@
+v=0
+o=- 0 0 IN IP4 127.0.0.1
+s=-
+c=IN IP4 127.0.0.1
+t=0 0
+m=audio 5004 RTP/AVPF 111
+a=rtcp:5005
+a=rtpmap:111 opus/48000/2
+a=fmtp:111 minptime=10;useinbandfec=1
+m=video 5006 RTP/AVPF 96
+a=rtcp:5007
+a=rtpmap:96 VP8/90000


### PR DESCRIPTION
## Summary
This code is for the issue Server based Video Recording #7737 . This code for configuration of mediasoup transport for ffmpeg for video recording. Total of 5 files client.ts, config.ts and MediaRecording.ts and two files for ffmpeg audio and video encoding. Server is running but testing for video recording is in progress.

_A summary of changes being made in this PR_


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

