### PR TITLE
Fixed some bugs with ProfileMenu and InputText cursor.

### DIFF
--- a/packages/client-core/src/admin/components/Project/BuildStatusDrawer.tsx
+++ b/packages/client-core/src/admin/components/Project/BuildStatusDrawer.tsx
@@ -66,7 +66,7 @@ const BuildStatusDrawer = ({ open, onClose }: Props) => {
       ),
       commitSHA: (
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
-          <span>{el.commitSHA.slice(0, 8)}</span>
+          <span>{el.commitSHA?.slice(0, 8)}</span>
         </Box>
       ),
       status: (

--- a/packages/client-core/src/admin/components/Project/ProjectFields.tsx
+++ b/packages/client-core/src/admin/components/Project/ProjectFields.tsx
@@ -240,7 +240,7 @@ const ProjectFields = ({ inputProject, existingProject = false, changeDestinatio
   })
 
   const commitMenu: InputMenuItem[] = projectUpdateStatus?.value?.commitData.map((el: ProjectCommitInterface) => {
-    let label = `Commit ${el.commitSHA.slice(0, 8)}`
+    let label = `Commit ${el.commitSHA?.slice(0, 8)}`
     if (el.projectVersion) label += ` -- Project Ver. ${el.projectVersion}`
     if (el.engineVersion) label += ` -- Engine Ver. ${el.engineVersion}`
     if (el.datetime) {

--- a/packages/client-core/src/admin/components/Project/UpdateDrawer.tsx
+++ b/packages/client-core/src/admin/components/Project/UpdateDrawer.tsx
@@ -73,7 +73,7 @@ const UpdateDrawer = ({ open, builderTags, onClose }: Props) => {
     })
     return {
       value: el.tag,
-      label: `Commit ${el.commitSHA.slice(0, 8)} -- ${el.tag === engineCommit.value ? '(Current) ' : ''}Version ${
+      label: `Commit ${el.commitSHA?.slice(0, 8)} -- ${el.tag === engineCommit.value ? '(Current) ' : ''}Version ${
         el.engineVersion
       } -- Pushed ${pushedDate}`
     }

--- a/packages/client-core/src/common/components/InputText/index.tsx
+++ b/packages/client-core/src/common/components/InputText/index.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { RefObject, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import capitalizeFirstLetter from '@etherealengine/common/src/utils/capitalizeFirstLetter'
+import { useHookstate } from '@etherealengine/hyperflux'
 import Box from '@etherealengine/ui/src/Box'
 import FormControl from '@etherealengine/ui/src/FormControl'
 import FormHelperText from '@etherealengine/ui/src/FormHelperText'
@@ -49,7 +50,7 @@ const InputText = ({
   endIconTitle,
   error,
   id,
-  inputRef,
+  inputRef = useRef(),
   label,
   name,
   placeholder,
@@ -70,23 +71,15 @@ const InputText = ({
   placeholder = placeholder ? placeholder : `${t('common:components.enter')} ${label}`
   placeholder = disabled ? undefined : placeholder
 
-  const [cursor, setCursor] = useState(null)
-  const ref = useRef(null)
+  const cursor = useHookstate(null)
 
   useEffect(() => {
-    if (type === 'number' && ref.current) {
-      let input
-      for (const child of (ref.current as any)?.children) {
-        if (child.tagName === 'INPUT') {
-          input = child
-        }
-      }
-      if (input && cursor) input.setSelectionRange(cursor, cursor)
-    }
-  }, [ref, cursor, value])
+    if (type !== 'number' && (inputRef as RefObject<any>)?.current && cursor.value)
+      (inputRef as RefObject<any>).current.setSelectionRange(cursor.value, cursor.value)
+  }, [inputRef, cursor.value, value])
 
   const handleChange = (e) => {
-    setCursor(e.target.selectionStart)
+    cursor.set(e.target.selectionStart)
     onChange && onChange(e)
   }
 

--- a/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
@@ -93,7 +93,7 @@ const ProfileMenu = ({ hideLogin, onClose, isPopover }: Props): JSX.Element => {
     (authState?.value?.linkedin && !oauthConnectedState.linkedin.value) ||
     (authState?.value?.twitter && !oauthConnectedState.twitter.value)
 
-  const removeSocial = Object.values(oauthConnectedState.value).filter((value) => value).length > 1
+  const removeSocial = Object.values(oauthConnectedState.value).filter((value) => value).length >= 1
 
   // const loadCredentialHandler = async () => {
   //   try {
@@ -192,7 +192,7 @@ const ProfileMenu = ({ hideLogin, onClose, isPopover }: Props): JSX.Element => {
   }
 
   const handleLogout = async () => {
-    PopupMenuServices.showPopupMenu()
+    PopupMenuServices.showPopupMenu(UserMenus.Profile)
     if (onClose) onClose()
     showUserId.set(false)
     showApiKey.set(false)

--- a/packages/editor/src/services/EditorHelperState.ts
+++ b/packages/editor/src/services/EditorHelperState.ts
@@ -1,5 +1,5 @@
 import { useHookstate } from '@hookstate/core'
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 
 import { matches, Validator } from '@etherealengine/engine/src/common/functions/MatchesUtils'
 import InfiniteGridHelper from '@etherealengine/engine/src/scene/classes/InfiniteGridHelper'


### PR DESCRIPTION
## Summary

ProfileMenu had reverted to not showing single OAuth identity provider. Fixed this.

Proper setting of cursor in InputText had been broken by recent changes. Fixed this by making a default inputRef and using this to set the selectionRange.

Made some slices of commitSHA's optional in case they somehow don't exist, lest the client page crash as a result (I'd seen this on a deployment, and it prevents updating the engine version).

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

