### PR TITLE
Finish decoupling uuid from EntityTreeComponent

### DIFF
--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -1,5 +1,5 @@
 import { command } from 'cli'
-import { Euler, Material, Matrix4, Mesh, Quaternion, Vector3 } from 'three'
+import { Euler, Material, MathUtils, Matrix4, Mesh, Quaternion, Vector3 } from 'three'
 
 import { EntityUUID } from '@etherealengine/common/src/interfaces/EntityUUID'
 import { EntityJson, SceneJson } from '@etherealengine/common/src/interfaces/SceneInterface'
@@ -203,6 +203,7 @@ const createObjectFromPrefab = (
     }
   }
   setComponent(newEntity, EntityTreeComponent, { parentEntity, childIndex })
+  setComponent(newEntity, UUIDComponent, MathUtils.generateUUID() as EntityUUID)
 
   createNewEditorNode(newEntity, prefab)
 

--- a/packages/engine/src/ecs/functions/EntityTree.ts
+++ b/packages/engine/src/ecs/functions/EntityTree.ts
@@ -135,6 +135,7 @@ export function initializeSceneEntity(): void {
   getMutableState(SceneState).sceneEntity.set(sceneEntity)
   setComponent(sceneEntity, NameComponent, 'scene')
   setComponent(sceneEntity, VisibleComponent, true)
+  setComponent(sceneEntity, UUIDComponent, MathUtils.generateUUID() as EntityUUID)
   setComponent(sceneEntity, SceneTagComponent, true)
   setTransformComponent(sceneEntity)
   setComponent(sceneEntity, EntityTreeComponent, { parentEntity: null })
@@ -173,7 +174,8 @@ export function addEntityNodeChild(entity: Entity, parentEntity: Entity, uuid?: 
     !hasComponent(entity, EntityTreeComponent) ||
     parentEntity !== getComponent(entity, EntityTreeComponent).parentEntity
   ) {
-    setComponent(entity, EntityTreeComponent, { parentEntity, uuid })
+    setComponent(entity, EntityTreeComponent, { parentEntity })
+    setComponent(entity, UUIDComponent, uuid || (MathUtils.generateUUID() as EntityUUID))
   }
 
   const parentTransform = getComponent(parentEntity, TransformComponent)

--- a/packages/engine/src/scene/systems/SceneLoadingSystem.ts
+++ b/packages/engine/src/scene/systems/SceneLoadingSystem.ts
@@ -134,7 +134,8 @@ export const loadECSData = async (sceneData: SceneJson, assetRoot?: Entity): Pro
     }
     const eNode = createEntity()
     const parent = eJson.parent ? UUIDComponent.entitiesByUUID[eJson.parent].value : rootEntity
-    setComponent(eNode, EntityTreeComponent, { parentEntity: parent, uuid })
+    setComponent(eNode, EntityTreeComponent, { parentEntity: parent })
+    setComponent(eNode, UUIDComponent, uuid)
     if (eJson.parent && loadedEntities[eJson.parent]) {
       addEntityNodeChild(eNode, parent)
     }
@@ -275,7 +276,8 @@ export const updateSceneFromJSON = async () => {
   }
 
   /** 4. update scene entities with new data, and load new ones */
-  setComponent(sceneState.sceneEntity.value, EntityTreeComponent, { parentEntity: null!, uuid: sceneData.scene.root })
+  setComponent(sceneState.sceneEntity.value, EntityTreeComponent, { parentEntity: null! })
+  setComponent(sceneState.sceneEntity.value, UUIDComponent, sceneData.scene.root)
   updateSceneEntity(sceneData.scene.root, sceneData.scene.entities[sceneData.scene.root])
   updateSceneEntitiesFromJSON(sceneData.scene.root)
 
@@ -305,7 +307,8 @@ export const updateSceneEntity = (uuid: EntityUUID, entityJson: EntityJson) => {
     } else {
       const entity = createEntity()
       const parentEntity = UUIDComponent.entitiesByUUID[entityJson.parent!].value
-      setComponent(entity, EntityTreeComponent, { parentEntity, uuid })
+      setComponent(entity, EntityTreeComponent, { parentEntity })
+      setComponent(entity, UUIDComponent, uuid)
       setLocalTransformComponent(entity, parentEntity)
       addEntityNodeChild(entity, parentEntity)
       deserializeSceneEntity(entity, entityJson)


### PR DESCRIPTION
Fixes critical bug with being unable to place new objects in an editor scene and have them serialize correctly.