### PR TITLE
fix(studio): close save-as dialog after click save button

### DIFF
--- a/packages/editor/src/components/EditorContainer.tsx
+++ b/packages/editor/src/components/EditorContainer.tsx
@@ -298,12 +298,16 @@ const EditorContainer = () => {
         const blob = await takeScreenshot(512, 320)
         const file = new File([blob!], editorState.sceneName + '.thumbnail.png')
         const result: { name: string } = (await new Promise((resolve) => {
+          const closeDialog = (val: unknown) => {
+            resolve(val)
+            setDialogComponent(null)
+          }
           setDialogComponent(
             <SaveNewSceneDialog
               thumbnailUrl={URL.createObjectURL(blob!)}
               initialName={Engine.instance.scene.name}
-              onConfirm={resolve}
-              onCancel={resolve}
+              onConfirm={closeDialog}
+              onCancel={closeDialog}
             />
           )
         })) as any


### PR DESCRIPTION
## Summary

Fixes the save as dialog not closing after clicking on the save button


## References

closes #7862 


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

