### PR TITLE
Fix patching of username

### DIFF
--- a/packages/instanceserver/src/channels.ts
+++ b/packages/instanceserver/src/channels.ts
@@ -15,6 +15,7 @@ import { SceneState } from '@etherealengine/engine/src/ecs/classes/Scene'
 import { NetworkTopics } from '@etherealengine/engine/src/networking/classes/Network'
 import { MessageTypes } from '@etherealengine/engine/src/networking/enums/MessageTypes'
 import { NetworkPeerFunctions } from '@etherealengine/engine/src/networking/functions/NetworkPeerFunctions'
+import { WorldState } from '@etherealengine/engine/src/networking/interfaces/WorldState'
 import { addNetwork, NetworkState } from '@etherealengine/engine/src/networking/NetworkState'
 import { updatePeers } from '@etherealengine/engine/src/networking/systems/OutgoingActionSystem'
 import { dispatchAction, getMutableState, getState } from '@etherealengine/hyperflux'
@@ -286,7 +287,12 @@ const loadEngine = async (app: Application, sceneId: string) => {
         }, 100)
       })
     }
+    const userUpdatedListener = async (user) => {
+      const worldState = getMutableState(WorldState)
+      if (worldState.userNames[user.id]?.value) worldState.userNames[user.id].set(user.name)
+    }
     app.service('scene').on('updated', sceneUpdatedListener)
+    app.service('user').on('patched', userUpdatedListener)
     await sceneUpdatedListener()
 
     logger.info('Scene loaded!')


### PR DESCRIPTION
## Summary

Publishing of user patched was not using the correct logic to determine which users on the same instance to notify.

Added listener to instanceserver for user name patching, so that users joining after a username has changed get the update-to-date name on the peer.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

