### PR TITLE
fix media bugs with multiple peers to same user

### DIFF
--- a/packages/client-core/src/components/UserMediaWindows/index.tsx
+++ b/packages/client-core/src/components/UserMediaWindows/index.tsx
@@ -2,51 +2,70 @@ import { useHookstate } from '@hookstate/core'
 import React from 'react'
 
 import { PeerID } from '@etherealengine/common/src/interfaces/PeerID'
+import { UserId } from '@etherealengine/common/src/interfaces/UserId'
 import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { getMutableState } from '@etherealengine/hyperflux'
 
+import { useMediaInstance } from '../../common/services/MediaInstanceConnectionService'
 import { PeerMediaChannelState, PeerMediaStreamInterface } from '../../transports/PeerMediaChannelState'
 import { useShelfStyles } from '../Shelves/useShelfStyles'
 import { UserMediaWindow, UserMediaWindowWidget } from '../UserMediaWindow'
 import styles from './index.module.scss'
 
+type WindowType = { peerID: PeerID; type: 'cam' | 'screen' }
+
+const sortScreensBeforeCameras = (a: WindowType, b: WindowType) => {
+  if (a.type === 'screen' && b.type === 'cam') return -1
+  if (a.type === 'cam' && b.type === 'screen') return 1
+  return 0
+}
+
 export const UserMediaWindows = () => {
   const peerMediaChannelState = useHookstate(getMutableState(PeerMediaChannelState))
+  const mediaNetworkInstanceState = useMediaInstance()
+  const mediaNetwork = Engine.instance.mediaNetwork
+  const mediaNetworkConnected = mediaNetwork && mediaNetworkInstanceState?.connected?.value
 
   const consumers = Object.entries(peerMediaChannelState.get({ noproxy: true })) as [
     PeerID,
     { cam: PeerMediaStreamInterface; screen: PeerMediaStreamInterface }
   ][]
 
-  const windows = [] as { peerID: PeerID; type: 'cam' | 'screen' }[]
-
-  const screens = consumers
-    .filter(([peerID, { cam, screen }]) => screen?.videoStream)
-    .map(([peerID]) => {
-      return { peerID, type: 'screen' as 'screen' }
-    })
-
-  const cams = consumers
-    .filter(
-      ([peerID, { cam, screen }]) =>
-        cam &&
-        ((cam.videoStream && !cam.videoProducerPaused && !cam.videoStreamPaused) ||
-          (cam.audioStream && !cam.audioProducerPaused && !cam.audioStreamPaused))
-    )
-    .map(([peerID]) => {
-      return { peerID, type: 'cam' as 'cam' }
-    })
-
-  windows.push(...screens, ...cams)
-
   const selfPeerID = Engine.instance.peerID
   const selfUserID = Engine.instance.userId
-  const mediaNetwork = Engine.instance.mediaNetwork
 
-  // if window doesnt exist for self, add it
-  if (!mediaNetwork || !windows.find(({ peerID }) => mediaNetwork.peers.get(peerID)?.userId === selfUserID)) {
-    windows.unshift({ peerID: selfPeerID, type: 'cam' })
-  }
+  const camActive = (cam: PeerMediaStreamInterface) =>
+    (cam.videoStream && !cam.videoProducerPaused && !cam.videoStreamPaused) ||
+    (cam.audioStream && !cam.audioProducerPaused && !cam.audioStreamPaused)
+
+  const userPeers: Array<[UserId, PeerID[]]> = mediaNetworkConnected
+    ? Array.from(mediaNetwork.users.entries())
+    : [[selfUserID, [selfPeerID]]]
+
+  // reduce all userPeers to an array 'windows' of { peerID, type } objects, displaying screens first, then cams. if a user has no cameras, only include one peerID for that user
+  const windows = userPeers
+    .reduce((acc, [userID, peerIDs]) => {
+      const userCams = consumers
+        .filter(([peerID, { cam, screen }]) => peerIDs.includes(peerID) && cam && camActive(cam))
+        .map(([peerID]) => {
+          return { peerID, type: 'cam' as const }
+        })
+
+      const userScreens = consumers
+        .filter(([peerID, { cam, screen }]) => peerIDs.includes(peerID) && screen?.videoStream)
+        .map(([peerID]) => {
+          return { peerID, type: 'screen' as const }
+        })
+
+      const userWindows = [...userScreens, ...userCams]
+      if (userWindows.length) {
+        acc.push(...userWindows)
+      } else {
+        acc.push({ peerID: peerIDs[0], type: 'cam' })
+      }
+      return acc
+    }, [] as WindowType[])
+    .sort(sortScreensBeforeCameras)
 
   const { topShelfStyle } = useShelfStyles()
 

--- a/packages/client-core/src/components/UserMediaWindows/index.tsx
+++ b/packages/client-core/src/components/UserMediaWindows/index.tsx
@@ -80,12 +80,26 @@ export const UserMediaWindowsWidget = () => {
     })
 
   const cams = consumers
