### PR TITLE
Option for Instancing in model-transform Service

### DIFF
--- a/packages/editor/src/components/properties/GLTFTransformProperties.tsx
+++ b/packages/editor/src/components/properties/GLTFTransformProperties.tsx
@@ -76,6 +76,12 @@ export default function GLTFTransformProperties({
             ]}
           />
         </InputGroup>
+        <InputGroup name="Instance" label={t('editor:properties.model.transform.instance')}>
+          <BooleanInput
+            value={transformParms.instance.value}
+            onChange={onChangeTransformParm(transformParms.instance)}
+          />
+        </InputGroup>
         <InputGroup name="Remove Duplicates" label={t('editor:properties.model.transform.removeDuplicates')}>
           <BooleanInput value={transformParms.dedup.value} onChange={onChangeTransformParm(transformParms.dedup)} />
         </InputGroup>

--- a/packages/engine/src/assets/classes/ModelTransform.ts
+++ b/packages/engine/src/assets/classes/ModelTransform.ts
@@ -75,7 +75,7 @@ export type ResourceTransforms = {
 export type ModelTransformParameters = ExtractedImageTransformParameters & {
   dst: string
   resourceUri: string
-
+  instance: boolean
   dedup: boolean
   prune: boolean
   reorder: boolean
@@ -97,6 +97,7 @@ export const DefaultModelTransformParameters: ModelTransformParameters = {
   dst: '',
   resourceUri: '',
   modelFormat: 'gltf',
+  instance: true,
   dedup: true,
   prune: true,
   reorder: true,

--- a/packages/server-core/src/assets/model-transform/model-transform.helpers.ts
+++ b/packages/server-core/src/assets/model-transform/model-transform.helpers.ts
@@ -344,15 +344,9 @@ export async function transformModel(app: Application, args: ModelTransformArgum
   unInstanceSingletons(document)
   await split(document)
   await combineMaterials(document)
-  await myInstance(document)
-
-  if (args.parms.dedup) {
-    await document.transform(dedup())
-  }
-
-  if (args.parms.prune) {
-    await document.transform(prune())
-  }
+  args.parms.instance && (await myInstance(document))
+  args.parms.dedup && (await document.transform(dedup()))
+  args.parms.prune && (await document.transform(prune()))
 
   /* Separate Instanced Geometry */
   const instancedNodes = root


### PR DESCRIPTION
Add toggle-able option to instance identical meshes in the gltf-transform pipeline. Useful for staging assets that still need to be optimized in external applications before instancing is applied.