### PR TITLE
Added origin-agent-cluster header to client servers.

### DIFF
--- a/packages/client/server.js
+++ b/packages/client/server.js
@@ -12,7 +12,12 @@ const PORT = process.env.HOST_PORT || 3000;
 const HTTPS = process.env.VITE_LOCAL_BUILD ?? false
 
 app.use(expressStaticGzip(path.join(packageRoot, 'packages', 'client', 'dist'), {
-  enableBrotli: true
+  enableBrotli: true,
+  serveStatic: {
+    setHeaders: (res) => {
+      res.set('Origin-Agent-Cluster', '?1')
+    }
+  }
 }));
 app.use('*', (req, res) => res.sendFile(path.join(packageRoot, 'packages', 'client', 'dist', 'index.html')));
 

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -154,7 +154,10 @@ export default defineConfig(async () => {
     server: {
       hmr: false,
       host: process.env['VITE_APP_HOST'],
-      port: process.env['VITE_APP_PORT']
+      port: process.env['VITE_APP_PORT'],
+      headers: {
+        'Origin-Agent-Cluster': '?1'
+      }
     },
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary

If serving client files from S3, one will need to configure CloudFront to provide the header. Documentation has been updated to reflect this.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

