### PR TITLE
Added logic to avoid Mediasoup using ports in use

### DIFF
--- a/packages/instanceserver/package.json
+++ b/packages/instanceserver/package.json
@@ -61,6 +61,7 @@
     "msgpackr": "^1.9.2",
     "primus": "^8.0.7",
     "ps-list": "7.2.0",
+    "tcp-port-used": "^1.0.2",
     "trace-unhandled": "2.0.1",
     "ts-node": "10.9.1",
     "typescript": "5.0.2",


### PR DESCRIPTION
## Summary

Mediasoup will throw an error if it tries to run
createWebRtcServer on a port that is in use. This is most often encountered in local development when things like IDEs use a port in the 40000 range.

Added some logic that checks if a port is in use before attempting to run on it. If it is in use, that port is skipped.

## References

closes #8097 

## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

