### PR TITLE
Fixed multiple slash in avatar paths

### DIFF
--- a/packages/server-core/src/media/upload-asset/upload-asset.service.ts
+++ b/packages/server-core/src/media/upload-asset/upload-asset.service.ts
@@ -2,6 +2,7 @@ import { Params } from '@feathersjs/feathers'
 import { bodyParser, koa } from '@feathersjs/koa'
 import Multer from '@koa/multer'
 import { createHash } from 'crypto'
+import path from 'path'
 import { Op } from 'sequelize'
 import { MathUtils } from 'three'
 
@@ -145,7 +146,7 @@ export const addGenericAssetToS3AndStaticResources = async (
   // make userId optional and safe for feathers create
   const key = processFileName(args.key)
   const whereArgs = {
-    [Op.or]: [{ key: key + '/' + files[0].originalname }, { id: args.id ?? '' }]
+    [Op.or]: [{ key: path.join(key, files[0].originalname) }, { id: args.id ?? '' }]
   } as any
   if (args.project) whereArgs.project = args.project
   const existingAsset = (await app.service('static-resource').Model.findOne({
@@ -154,7 +155,7 @@ export const addGenericAssetToS3AndStaticResources = async (
 
   const mimeType = CommonKnownContentTypes[extension] as string
 
-  const assetURL = getCachedURL(key + '/' + files[0].originalname, provider.cacheDomain)
+  const assetURL = getCachedURL(path.join(key, files[0].originalname), provider.cacheDomain)
   const hash = args.hash || createStaticResourceHash(files[0].buffer, { name: args.name, assetURL })
   const body = {
     hash,
@@ -168,7 +169,7 @@ export const addGenericAssetToS3AndStaticResources = async (
   // upload asset to storage provider
   for (let i = 0; i < files.length; i++) {
     const file = files[i]
-    const useKey = key + '/' + file.originalname
+    const useKey = path.join(key, file.originalname)
     variants.push({
       url: getCachedURL(useKey, provider.cacheDomain),
       metadata: { size: file.size }


### PR DESCRIPTION
## Summary

This PR fixes following error when using MinIO as storage provider and probably also when using AWS S3 as reported by a user in discord.
```
[16:59:42.962] ERROR: Object name contains unsupported characters.
    component: "server-core"
    err: {
      "type": "S3ServiceException",
      "message": "Object name contains unsupported characters.",
      "stack":
          XMinioInvalidObjectName: Object name contains unsupported characters.
              at throwDefaultError (/home/hanzlamateen/etherealengine2/node_modules/@aws-sdk/smithy-client/dist-cjs/default-error-handler.js:8:22)
              at /home/hanzlamateen/etherealengine2/node_modules/@aws-sdk/smithy-client/dist-cjs/default-error-handler.js:18:39
              at de_PutObjectCommandError (/home/hanzlamateen/etherealengine2/node_modules/@aws-sdk/client-s3/dist-cjs/protocols/Aws_restXml.js:5701:12)
              at processTicksAndRejections (node:internal/process/task_queues:95:5)
              at async /home/hanzlamateen/etherealengine2/node_modules/@aws-sdk/middleware-serde/dist-cjs/deserializerMiddleware.js:7:24
              at async /home/hanzlamateen/etherealengine2/node_modules/@aws-sdk/middleware-signing/dist-cjs/middleware.js:14:20
              at async /home/hanzlamateen/etherealengine2/node_modules/@aws-sdk/middleware-retry/dist-cjs/retryMiddleware.js:27:46
              at async /home/hanzlamateen/etherealengine2/node_modules/@aws-sdk/middleware-flexible-checksums/dist-cjs/flexibleChecksumsMiddleware.js:58:20
              at async /home/hanzlamateen/etherealengine2/node_modules/@aws-sdk/middleware-logger/dist-cjs/loggerMiddleware.js:7:26
              at async S3Provider.putObject (/home/hanzlamateen/etherealengine2/packages/server-core/src/media/storageprovider/s3.storage.ts:241:24)
              at async uploadVariant (/home/hanzlamateen/etherealengine2/packages/server-core/src/media/upload-asset/upload-asset.service.ts:61:3)
              at async Promise.all (index 0)
              at async addGenericAssetToS3AndStaticResources (/home/hanzlamateen/etherealengine2/packages/server-core/src/media/upload-asset/upload-asset.service.ts:183:3)
              at async Promise.all (index 0)
              at async uploadAvatarStaticResource (/home/hanzlamateen/etherealengine2/packages/server-core/src/user/avatar/avatar-helper.ts:198:46)
              at async /home/hanzlamateen/etherealengine2/packages/server-core/src/user/avatar/avatar-helper.ts:127:52
              at async Promise.all (index 7)
              at async installAvatarsFromProject (/home/hanzlamateen/etherealengine2/packages/server-core/src/user/avatar/avatar-helper.ts:103:3)
              at async onProjectEvent (/home/hanzlamateen/etherealengine2/packages/server-core/src/projects/project/project-helper.ts:198:12)
              at async seeder (/home/hanzlamateen/etherealengine2/packages/server-core/src/seeder.ts:60:5)
              at async Feathers.app.setup (/home/hanzlamateen/etherealengine2/packages/server-core/src/sequelize.ts:117:13)
      "name": "XMinioInvalidObjectName",
      "$fault": "client",
      "$metadata": {
        "httpStatusCode": 400,
        "requestId": "1767E78DDE4AE482",
        "extendedRequestId": "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8",
        "attempts": 1,
        "totalRetryDelay": 0
      },
      "Code": "XMinioInvalidObjectName",
      "Key": "static-resources/avatar/public//CyberbotSilver.glb",
      "BucketName": "etherealengine-static-resources",
      "Resource": "/etherealengine-static-resources/static-resources/avatar/public//CyberbotSilver.glb",
      "RequestId": "1767E78DDE4AE482",
      "HostId": "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
    }
```

## References

#8054


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

