### PR TITLE
Fixed issues with Mediasoup port allocation.

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -120,7 +120,7 @@ export default defineConfig(async () => {
   })
   const clientSetting = await getClientSetting()
 
-  let base = `${process.env['APP_URL']}/`
+  let base = `https://${process.env['VITE_APP_HOST'] || process.env['APP_URL']}/`
 
   if (
     process.env.SERVE_CLIENT_FROM_STORAGE_PROVIDER === 'true' &&

--- a/packages/instanceserver/package.json
+++ b/packages/instanceserver/package.json
@@ -33,9 +33,9 @@
   "scripts": {
     "check-errors": "tsc --noemit",
     "start": "cross-env APP_ENV=production ts-node --swc src/index.ts",
-    "start-channel": "cross-env APP_ENV=production INSTANCESERVER_PORT=3032 ts-node --swc src/index.ts",
+    "start-channel": "cross-env APP_ENV=production INSTANCESERVER_PORT=3032 DEV_CHANNEL=true ts-node --swc src/index.ts",
     "dev": "cross-env APP_ENV=development NODE_OPTIONS='--inspect=2995' ts-node --swc src/index.ts",
-    "dev-channel": " cross-env APP_ENV=development NODE_OPTIONS='--inspect=2996' INSTANCESERVER_PORT=3032 ts-node --swc src/index.ts",
+    "dev-channel": " cross-env APP_ENV=development NODE_OPTIONS='--inspect=2996' DEV_CHANNEL=true INSTANCESERVER_PORT=3032 ts-node --swc src/index.ts",
     "dev-nossl": "cross-env NOSSL=true ts-node --swc src/index.ts",
     "test": "exit 0",
     "validate": "npm run build && npm run test"

--- a/packages/instanceserver/src/NetworkFunctions.ts
+++ b/packages/instanceserver/src/NetworkFunctions.ts
@@ -87,6 +87,10 @@ export const setupSubdomain = async () => {
       announcedIp
     }
   ]
+  localConfig.mediasoup.webRtcServerOptions.listenInfos.forEach((listenInfo) => {
+    listenInfo.announcedIp = announcedIp
+    listenInfo.ip = '0.0.0.0'
+  })
 }
 
 export async function getFreeSubdomain(isIdentifier: string, subdomainNumber: number): Promise<string> {
@@ -441,7 +445,7 @@ export async function handleDisconnect(network: SocketWebRTCServerNetwork, spark
   const peerID = spark.id as PeerID
   const userId = getUserIdFromPeerID(network, peerID) as UserId
   const disconnectedClient = network.peers.get(peerID)
-  if (!disconnectedClient) return logger.warn(`Tried to handle disconnect for peer ${peerID} but was not foudn`)
+  if (!disconnectedClient) return logger.warn(`Tried to handle disconnect for peer ${peerID} but was not found`)
   // On local, new connections can come in before the old sockets are disconnected.
   // The new connection will overwrite the socketID for the user's client.
   // This will only clear transports if the client's socketId matches the socket that's disconnecting.

--- a/packages/instanceserver/src/WebRTCFunctions.ts
+++ b/packages/instanceserver/src/WebRTCFunctions.ts
@@ -5,12 +5,12 @@ import {
   DataProducer,
   DataProducerOptions,
   MediaKind,
-  ProducerOptions,
   Router,
   RtpCodecCapability,
   RtpParameters,
   SctpStreamParameters,
   Transport,
+  WebRtcServer,
   WebRtcTransport,
   Worker
 } from 'mediasoup/node/lib/types'
@@ -18,18 +18,14 @@ import os from 'os'
 import { Spark } from 'primus'
 
 import { PeerID } from '@etherealengine/common/src/interfaces/PeerID'
-import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { DataChannelType } from '@etherealengine/engine/src/networking/classes/Network'
 import { MessageTypes } from '@etherealengine/engine/src/networking/enums/MessageTypes'
-import { NetworkPeer } from '@etherealengine/engine/src/networking/interfaces/NetworkPeer'
 import {
   dataChannelRegistry,
   MediaStreamAppData,
-  MediaTagType,
-  NetworkState
+  MediaTagType
 } from '@etherealengine/engine/src/networking/NetworkState'
 import { getState } from '@etherealengine/hyperflux'
-import { Application } from '@etherealengine/server-core/declarations'
 import config from '@etherealengine/server-core/src/appconfig'
 import { localConfig, sctpParameters } from '@etherealengine/server-core/src/config'
 import multiLogger from '@etherealengine/server-core/src/ServerLogger'
@@ -63,6 +59,10 @@ export async function startWebRTC() {
       logTags: ['sctp']
     })
 
+    const webRtcServerOptions = JSON.parse(JSON.stringify(localConfig.mediasoup.webRtcServerOptions))
+    for (const listenInfo of webRtcServerOptions.listenInfos) listenInfo.port += i
+    newWorker.appData.webRtcServer = await newWorker.createWebRtcServer(webRtcServerOptions)
+
     newWorker.on('died', (err) => {
       logger.fatal(err, 'mediasoup worker died (this should never happen)')
       process.exit(1)
@@ -71,7 +71,7 @@ export async function startWebRTC() {
     logger.info('Created Mediasoup worker.')
 
     const mediaCodecs = localConfig.mediasoup.router.mediaCodecs as RtpCodecCapability[]
-    const newRouter = await newWorker.createRouter({ mediaCodecs })
+    const newRouter = await newWorker.createRouter({ mediaCodecs, appData: { worker: newWorker } })
     routers.instance.push(newRouter)
     logger.info('Worker created router.')
     workers.push(newWorker)
@@ -261,6 +261,13 @@ export const handleWebRtcConsumeData = async (
   }
 }
 
+export async function closeDataProducer(network, dataProducer): Promise<void> {
+  network.dataProducers.delete(dataProducer.id)
+  logger.info("data producer's transport closed: " + dataProducer.id)
+  dataProducer.close()
+  network.peers.get(dataProducer.appData.peerID)!.dataProducers!.delete(dataProducer.id)
+}
+
 export async function closeTransport(
   network: SocketWebRTCServerNetwork,
   transport: WebRTCTransportExtension
@@ -269,6 +276,10 @@ export async function closeTransport(
   // our producer and consumer event handlers will take care of
   // calling closeProducer() and closeConsumer() on all the producers
   // and consumers associated with this transport
+  const dataProducers = (transport as any).dataProducers
+  dataProducers?.forEach(async (dataProducer) => await closeDataProducer(network, dataProducer))
+  const producers = (transport as any).producers
+  producers?.forEach(async (producer) => await closeProducer(network, producer))
   if (transport && typeof transport.close === 'function') {
     await transport.close()
     delete network.mediasoupTransports[transport.id]
@@ -335,7 +346,7 @@ export async function createWebRtcTransport(
       network.routers[`${channelType}:${channelId}`] = [] as any
       await Promise.all(
         network.workers.map(async (worker) => {
-          const newRouter = await worker.createRouter({ mediaCodecs })
+          const newRouter = await worker.createRouter({ mediaCodecs, appData: { worker } })
           network.routers[`${channelType}:${channelId}`].push(newRouter)
           return Promise.resolve()
         })
@@ -357,7 +368,7 @@ export async function createWebRtcTransport(
   }
 
   return selectedrouter?.createWebRtcTransport({
-    listenIps: listenIps,
+    webRtcServer: (selectedrouter.appData.worker as Worker).appData!.webRtcServer as WebRtcServer,
     enableUdp: true,
     enableTcp: false,
     preferUdp: true,
@@ -509,7 +520,6 @@ export async function handleWebRtcProduceData(
   messageId?: string
 ): Promise<any> {
   try {
-    console.log('webRTCProduceData')
     const peerID = spark.id as PeerID
     const userId = getUserIdFromPeerID(network, peerID)
     if (!userId) {
@@ -557,22 +567,16 @@ export async function handleWebRtcProduceData(
 
           await Promise.all(
             network.routers.instance.map(async (router) => {
-              if (router.id !== transport.internal.routerId) {
+              if (router.id !== transport.internal.routerId)
                 return currentRouter.pipeToRouter({
                   dataProducerId: dataProducer.id,
                   router: router
                 })
-              }
             })
           )
 
           // if our associated transport closes, close ourself, too
-          dataProducer.on('transportclose', () => {
-            network.dataProducers.delete(dataProducer.id)
-            logger.info("data producer's transport closed: " + dataProducer.id)
-            dataProducer.close()
-            network.peers.get(peerID)!.dataProducers!.delete(dataProducer.id)
-          })
+          dataProducer.on('transportclose', () => closeDataProducer(network, dataProducer))
           const internalConsumer = await createInternalDataConsumer(network, dataProducer, peerID)
           if (internalConsumer) {
             if (!network.peers.has(peerID)) {
@@ -1046,7 +1050,7 @@ export async function handleWebRtcInitializeRouter(
       network.routers[`${channelType}:${channelId}`] = []
       await Promise.all(
         network.workers.map(async (worker) => {
-          const newRouter = await worker.createRouter({ mediaCodecs })
+          const newRouter = await worker.createRouter({ mediaCodecs, appData: { worker } })
           network.routers[`${channelType}:${channelId}`].push(newRouter)
         })
       )

--- a/packages/server-core/src/config.ts
+++ b/packages/server-core/src/config.ts
@@ -3,6 +3,8 @@ import type { PlainTransportOptions } from 'mediasoup/node/lib/PlainTransport'
 import configFile from './appconfig'
 import { SctpParameters } from './types/SctpParameters'
 
+const NUM_RTC_PORTS = process.env.NUM_RTC_PORTS ? parseInt(process.env.NUM_RTC_PORTS) : 10000
+
 export const sctpParameters: SctpParameters = {
   OS: 1024,
   MIS: 65535,
@@ -13,6 +15,22 @@ export const sctpParameters: SctpParameters = {
 export const config = {
   httpPeerStale: 15000,
   mediasoup: {
+    webRtcServerOptions: {
+      listenInfos: [
+        {
+          protocol: 'udp',
+          ip: configFile.instanceserver.hostname! || '0.0.0.0',
+          announcedIp: null! as string,
+          port: process.env.DEV_CHANNEL === 'true ' ? 30000 : 40000
+        },
+        {
+          protocol: 'tcp',
+          ip: configFile.instanceserver.hostname! || '0.0.0.0',
+          announcedIp: null! as string,
+          port: process.env.DEV_CHANNEL === 'true' ? 30000 : 40000
+        }
+      ]
+    },
     worker: {
       rtcMinPort: 40000,
       rtcMaxPort: 49999,
@@ -72,9 +90,26 @@ export const config = {
 export const localConfig = {
   httpPeerStale: 15000,
   mediasoup: {
+    webRtcServerOptions: {
+      listenInfos: [
+        {
+          protocol: 'udp',
+          ip: configFile.instanceserver.hostname! || '0.0.0.0',
+          announcedIp: null! as string,
+          port: process.env.DEV_CHANNEL === 'true' ? 30000 : configFile.instanceserver.rtc_start_port
+        },
+        {
+          protocol: 'tcp',
+          ip: configFile.instanceserver.hostname! || '0.0.0.0',
+          announcedIp: null! as string,
+          port: process.env.DEV_CHANNEL === 'true' ? 30000 : configFile.instanceserver.rtc_start_port
+        }
+      ]
+    },
     worker: {
-      rtcMinPort: configFile.instanceserver.rtc_start_port,
-      rtcMaxPort: configFile.instanceserver.rtc_end_port,
+      rtcMinPort: process.env.DEV_CHANNEL === 'true' ? 30000 : configFile.instanceserver.rtc_start_port,
+      rtcMaxPort:
+        (process.env.DEV_CHANNEL === 'true' ? 30000 : configFile.instanceserver.rtc_start_port) + NUM_RTC_PORTS - 1,
       logLevel: 'info',
       logTags: ['info', 'ice', 'dtls', 'rtp', 'srtp', 'rtcp']
     },


### PR DESCRIPTION
## Summary

Testing of instanceservers on microk8s on a 24-thread CPU demonstrated some scaling problems with the port allocation to mediasoup. In order to make (data)producers consumable on every core, each (data)producer needs to be piped to every other core. This uses up two local ports per other core, as each router must create a pipeTransport to the other router, which also needs a pipeTransport. This scales exponentially; if mediasoup is given 200 ports to use, it cannot support a 16-core/thread processor, as that alone would require 240 ports, which does not even factor in the ports needed for incoming transports from clients.

The solution involved a newer feature of mediasoup, WebRtcServers. Prior to this, each external transport used up a port of its own, leading to 2n transports per client (one for recvTransport and one for sendTransport). WebRtcServers can handle a near-infinite number of transports on a single inbound port. Now, when an instanceserver starts, it makes a WebRtcServer on each worker and saves a reference on that worker. When a (data)transport is created, instead of passing listenIps to createWebRtcTransport, the routers' worker's WebRtcSerer is passed instead.

The solution also involves greatly expanding the number of ports that mediasoup uses, while trusting that only the first 100-200 are publicly exposed. Prior to this, only the 200 (by default) ports specified in the instanceserver fleet specification in the etherealengine Helm chart were used by mediasoup, under the theory that that many were needed to adequately handle 50-100 connecting clients. With the use of WebRtcServers, only the number of cores' worth of ports need to be exposed publicly, and since they are the first thing to start and be assigned ports, they will get ports somewhere in the range 40000-40199, starting with 40000.

Mediasoup is now given a 10,000-port block in total to work with. The first n ports will be used by the WebRtcServers, and the rest will be free to be allocated to pipeTransports as requested. This supports up to a 100-core/thread CPU, which seems sufficiently future-proof. If a higher-thread-count CPU needs to be supported, all that's needed is to set the environment variable NUM_RTC_PORTS, which will override the default of 10000.

Added an environment variable DEV_CHANNEL='true' on instanceservers' start-channel and dev-channel scripts. This allows those processes to run on a different port range so that, in dev mode, the channel server does not confliect with the ports used by the world server (by default channel will start at port 30000 instead of 40000).

Also made some more explicit closings of (data)producers, rather than just relying on the closing transport to close them.

## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

