### PR TITLE
Fix css for lightmap baking parameters

### DIFF
--- a/packages/editor/src/components/properties/LightmapBakerProperties.tsx
+++ b/packages/editor/src/components/properties/LightmapBakerProperties.tsx
@@ -9,7 +9,7 @@ import { ModelComponent } from '@etherealengine/engine/src/scene/components/Mode
 import { useHookstate } from '@etherealengine/hyperflux'
 import { State } from '@etherealengine/hyperflux/functions/StateFunctions'
 
-import { Typography } from '@mui/material'
+import { Grid, Typography } from '@mui/material'
 
 import { bakeLightmaps } from '../../lightmapper/lightmap'
 import { WorkbenchSettings } from '../../lightmapper/workbench'
@@ -73,16 +73,7 @@ export default function LightmapBakerProperties({
               bounceMultiplier: { ...FloatArg, default: 1 },
               emissiveMultiplier: { ...FloatArg, default: 1 },
               lightMapSize: { ...FloatArg, default: 1024 },
-              texelsPerUnit: { ...FloatArg, default: 16 },
-              samplerSettings: {
-                ...ObjectArg,
-                default: {
-                  targetSize: { ...FloatArg, default: 64 },
-                  offset: FloatArg,
-                  near: { ...FloatArg, default: 0.05 },
-                  far: { ...FloatArg, default: 50 }
-                }
-              }
+              texelsPerUnit: { ...FloatArg, default: 16 }
             }}
             onChange={(k: keyof WorkbenchSettings) => {
               return (val) => {
@@ -90,6 +81,41 @@ export default function LightmapBakerProperties({
               }
             }}
           />
+          <Grid
+            container
+            spacing={2}
+            style={{
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+              outline: 'solid 1px #fff',
+              borderRadius: '0.5rem',
+              paddingBottom: '1rem',
+              width: 'auto',
+              margin: '1rem',
+              overflow: 'overlay'
+            }}
+          >
+            <Grid item xs={2}>
+              <Typography variant="subtitle1">Sampler Settings</Typography>
+            </Grid>
+            <Grid item xs>
+              <ParameterInput
+                entity={modelState.src.value}
+                values={bakeProperties.samplerSettings.value ?? {}}
+                defaults={{
+                  targetSize: { ...FloatArg, default: 64 },
+                  offset: FloatArg,
+                  near: { ...FloatArg, default: 0.05 },
+                  far: { ...FloatArg, default: 50 }
+                }}
+                onChange={(k: string) => {
+                  return (val) => {
+                    bakeProperties.samplerSettings[k].set(val)
+                  }
+                }}
+              />
+            </Grid>
+          </Grid>
         </Well>
         {!baking.value && <Button onClick={doLightmapBake}>Bake Lightmaps</Button>}
         {baking.value && <Typography variant="subtitle1">Baking...</Typography>}


### PR DESCRIPTION
## Summary

Fixes the css padding which made it impossible to access most sampler settings in lightmap baker


## References

closes #7853 

Before:
![plank-2023-04-13_12-19-02](https://user-images.githubusercontent.com/94419856/231861375-32883a09-a2e5-4f8e-b0bb-a0c144613f23.png)

After:
![plank-2023-04-13_12-16-33](https://user-images.githubusercontent.com/94419856/231861399-5ead397c-d94e-4ab9-aaa1-3ed7a9d7e283.png)
