### PR TITLE
Fix "Material Prototype Not Found" errors on GLTF load

### DIFF
--- a/packages/engine/src/assets/loaders/gltf/extensions/RegisterMaterialsExtension.ts
+++ b/packages/engine/src/assets/loaders/gltf/extensions/RegisterMaterialsExtension.ts
@@ -1,15 +1,14 @@
 import { Mesh, Object3D } from 'three'
-import { GLTFParser } from 'three/examples/jsm/loaders/GLTFLoader'
 
 import { getState } from '@etherealengine/hyperflux'
 
 import { SourceType } from '../../../../renderer/materials/components/MaterialSource'
 import { registerMaterial } from '../../../../renderer/materials/functions/MaterialLibraryFunctions'
-import { MaterialLibraryState } from '../../../../renderer/materials/MaterialLibrary'
+import { initializeMaterialLibrary, MaterialLibraryState } from '../../../../renderer/materials/MaterialLibrary'
 import { GLTF, GLTFLoaderPlugin } from '../GLTFLoader'
 import { ImporterExtension } from './ImporterExtension'
 
-export function registerMaterials(root: Object3D, type: SourceType = SourceType.EDITOR_SESSION, path: string = '') {
+export function registerMaterials(root: Object3D, type: SourceType = SourceType.EDITOR_SESSION, path = '') {
   const materialLibrary = getState(MaterialLibraryState)
   root.traverse((mesh: Mesh) => {
     if (!mesh?.isMesh) return
@@ -23,6 +22,7 @@ export function registerMaterials(root: Object3D, type: SourceType = SourceType.
 export default class RegisterMaterialsExtension extends ImporterExtension implements GLTFLoaderPlugin {
   async afterRoot(result: GLTF) {
     const parser = this.parser
+    initializeMaterialLibrary()
     registerMaterials(result.scene, SourceType.MODEL, parser.options.url)
   }
 }

--- a/packages/engine/src/renderer/materials/MaterialLibrary.ts
+++ b/packages/engine/src/renderer/materials/MaterialLibrary.ts
@@ -6,6 +6,7 @@ import {
   defineState,
   dispatchAction,
   getMutableState,
+  getState,
   StateDefinition,
   useState
 } from '@etherealengine/hyperflux'
@@ -28,6 +29,7 @@ export type MaterialLibraryType = {
   prototypes: Record<string, MaterialPrototypeComponentType>
   materials: Record<string, MaterialComponentType>
   sources: Record<string, MaterialSourceComponentType>
+  initialized: boolean
 }
 
 export const MaterialLibraryState: StateDefinition<MaterialLibraryType> = defineState({
@@ -35,7 +37,8 @@ export const MaterialLibraryState: StateDefinition<MaterialLibraryType> = define
   initial: {
     prototypes: {},
     materials: {},
-    sources: {}
+    sources: {},
+    initialized: false
   } as MaterialLibraryType
 })
 /**@deprecated use getMutableState directly instead */
@@ -61,15 +64,18 @@ export const MaterialLibraryActions = {
 
 export function initializeMaterialLibrary() {
   //load default prototypes from source
-  ;[
-    MeshBasicMaterial,
-    MeshStandardMaterial,
-    MeshMatcapMaterial,
-    MeshPhysicalMaterial,
-    MeshLambertMaterial,
-    MeshPhongMaterial,
-    MeshToonMaterial,
-    ShaderMaterial,
-    ShadowMaterial
-  ].map(registerMaterialPrototype)
+  const materialLibrary = getState(MaterialLibraryState)
+  ;(!materialLibrary.initialized &&
+    [
+      MeshBasicMaterial,
+      MeshStandardMaterial,
+      MeshMatcapMaterial,
+      MeshPhysicalMaterial,
+      MeshLambertMaterial,
+      MeshPhongMaterial,
+      MeshToonMaterial,
+      ShaderMaterial,
+      ShadowMaterial
+    ].map(registerMaterialPrototype)) ||
+    getMutableState(MaterialLibraryState).initialized.set(true)
 }

--- a/packages/engine/src/renderer/materials/functions/MaterialLibraryFunctions.ts
+++ b/packages/engine/src/renderer/materials/functions/MaterialLibraryFunctions.ts
@@ -67,7 +67,7 @@ export function prototypeFromId(protoId: string): MaterialPrototypeComponentType
   return prototype
 }
 
-export function materialIdToDefaultArgs(matId: string): Object {
+export function materialIdToDefaultArgs(matId: string): object {
   const material = materialFromId(matId)
   const prototype = prototypeFromId(material.prototype)
   return injectDefaults(prototype.arguments, material.parameters)
@@ -185,7 +185,7 @@ export function unregisterMaterial(material: Material) {
 
 export function registerMaterialPrototype(prototype: MaterialPrototypeComponentType) {
   const materialLibrary = getMaterialLibrary()
-  if (!!materialLibrary.prototypes[prototype.prototypeId].value) {
+  if (materialLibrary.prototypes[prototype.prototypeId].value) {
     console.warn(
       'overwriting existing material prototype!\nnew:',
       prototype.prototypeId,


### PR DESCRIPTION
MaterialLibrary tolerates multiple initializations
add material library initialization to gltf import
