### PR TITLE
add 'Origin' to tranform pivot options

### DIFF
--- a/packages/editor/src/components/toolbar/tools/TransformPivotTool.tsx
+++ b/packages/editor/src/components/toolbar/tools/TransformPivotTool.tsx
@@ -13,7 +13,8 @@ import * as styles from '../styles.module.scss'
 const transformPivotOptions = [
   { label: 'Selection', value: TransformPivot.Selection },
   { label: 'Center', value: TransformPivot.Center },
-  { label: 'Bottom', value: TransformPivot.Bottom }
+  { label: 'Bottom', value: TransformPivot.Bottom },
+  { label: 'Origin', value: TransformPivot.Origin }
 ]
 
 const TransformPivotTool = () => {

--- a/packages/editor/src/systems/EditorControlSystem.ts
+++ b/packages/editor/src/systems/EditorControlSystem.ts
@@ -360,6 +360,8 @@ export default async function EditorControlSystem() {
         if (isChanged || transformPivotChanged) {
           if (transformPivot === TransformPivot.Selection) {
             gizmoObj.position.copy(lastSelectedTransform.position)
+          } else if (transformPivot === TransformPivot.Origin) {
+            gizmoObj.position.set(0, 0, 0)
           } else {
             box.makeEmpty()
 

--- a/packages/engine/src/scene/constants/transformConstants.ts
+++ b/packages/engine/src/scene/constants/transformConstants.ts
@@ -3,7 +3,8 @@ import { Vector3 } from 'three'
 export const TransformPivot = {
   Selection: 'Selection' as const,
   Center: 'Center' as const,
-  Bottom: 'Bottom' as const
+  Bottom: 'Bottom' as const,
+  Origin: 'Origin' as const
 }
 export const TransformMode = {
   Disabled: 'Disabled' as const,


### PR DESCRIPTION
Adds option to rotate, scale, translate selected objects about the scene origin.

closes #7848 