-    .filter(([peerID, { cam, screen }]) => cam)
+    .filter(
+      ([peerID, { cam, screen }]) =>
+        cam &&
+        ((cam.videoStream && !cam.videoProducerPaused && !cam.videoStreamPaused) ||
+          (cam.audioStream && !cam.audioProducerPaused && !cam.audioStreamPaused))
+    )
     .map(([peerID]) => {
       return { peerID, type: 'cam' as 'cam' }
     })
 
   windows.push(...screens, ...cams)
+
+  const selfPeerID = Engine.instance.peerID
+  const selfUserID = Engine.instance.userId
+  const mediaNetwork = Engine.instance.mediaNetwork
+
+  // if window doesnt exist for self, add it
+  if (!mediaNetwork || !windows.find(({ peerID }) => mediaNetwork.peers.get(peerID)?.userId === selfUserID)) {
+    windows.unshift({ peerID: selfPeerID, type: 'cam' })
+  }
 
   return (
     <div className={`${styles.userMediaWindowsContainer}`}>

--- a/packages/client-core/src/media/PeerMedia.tsx
+++ b/packages/client-core/src/media/PeerMedia.tsx
@@ -2,7 +2,6 @@ import React, { useEffect } from 'react'
 
 import { PeerID } from '@etherealengine/common/src/interfaces/PeerID'
 import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
-import { Network } from '@etherealengine/engine/src/networking/classes/Network'
 import { MessageTypes } from '@etherealengine/engine/src/networking/enums/MessageTypes'
 import {
   MediaTagType,
@@ -12,9 +11,9 @@ import {
   webcamAudioDataChannelType,
   webcamVideoDataChannelType
 } from '@etherealengine/engine/src/networking/NetworkState'
-import { getMutableState, getState, State, useHookstate } from '@etherealengine/hyperflux'
+import { getMutableState, getState, useHookstate } from '@etherealengine/hyperflux'
 
-import { MediaInstanceState } from '../common/services/MediaInstanceConnectionService'
+import { useMediaNetwork } from '../common/services/MediaInstanceConnectionService'
 import { MediaStreamState } from '../transports/MediaStreams'
 import {
   createPeerMediaChannels,
@@ -26,53 +25,6 @@ import {
   ProducerExtension,
   SocketWebRTCClientNetwork
 } from '../transports/SocketWebRTCClientFunctions'
-import { AuthState } from '../user/services/AuthService'
-
-export const getMediaChannels = (network: SocketWebRTCClientNetwork | Network, consumers: ConsumerExtension[]) => {
-  const mediaStreamState = getMutableState(MediaStreamState)
-  const selfUserId = getState(AuthState).user.id
-  const channelConnectionState = getMutableState(MediaInstanceState)
-  const currentChannelInstanceConnection = network && channelConnectionState.instances[network.hostId].ornull
-
-  const displayedUsers = (
-    network?.hostId && currentChannelInstanceConnection
-      ? Array.from(network.peers.values()).filter((peer) => peer.peerID !== 'server' && peer.userId !== selfUserId) ||
-        []
-      : []
-  ).map((peer) => peer.userId)
-
-  const mediaChannels = [] as Array<{ peerID: PeerID; mediaTag?: MediaTagType }>
-
-  /** always put own peer first */
-  const selfPeerID = Engine.instance.peerID
-  if (mediaStreamState.screenVideoProducer.value != null && !mediaStreamState.screenShareVideoPaused.value)
-    mediaChannels.push({ peerID: selfPeerID, mediaTag: screenshareVideoDataChannelType })
-  if (mediaStreamState.screenAudioProducer.value != null && !mediaStreamState.screenShareAudioPaused.value)
-    mediaChannels.push({ peerID: selfPeerID, mediaTag: screenshareAudioDataChannelType })
-  mediaChannels.push({ peerID: selfPeerID, mediaTag: webcamVideoDataChannelType })
-  mediaChannels.push({ peerID: selfPeerID, mediaTag: webcamAudioDataChannelType })
-
-  // filter out pairs of cam video & cam audio
-  consumers.forEach((consumer) => {
-    const isUnique = !mediaChannels.find(
-      (u) =>
-        consumer.appData.peerID === u.peerID &&
-        ((consumer.appData.mediaTag === webcamVideoDataChannelType && u.mediaTag === webcamAudioDataChannelType) ||
-          (consumer.appData.mediaTag === webcamAudioDataChannelType && u.mediaTag === webcamVideoDataChannelType))
-    )
-    if (isUnique && displayedUsers.includes(network.peers.get(consumer.appData.peerID)?.userId!))
-      mediaChannels.push({ peerID: consumer.appData.peerID, mediaTag: consumer.appData.mediaTag })
-  })
-
-  // include a peer for each user without any consumers
-  if (network)
-    displayedUsers.forEach((userId) => {
-      const peerID = Array.from(network.peers.values()).find((peer) => peer.userId === userId)?.peerID
-      if (peerID && !mediaChannels.find((window) => window.peerID === peerID)) mediaChannels.push({ peerID })
-    })
-
-  return mediaChannels
-}
 
 /**
  * Sets media stream state for a peer
@@ -295,40 +247,46 @@ const PeerMedia = (props: {
   return null
 }
 
-export const PeerConsumers = () => {
+export const PeerMediaChannels = () => {
   const mediaStreamState = useHookstate(getMutableState(MediaStreamState))
-  const peerMediaChannelState = useHookstate(getMutableState(PeerMediaChannelState))
-  const selfUserId = getState(AuthState).user.id
-
-  const networkState = useHookstate(getMutableState(NetworkState))
-  const network = networkState?.get({ noproxy: true })
-  const mediaHostId = network.hostIds?.media
-  const mediaNetwork = mediaHostId ? network.networks[mediaHostId] : null
+  const mediaNetworkState = useMediaNetwork()
 
   // create a peer media stream for each peer with a consumer
   useEffect(() => {
-    if (!mediaNetwork?.consumers) return
-    const mediaChannels = getMediaChannels(mediaNetwork, mediaNetwork.consumers)
-    for (const consumer of mediaChannels) {
-      if (!peerMediaChannelState.get({ noproxy: true })[consumer.peerID]) {
-        createPeerMediaChannels(consumer.peerID)
+    const mediaNetwork = Engine.instance.mediaNetwork as SocketWebRTCClientNetwork
+    if (!mediaNetwork) return
+    const peerMediaChannels = getState(PeerMediaChannelState)
+    const mediaChannelPeers = Array.from(mediaNetwork.peers.keys()).filter((peerID) => peerID !== 'server')
+    for (const peerID of mediaChannelPeers) {
+      if (!peerMediaChannels[peerID]) {
+        createPeerMediaChannels(peerID)
       }
     }
-    for (const peerID of Object.keys(peerMediaChannelState.get({ noproxy: true }))) {
-      const peerConsumers = mediaChannels.filter((consumer) => consumer.peerID === peerID)
+    for (const peerID of Object.keys(peerMediaChannels)) {
+      const peerConsumers = mediaChannelPeers.filter((peer) => peer === peerID)
       if (peerConsumers.length === 0) {
         removePeerMediaChannels(peerID as PeerID)
       }
     }
   }, [
-    mediaNetwork?.peers?.size,
-    mediaNetwork?.consumers?.length,
-    peerMediaChannelState.get({ noproxy: true }),
+    mediaNetworkState?.peers?.size,
+    mediaNetworkState?.consumers?.length,
     mediaStreamState.videoStream,
     mediaStreamState.audioStream,
     mediaStreamState.screenAudioProducer,
     mediaStreamState.screenVideoProducer
   ])
+
+  return null
+}
+
+export const PeerConsumers = () => {
+  const mediaStreamState = useHookstate(getMutableState(MediaStreamState))
+  const peerMediaChannelState = useHookstate(getMutableState(PeerMediaChannelState))
+  const networkState = useHookstate(getMutableState(NetworkState))
+  const network = networkState?.get({ noproxy: true })
+  const mediaHostId = network.hostIds?.media
+  const mediaNetwork = mediaHostId ? network.networks[mediaHostId] : null
 
   const mediaChannels = [] as {
     peerID: PeerID
@@ -345,35 +303,39 @@ export const PeerConsumers = () => {
 
   // own peer id
   const peerID = Engine.instance.peerID
-  if (mediaStreamState.camVideoProducer.value)
-    mediaChannels.push({
-      peerID,
-      channel: mediaStreamState.camVideoProducer.value,
-      mediaTag: webcamVideoDataChannelType
-    })
-  if (mediaStreamState.camAudioProducer.value)
-    mediaChannels.push({
-      peerID,
-      channel: mediaStreamState.camAudioProducer.value,
-      mediaTag: webcamAudioDataChannelType
-    })
-  if (mediaStreamState.screenVideoProducer.value)
-    mediaChannels.push({
-      peerID,
-      channel: mediaStreamState.screenVideoProducer.value,
-      mediaTag: screenshareVideoDataChannelType
-    })
-  if (mediaStreamState.screenAudioProducer.value)
-    mediaChannels.push({
-      peerID,
-      channel: mediaStreamState.screenAudioProducer.value,
-      mediaTag: screenshareAudioDataChannelType
-    })
+  const alreadyContainsSelf = mediaChannels.find((channel) => channel.peerID === peerID)
+  if (!alreadyContainsSelf) {
+    if (mediaStreamState.camVideoProducer.value)
+      mediaChannels.push({
+        peerID,
+        channel: mediaStreamState.camVideoProducer.value,
+        mediaTag: webcamVideoDataChannelType
+      })
+    if (mediaStreamState.camAudioProducer.value)
+      mediaChannels.push({
+        peerID,
+        channel: mediaStreamState.camAudioProducer.value,
+        mediaTag: webcamAudioDataChannelType
+      })
+    if (mediaStreamState.screenVideoProducer.value)
+      mediaChannels.push({
+        peerID,
+        channel: mediaStreamState.screenVideoProducer.value,
+        mediaTag: screenshareVideoDataChannelType
+      })
+    if (mediaStreamState.screenAudioProducer.value)
+      mediaChannels.push({
+        peerID,
+        channel: mediaStreamState.screenAudioProducer.value,
+        mediaTag: screenshareAudioDataChannelType
+      })
+  }
 
   return (
     <>
+      <PeerMediaChannels />
       {mediaChannels
-        .filter(({ peerID }) => peerMediaChannelState[peerID].get({ noproxy: true }))
+        .filter(({ peerID }) => peerMediaChannelState.get({ noproxy: true })[peerID])
         .map(({ channel, peerID, mediaTag }) => (
           <PeerMedia channel={channel} peerID={peerID} mediaTag={mediaTag} key={peerID + '-' + mediaTag} />
         ))}

--- a/packages/client-core/src/transports/PeerMediaChannelState.ts
+++ b/packages/client-core/src/transports/PeerMediaChannelState.ts
@@ -58,10 +58,12 @@ export const createPeerMediaChannels = (peerID: PeerID) => {
 }
 
 export const removePeerMediaChannels = (peerID: PeerID) => {
+  console.log('removePeerMediaChannels', peerID)
   const state = getMutableState(PeerMediaChannelState)
   state[peerID].set(none)
 }
 
 export const clearPeerMediaChannels = () => {
+  console.log('clearPeerMediaChannels')
   getMutableState(PeerMediaChannelState).set({})
 }

--- a/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
@@ -557,7 +557,7 @@ export async function onConnectToMediaInstance(network: SocketWebRTCClientNetwor
     // not guaranteed to be returned, will be refactored when converted to hyperflux actions
     if (!consumerId) return
     const consumer = network.consumers.find((c) => c.id === consumerId) as ConsumerExtension
-    if (!consumer) throw new Error('Consumer not found: ' + consumerId)
+    if (!consumer) return
     const peerID = consumer?.appData?.peerID
     const mediaTag = consumer.appData.mediaTag
     consumer.close()

--- a/packages/instanceserver/src/WebRTCFunctions.ts
+++ b/packages/instanceserver/src/WebRTCFunctions.ts
@@ -111,69 +111,45 @@ export const createOutgoingDataProducer = async (network: SocketWebRTCServerNetw
   network.outgoingDataProducers[dataChannel] = outgoingDataProducer
 }
 
-export const sendNewProducer =
-  (network: SocketWebRTCServerNetwork, spark: Spark, peerID: PeerID, channelType: string, channelId?: string) =>
-  async (producer: ProducerExtension): Promise<void> => {
-    const userId = getUserIdFromPeerID(network, peerID)!
-    const selfClient = network.peers.get(peerID)!
-    if (selfClient?.peerID != null) {
-      for (const [, client] of network.peers) {
-        logger.info(`Sending media for "${userId}".`)
-        client?.media &&
-          Object.entries(client.media!).map(([subName, subValue]) => {
-            if (
-              channelType === 'instance'
-                ? 'instance' === subValue.channelType
-                : subValue.channelType === channelType && subValue.channelId === channelId
-            )
-              selfClient.spark!.write({
-                type: MessageTypes.WebRTCCreateProducer.toString(),
-                data: {
-                  peerID,
-                  mediaTag: subName,
-                  producerId: producer.id,
-                  channelType,
-                  channelId
-                }
-              })
-          })
-      }
-    }
-  }
-// Create consumer for each client!
+/**
+ * Sends all current producers to a new peer
+ * @param network
+ * @param spark
+ * @param selfPeerID
+ * @param userIds
+ * @param channelType
+ * @param channelId
+ */
 export const sendCurrentProducers = async (
   network: SocketWebRTCServerNetwork,
   spark: Spark,
-  peerID: PeerID,
+  selfPeerID: PeerID,
   userIds: string[],
   channelType: string,
   channelId?: string
 ): Promise<void> => {
-  const selfUserId = getUserIdFromPeerID(network, peerID)!
-  const selfClient = network.peers.get(peerID)!
-  if (selfClient?.peerID) {
-    for (const [peerID, client] of network.peers) {
-      if (
-        !(
-          client.userId === selfUserId ||
-          (userIds.length > 0 && !userIds.includes(client.userId)) ||
-          !client.media ||
-          !client.peerID
-        )
-      )
-        Object.entries(client.media).map(([subName, subValue]) => {
-          if (subValue.channelType === channelType && subValue.channelId === channelId && !subValue.paused)
-            selfClient.spark!.write({
-              type: MessageTypes.WebRTCCreateProducer.toString(),
-              data: {
-                peerID,
-                mediaTag: subName,
-                producerId: subValue.producerId,
-                channelType,
-                channelId
-              }
-            })
-        })
+  for (const [peerID, client] of network.peers) {
+    if (
+      peerID === selfPeerID ||
+      (userIds.length > 0 && !userIds.includes(client.userId)) ||
+      !client.media ||
+      !client.peerID
+    )
+      continue
+
+    for (const [dataChannel, peerMedia] of Object.entries(client.media)) {
+      if (peerMedia.channelType !== channelType || peerMedia.channelId !== channelId || peerMedia.paused) continue
+      // logger.info(`Sending producer ${peerMedia.producerId} to peer "${peerID}".`)
+      spark.write({
+        type: MessageTypes.WebRTCCreateProducer.toString(),
+        data: {
+          peerID,
+          mediaTag: dataChannel,
+          producerId: peerMedia.producerId,
+          channelType,
+          channelId
+        }
+      })
     }
   }
 }
@@ -495,7 +471,7 @@ export async function handleWebRtcTransportCreate(
     newTransport.observer.on('dtlsstatechange', (dtlsState) => {
       if (dtlsState === 'closed') closeTransport(network, newTransport as unknown as WebRTCTransportExtension)
     })
-    newTransport.observer.on('newproducer', sendNewProducer(network, spark, peerID, channelType, channelId) as any)
+    // newTransport.observer.on('newproducer', sendNewProducer(network, spark, peerID, channelType, channelId) as any)
     spark.write({
       type: MessageTypes.WebRTCTransportCreate.toString(),
       data: { transportOptions: clientTransportOptions },
@@ -767,6 +743,7 @@ export async function handleWebRtcSendTrack(
       logger.warn('Media stream producers is undefined.')
     }
     network.producers?.push(producer)
+    logger.info(`New Producer: peerID "${peerID}", Media stream "${appData.mediaTag}"`)
 
     if (userId && network.peers.has(peerID)) {
       network.peers.get(peerID)!.media![appData.mediaTag] = {
@@ -778,10 +755,9 @@ export async function handleWebRtcSendTrack(
         channelId: appData.channelId
       }
     }
-
     for (const [clientPeerID, client] of network.peers) {
       if (clientPeerID !== peerID && client.spark) {
-        client.spark!.write({
+        client.spark.write({
           type: MessageTypes.WebRTCCreateProducer.toString(),
           data: {
             peerID,


### PR DESCRIPTION
## Summary

PeerMediaChannelState made assumptions about and was determinded by an algorithm to select specific peers to be shown in the user media windows. PeerMediaChannelState should hold an entry for every peer, as logic is dependent upon it to handle consumers & producers.

Moving the assumption to the media window component itself cleans up the logic a lot, and fixes the issues.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

