### PR TITLE
fix(admin-panel): settings sidebar css

### DIFF
--- a/packages/client-core/src/admin/components/Setting/index.tsx
+++ b/packages/client-core/src/admin/components/Setting/index.tsx
@@ -105,7 +105,7 @@ const settingItems = [
   },
   {
     name: 'aws',
-    title: 'Aws',
+    title: 'AWS',
     icon: <Iconify icon="logos:aws" />,
     content: <Aws />
   },
@@ -171,17 +171,19 @@ const Setting = () => {
   return (
     <div ref={rootRef}>
       <div className={styles.invisible}>
-        <Button size="small" onClick={() => menuVisible.set(!menuVisible.value)} className={styles.menuBtn}>
-          <Icon type="Menu" />
-        </Button>
-        {menuVisible && (
+        {!menuVisible.value && (
+          <Button size="small" onClick={() => menuVisible.set(true)} className={styles.menuBtn}>
+            <Icon type="Menu" />
+          </Button>
+        )}
+        {menuVisible.value && (
           <div className={styles.hoverSettings}>
             <Grid display="flex" flexDirection="row" alignItems="center" marginBottom="10px">
               <Typography variant="h6" className={styles.settingsHeading}>
                 {t('admin:components.setting.settings')}
               </Typography>
               <IconButton
-                onClick={() => menuVisible.set(!menuVisible.value)}
+                onClick={() => menuVisible.set(false)}
                 style={{
                   color: 'orange',
                   fontSize: '3rem',

--- a/packages/client-core/src/admin/styles/settings.module.scss
+++ b/packages/client-core/src/admin/styles/settings.module.scss
@@ -31,9 +31,11 @@
   color: var(--iconButtonColor);
   font-size: 3rem;
   background: var(--iconButtonBackground);
-  position: fixed;
   width: auto;
   min-width: auto;
+  position: absolute;
+  top: -3rem;
+  left: -1rem;
 }
 
 .gradientButton {


### PR DESCRIPTION
## Summary

Earlier the menu button was not visible in mobile viewports and the settings sidebar was overlapping the settings inputs.
 
Fixed the CSS styles and the menu button's visibility error. Clicking the menu button will make the settings sidebar appear.

![image](https://github.com/EtherealEngine/etherealengine/assets/55396651/de3fe573-b800-4470-b4d6-f161c6d42bba)



## References

closes #8175


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

