### PR TITLE
feat: admin location controls - ban user

### DIFF
--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -63,6 +63,7 @@
       "delete": "Delete",
       "view": "View",
       "kick": "Kick",
+      "ban": "Ban",
       "yes": "Yes",
       "no": "No",
       "refresh": "Refresh",
@@ -205,7 +206,8 @@
       "confirmInstanceDelete": "Do you want to delete instance",
       "location": "Location",
       "count": "Count",
-      "kickDuration": "Kick Duration"
+      "kickDuration": "Kick Duration",
+      "confirmUserBan": "Are you sure you want to ban this user?"
     },
     "resources": {
       "resources": "resources",

--- a/packages/client-core/src/admin/services/InstanceService.ts
+++ b/packages/client-core/src/admin/services/InstanceService.ts
@@ -166,14 +166,18 @@ export const AdminInstanceUserService = {
     dispatchAction(AdminInstanceUserActions.instanceUsersRetrieved({ users }))
   },
   kickUser: async (kickData: { userId: UserInterface['id']; instanceId: Instance['id']; duration: string }) => {
-    console.log('kicking user', kickData)
-
     const duration = new Date()
-    duration.setHours(duration.getHours() + parseInt(kickData.duration, 10))
+    if (kickData.duration === 'INFINITY') {
+      duration.setFullYear(duration.getFullYear() + 10) // ban for 10 years
+    } else {
+      duration.setHours(duration.getHours() + parseInt(kickData.duration, 10))
+    }
 
     const userKick = await API.instance.client.service('user-kick').create({ ...kickData, duration })
 
-    console.log('kicked user', userKick)
+    console.log('user kicked ->', userKick)
+
+    NotificationService.dispatchNotify(`user was kicked`, { variant: 'default' })
   }
 }
 


### PR DESCRIPTION
## Summary

Implements ban functionality for admin location controls.
Ban means user has an infinite Kick duration.

![image](https://user-images.githubusercontent.com/55396651/236663433-a4a3e7ca-9bee-4591-b73e-7dc61345ea7e.png)


## References

closes #5404 


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

