### PR TITLE
Fix avatar misalignments

### DIFF
--- a/packages/engine/src/avatar/animation/avatarPose.ts
+++ b/packages/engine/src/avatar/animation/avatarPose.ts
@@ -145,11 +145,6 @@ export function applySkeletonPose(mesh: SkinnedMesh) {
   const target = new Vector3()
   const posAttr = mesh.geometry.attributes.position as BufferAttribute | InterleavedBufferAttribute
   const normalAttr = mesh.geometry.attributes.normal as BufferAttribute | InterleavedBufferAttribute
-  const { bones } = mesh.skeleton
-
-  bones.forEach((bone) => {
-    bone.updateMatrixWorld()
-  })
 
   for (let i = 0; i < posAttr.count; i++) {
     target.fromBufferAttribute(posAttr, i)

--- a/packages/engine/src/avatar/animation/avatarPose.ts
+++ b/packages/engine/src/avatar/animation/avatarPose.ts
@@ -145,6 +145,11 @@ export function applySkeletonPose(mesh: SkinnedMesh) {
   const target = new Vector3()
   const posAttr = mesh.geometry.attributes.position as BufferAttribute | InterleavedBufferAttribute
   const normalAttr = mesh.geometry.attributes.normal as BufferAttribute | InterleavedBufferAttribute
+  const { bones } = mesh.skeleton
+
+  bones.forEach((bone) => {
+    bone.updateMatrixWorld()
+  })
 
   for (let i = 0; i < posAttr.count; i++) {
     target.fromBufferAttribute(posAttr, i)

--- a/packages/engine/src/avatar/functions/avatarFunctions.ts
+++ b/packages/engine/src/avatar/functions/avatarFunctions.ts
@@ -165,12 +165,13 @@ export const rigAvatarModel = (entity: Entity) => (model: Object3D) => {
 
   const skinnedMeshes = findSkinnedMeshes(model)
 
-  /**@todo replace check for loop aniamtion component with ensuring tpose is only handled once */
+  /*
   // Try converting to T pose
   if (!hasComponent(entity, LoopAnimationComponent)) {
     makeTPose(rig)
     skinnedMeshes.forEach(applySkeletonPose)
   }
+  */
 
   const targetSkeleton = createSkeletonFromBone(rootBone)
 


### PR DESCRIPTION
## Summary

Minor change, removes matrix world upate to bones of avatar skinned meshes to prevent misalignments.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

