### PR TITLE
Added ability to set Helm chart versions.

### DIFF
--- a/dockerfiles/api/Dockerfile-api
+++ b/dockerfiles/api/Dockerfile-api
@@ -26,4 +26,6 @@ WORKDIR /app
 
 COPY --from=builder /app ./
 
+RUN bash ./scripts/setup_helm.sh
+
 CMD ["scripts/start-server.sh"]

--- a/dockerfiles/api/Dockerfile-api-client
+++ b/dockerfiles/api/Dockerfile-api-client
@@ -106,4 +106,6 @@ WORKDIR /app
 COPY --from=apiBuilder /app ./
 COPY --from=clientBuilder /app/packages/client ./packages/client
 
+RUN bash ./scripts/setup_helm.sh
+
 CMD ["scripts/start-server.sh"]

--- a/packages/client-core/i18n/en/admin.json
+++ b/packages/client-core/i18n/en/admin.json
@@ -361,6 +361,14 @@
         "taskServer": "Task Server",
         "port": "Port",
         "processInterval": "Process Interval"
+      },
+      "helm": {
+        "header": "Helm Chart Versions",
+        "main": "Main deployment Helm version",
+        "builder": "Builder deployment Helm version",
+        "explainer": "To apply a new Helm chart version, Save here, then go to /admin/projects and then Rebuild",
+        "builderHelmToDeploy": "Builder Helm chart to deploy",
+        "mainHelmToDeploy": "Main Helm chart to deploy"
       }
     },
     "avatar": {

--- a/packages/client-core/src/admin/components/Setting/Helm.tsx
+++ b/packages/client-core/src/admin/components/Setting/Helm.tsx
@@ -1,0 +1,141 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import React, { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import InputSwitch from '@etherealengine/client-core/src/common/components/InputSwitch'
+import InputText from '@etherealengine/client-core/src/common/components/InputText'
+import { AwsCloudFrontType, AwsSmsType } from '@etherealengine/engine/src/schemas/setting/aws-setting.schema'
+import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
+import Box from '@etherealengine/ui/src/primitives/mui/Box'
+import Button from '@etherealengine/ui/src/primitives/mui/Button'
+import Grid from '@etherealengine/ui/src/primitives/mui/Grid'
+import Typography from '@etherealengine/ui/src/primitives/mui/Typography'
+
+import InputSelect, { InputMenuItem } from '../../../common/components/InputSelect'
+import { AuthState } from '../../../user/services/AuthService'
+import { AwsSettingService } from '../../services/Setting/AwsSettingService'
+import { AdminHelmSettingsState, HelmSettingService } from '../../services/Setting/HelmSettingService'
+import styles from '../../styles/settings.module.scss'
+
+const Helm = () => {
+  const { t } = useTranslation()
+  const helmSettingState = useHookstate(getMutableState(AdminHelmSettingsState))
+  const [helmSetting] = helmSettingState?.helmSettings?.get({ noproxy: true }) || []
+  const id = helmSetting?.id
+  const helmMainVersions = helmSettingState?.mainVersions?.get({ noproxy: true }) || []
+  const helmBuilderVersions = helmSettingState?.builderVersions?.get({ noproxy: true }) || []
+  const user = useHookstate(getMutableState(AuthState).user)
+  const selectedMainVersion = useHookstate('')
+  const selectedBuilderVersion = useHookstate('')
+
+  const handleMainVersionChange = async (e) => {
+    console.log('changeMainVersion', e, e.target.value)
+    selectedMainVersion.set(e.target.value)
+  }
+  const handleBuilderVersionChange = async (e) => {
+    selectedBuilderVersion.set(e.target.value)
+  }
+
+  const mainVersionMenu: InputMenuItem[] = helmMainVersions.map((el) => {
+    return {
+      value: el as string,
+      label: el
+    }
+  })
+
+  const builderVersionMenu: InputMenuItem[] = helmBuilderVersions.map((el) => {
+    return {
+      value: el as string,
+      label: el
+    }
+  })
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+
+    HelmSettingService.patchHelmSetting({ main: selectedMainVersion.value, builder: selectedBuilderVersion.value }, id)
+  }
+
+  const handleCancel = () => {
+    selectedMainVersion.set(helmSetting?.main)
+    selectedBuilderVersion.set(helmSetting?.builder)
+  }
+
+  useEffect(() => {
+    if (user?.id?.value != null && helmSettingState?.updateNeeded?.value) {
+      HelmSettingService.fetchHelmSetting()
+      HelmSettingService.fetchMainHelmVersions()
+      HelmSettingService.fetchBuilderHelmVersions()
+    }
+  }, [user?.id?.value, helmSettingState?.updateNeeded?.value])
+
+  useEffect(() => {
+    if (helmSetting?.main) selectedMainVersion.set(helmSetting.main)
+    if (helmSetting?.builder) selectedBuilderVersion.set(helmSetting.builder)
+  }, [helmSetting])
+
+  return (
+    <Box>
+      <Typography component="h1" className={styles.settingsHeading}>
+        {t('admin:components.setting.helm.header')}
+      </Typography>
+      <Grid container spacing={3}>
+        <Grid item xs={6} sm={6}>
+          <InputSelect
+            name="helmMain"
+            label={t('admin:components.setting.helm.main')}
+            value={selectedMainVersion.value}
+            menu={mainVersionMenu}
+            onChange={handleMainVersionChange}
+          />
+        </Grid>
+        <Grid item xs={6} sm={6}>
+          <InputSelect
+            name="helmBuilder"
+            label={t('admin:components.setting.helm.builder')}
+            value={selectedBuilderVersion.value}
+            menu={builderVersionMenu}
+            onChange={handleBuilderVersionChange}
+          />
+        </Grid>
+      </Grid>
+
+      <Typography component="h1" className={styles.settingsSubheading}>
+        {t('admin:components.setting.helm.explainer')}
+      </Typography>
+
+      <Button sx={{ maxWidth: '100%' }} className={styles.outlinedButton} onClick={handleCancel}>
+        {t('admin:components.common.cancel')}
+      </Button>
+      <Button sx={{ maxWidth: '100%', ml: 1 }} className={styles.gradientButton} onClick={handleSubmit}>
+        {t('admin:components.common.save')}
+      </Button>
+    </Box>
+  )
+}
+
+export default Helm

--- a/packages/client-core/src/admin/components/Setting/index.tsx
+++ b/packages/client-core/src/admin/components/Setting/index.tsx
@@ -48,6 +48,7 @@ import Client from './Client'
 import ClientTheme from './ClientTheme'
 import Coil from './Coil'
 import Email from './Email'
+import Helm from './Helm'
 import InstanceServer from './InstanceServer'
 import Project from './Project'
 import Redis from './Redis'
@@ -66,6 +67,12 @@ const settingItems = [
     title: 'Server',
     icon: <Iconify icon="carbon:bare-metal-server" color="orange" />,
     content: <Server />
+  },
+  {
+    name: 'helm',
+    title: 'Helm Charts',
+    icon: <Icon type="Poll" sx={{ color: 'orange' }} />,
+    content: <Helm />
   },
   {
     name: 'client',
@@ -168,6 +175,12 @@ const Setting = () => {
     rootRef?.current?.scrollIntoView()
   }, [menuVisible.value])
 
+  useEffect(() => {
+    const hash = window.location.hash.replace('#', '')
+    const settingsItemsNames = settingItems.map((item) => item.name)
+    if (settingsItemsNames.indexOf(hash) >= 0) selectedItem.set(hash)
+  }, [])
+
   return (
     <div ref={rootRef}>
       <div className={styles.invisible}>
@@ -197,6 +210,7 @@ const Setting = () => {
             <Sidebar
               selected={selectedItem.value}
               onChange={(name) => {
+                window.location.hash = `#${name}`
                 selectedItem.set(name)
               }}
             />
@@ -211,6 +225,7 @@ const Setting = () => {
           <Sidebar
             selected={selectedItem.value}
             onChange={(name) => {
+              window.location.hash = `#${name}`
               selectedItem.set(name)
             }}
           />

--- a/packages/client-core/src/admin/services/ResourceService.ts
+++ b/packages/client-core/src/admin/services/ResourceService.ts
@@ -23,8 +23,6 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { Paginated } from '@feathersjs/feathers/lib'
-
 import { StaticResourceInterface } from '@etherealengine/common/src/interfaces/StaticResourceInterface'
 import {
   StaticResourceFilterResult,
@@ -36,7 +34,6 @@ import { matches, Validator } from '@etherealengine/engine/src/common/functions/
 import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { defineAction, defineState, dispatchAction, getMutableState } from '@etherealengine/hyperflux'
 
-import { API } from '../../API'
 import { NotificationService } from '../../common/services/NotificationService'
 import { uploadToFeathersService } from '../../util/upload'
 

--- a/packages/client-core/src/admin/services/Setting/AuthSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/AuthSettingService.ts
@@ -27,9 +27,9 @@ import { Paginated } from '@feathersjs/feathers'
 
 import { AdminAuthSetting, PatchAuthSetting } from '@etherealengine/common/src/interfaces/AdminAuthSetting'
 import { matches, Validator } from '@etherealengine/engine/src/common/functions/MatchesUtils'
+import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { defineAction, defineState, dispatchAction, getMutableState } from '@etherealengine/hyperflux'
 
-import { API } from '../../../API'
 import { NotificationService } from '../../../common/services/NotificationService'
 import waitForClientAuthenticated from '../../../util/wait-for-client-authenticated'
 
@@ -88,7 +88,7 @@ export const AuthSettingsService = {
   fetchAuthSetting: async () => {
     try {
       await waitForClientAuthenticated()
-      const authSetting = (await API.instance.client
+      const authSetting = (await Engine.instance.api
         .service('authentication-setting')
         .find()) as Paginated<AdminAuthSetting>
       dispatchAction(AuthSettingsActions.authSettingRetrieved({ authSetting }))
@@ -99,7 +99,7 @@ export const AuthSettingsService = {
   },
   patchAuthSetting: async (data: PatchAuthSetting, id: string) => {
     try {
-      await API.instance.client.service('authentication-setting').patch(id, data)
+      await Engine.instance.api.service('authentication-setting').patch(id, data)
       dispatchAction(AuthSettingsActions.authSettingPatched({}))
     } catch (err) {
       NotificationService.dispatchNotify(err.message, { variant: 'error' })

--- a/packages/client-core/src/admin/services/Setting/AwsSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/AwsSettingService.ts
@@ -26,6 +26,7 @@ Ethereal Engine. All Rights Reserved.
 import { Paginated } from '@feathersjs/feathers'
 
 import { matches, Validator } from '@etherealengine/engine/src/common/functions/MatchesUtils'
+import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import {
   AwsSettingPatch,
   awsSettingPath,
@@ -33,7 +34,6 @@ import {
 } from '@etherealengine/engine/src/schemas/setting/aws-setting.schema'
 import { defineAction, defineState, dispatchAction, getMutableState } from '@etherealengine/hyperflux'
 
-import { API } from '../../../API'
 import { NotificationService } from '../../../common/services/NotificationService'
 
 export const AdminAwsSettingState = defineState({
@@ -65,7 +65,7 @@ export const AwsSettingReceptors = {
 export const AwsSettingService = {
   fetchAwsSetting: async () => {
     try {
-      const awsSettings = (await API.instance.client.service(awsSettingPath).find()) as Paginated<AwsSettingType>
+      const awsSettings = (await Engine.instance.api.service(awsSettingPath).find()) as Paginated<AwsSettingType>
       dispatchAction(AdminAwsSettingActions.awsSettingRetrieved({ awsSettings }))
     } catch (err) {
       NotificationService.dispatchNotify(err.message, { variant: 'error' })
@@ -73,7 +73,7 @@ export const AwsSettingService = {
   },
   patchAwsSetting: async (data: AwsSettingPatch, id: string) => {
     try {
-      await API.instance.client.service(awsSettingPath).patch(id, data)
+      await Engine.instance.api.service(awsSettingPath).patch(id, data)
       dispatchAction(AdminAwsSettingActions.awsSettingPatched({}))
     } catch (err) {
       NotificationService.dispatchNotify(err.message, { variant: 'error' })

--- a/packages/client-core/src/admin/services/Setting/ChargebeeSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/ChargebeeSettingService.ts
@@ -26,13 +26,13 @@ Ethereal Engine. All Rights Reserved.
 import { Paginated } from '@feathersjs/feathers'
 
 import { matches, Validator } from '@etherealengine/engine/src/common/functions/MatchesUtils'
+import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import {
   chargebeeSettingPath,
   ChargebeeSettingType
 } from '@etherealengine/engine/src/schemas/setting/chargebee-setting.schema'
 import { defineAction, defineState, dispatchAction, getMutableState } from '@etherealengine/hyperflux'
 
-import { API } from '../../../API'
 import { NotificationService } from '../../../common/services/NotificationService'
 
 export const AdminChargebeeSettingsState = defineState({
@@ -57,7 +57,7 @@ export const AdminChargebeeReceptors = {
 export const ChargebeeSettingService = {
   fetchChargeBee: async () => {
     try {
-      const chargeBee = (await API.instance.client
+      const chargeBee = (await Engine.instance.api
         .service(chargebeeSettingPath)
         .find()) as Paginated<ChargebeeSettingType>
       dispatchAction(AdminChargebeeSettingActions.chargebeeSettingRetrieved({ chargebeeSetting: chargeBee }))

--- a/packages/client-core/src/admin/services/Setting/ClientSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/ClientSettingService.ts
@@ -28,6 +28,7 @@ import { Paginated } from '@feathersjs/feathers'
 import config from '@etherealengine/common/src/config'
 import multiLogger from '@etherealengine/common/src/logger'
 import { matches, Validator } from '@etherealengine/engine/src/common/functions/MatchesUtils'
+import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import {
   ClientSettingPatch,
   clientSettingPath,
@@ -35,7 +36,6 @@ import {
 } from '@etherealengine/engine/src/schemas/setting/client-setting.schema'
 import { defineAction, defineState, dispatchAction, getMutableState } from '@etherealengine/hyperflux'
 
-import { API } from '../../../API'
 import { NotificationService } from '../../../common/services/NotificationService'
 import waitForClientAuthenticated from '../../../util/wait-for-client-authenticated'
 
@@ -86,7 +86,7 @@ export const ClientSettingService = {
       logger.info('waitingForClientAuthenticated')
       await waitForClientAuthenticated()
       logger.info('CLIENT AUTHENTICATED!')
-      const clientSettings = (await API.instance.client
+      const clientSettings = (await Engine.instance.api
         .service(clientSettingPath)
         .find()) as Paginated<ClientSettingType>
       logger.info('Dispatching fetchedClient')
@@ -98,7 +98,7 @@ export const ClientSettingService = {
   },
   patchClientSetting: async (data: ClientSettingPatch, id: string) => {
     try {
-      await API.instance.client.service(clientSettingPath).patch(id, data)
+      await Engine.instance.api.service(clientSettingPath).patch(id, data)
       dispatchAction(ClientSettingActions.clientSettingPatched({}))
     } catch (err) {
       logger.error(err)

--- a/packages/client-core/src/admin/services/Setting/CoilSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/CoilSettingService.ts
@@ -26,10 +26,10 @@ Ethereal Engine. All Rights Reserved.
 import { Paginated } from '@feathersjs/feathers'
 
 import { matches, Validator } from '@etherealengine/engine/src/common/functions/MatchesUtils'
+import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { coilSettingPath, CoilSettingType } from '@etherealengine/engine/src/schemas/setting/coil-setting.schema'
 import { defineAction, defineState, dispatchAction, getMutableState } from '@etherealengine/hyperflux'
 
-import { API } from '../../../API'
 import { NotificationService } from '../../../common/services/NotificationService'
 
 export const AdminCoilSettingsState = defineState({
@@ -52,7 +52,7 @@ export const CoilSettingReceptors = {
 export const AdminCoilSettingService = {
   fetchCoil: async () => {
     try {
-      const coilSettings = (await API.instance.client.service(coilSettingPath).find()) as Paginated<CoilSettingType>
+      const coilSettings = (await Engine.instance.api.service(coilSettingPath).find()) as Paginated<CoilSettingType>
       dispatchAction(AdminCoilSettingActions.fetchedCoil({ coilSettings }))
     } catch (err) {
       NotificationService.dispatchNotify(err.message, { variant: 'error' })

--- a/packages/client-core/src/admin/services/Setting/EmailSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/EmailSettingService.ts
@@ -26,6 +26,7 @@ Ethereal Engine. All Rights Reserved.
 import { Paginated } from '@feathersjs/feathers'
 
 import { matches, Validator } from '@etherealengine/engine/src/common/functions/MatchesUtils'
+import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import {
   EmailSettingPatch,
   emailSettingPath,
@@ -33,7 +34,6 @@ import {
 } from '@etherealengine/engine/src/schemas/setting/email-setting.schema'
 import { defineAction, defineState, dispatchAction, getMutableState } from '@etherealengine/hyperflux'
 
-import { API } from '../../../API'
 import { NotificationService } from '../../../common/services/NotificationService'
 
 export const AdminEmailSettingsState = defineState({
@@ -62,7 +62,7 @@ export const EmailSettingReceptors = {
 export const EmailSettingService = {
   fetchedEmailSettings: async (inDec?: 'increment' | 'dcrement') => {
     try {
-      const emailSettings = (await API.instance.client.service(emailSettingPath).find()) as Paginated<EmailSettingType>
+      const emailSettings = (await Engine.instance.api.service(emailSettingPath).find()) as Paginated<EmailSettingType>
       dispatchAction(EmailSettingActions.fetchedEmail({ emailSettings }))
     } catch (err) {
       console.log(err.message)
@@ -71,7 +71,7 @@ export const EmailSettingService = {
   },
   patchEmailSetting: async (data: EmailSettingPatch, id: string) => {
     try {
-      await API.instance.client.service(emailSettingPath).patch(id, data)
+      await Engine.instance.api.service(emailSettingPath).patch(id, data)
       dispatchAction(EmailSettingActions.emailSettingPatched({}))
     } catch (err) {
       NotificationService.dispatchNotify(err.message, { variant: 'error' })

--- a/packages/client-core/src/admin/services/Setting/HelmSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/HelmSettingService.ts
@@ -1,0 +1,138 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and
+provide for limited attribution for the Original Developer. In addition,
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023
+Ethereal Engine. All Rights Reserved.
+*/
+
+import { Paginated } from '@feathersjs/feathers'
+
+import { matches, Validator } from '@etherealengine/engine/src/common/functions/MatchesUtils'
+import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
+import {
+  helmBuilderVersionPath,
+  helmMainVersionPath,
+  HelmSettingPatch,
+  helmSettingPath,
+  HelmSettingType
+} from '@etherealengine/engine/src/schemas/setting/helm-setting.schema'
+import { defineAction, defineState, dispatchAction, getMutableState } from '@etherealengine/hyperflux'
+
+import { NotificationService } from '../../../common/services/NotificationService'
+
+export const AdminHelmSettingsState = defineState({
+  name: 'AdminHelmSettingsState',
+  initial: () => ({
+    helmSettings: [] as Array<HelmSettingType>,
+    mainVersions: [] as Array<String>,
+    builderVersions: [] as Array<String>,
+    skip: 0,
+    limit: 100,
+    total: 0,
+    updateNeeded: true
+  })
+})
+
+const helmSettingRetrievedReceptor = (action: typeof AdminHelmSettingActions.helmSettingRetrieved.matches._TYPE) => {
+  const state = getMutableState(AdminHelmSettingsState)
+  return state.merge({ helmSettings: action.adminHelmSetting.data, updateNeeded: false })
+}
+const helmSettingPatchedReceptor = (action: typeof AdminHelmSettingActions.helmSettingPatched.matches._TYPE) => {
+  const state = getMutableState(AdminHelmSettingsState)
+  return state.merge({ updateNeeded: true })
+}
+const helmMainVersionsRetrievedReceptor = (
+  action: typeof AdminHelmSettingActions.helmMainVersionsRetrieved.matches._TYPE
+) => {
+  const state = getMutableState(AdminHelmSettingsState)
+  return state.merge({ mainVersions: action.adminHelmMainVersions, updateNeeded: false })
+}
+const helmBuilderVersionsRetrievedReceptor = (
+  action: typeof AdminHelmSettingActions.helmBuilderVersionsRetrieved.matches._TYPE
+) => {
+  const state = getMutableState(AdminHelmSettingsState)
+  return state.merge({ builderVersions: action.adminHelmBuilderVersions, updateNeeded: false })
+}
+
+export const HelmSettingReceptors = {
+  helmSettingRetrievedReceptor,
+  helmSettingPatchedReceptor,
+  helmMainVersionsRetrievedReceptor,
+  helmBuilderVersionsRetrievedReceptor
+}
+
+export const HelmSettingService = {
+  fetchHelmSetting: async () => {
+    try {
+      const helmSetting = (await Engine.instance.api.service(helmSettingPath).find()) as Paginated<HelmSettingType>
+      dispatchAction(AdminHelmSettingActions.helmSettingRetrieved({ adminHelmSetting: helmSetting }))
+    } catch (err) {
+      NotificationService.dispatchNotify(err.message, { variant: 'error' })
+    }
+  },
+  fetchMainHelmVersions: async () => {
+    try {
+      const helmMainVersions = await Engine.instance.api.service(helmMainVersionPath).find()
+      dispatchAction(AdminHelmSettingActions.helmMainVersionsRetrieved({ adminHelmMainVersions: helmMainVersions }))
+    } catch (err) {
+      NotificationService.dispatchNotify(err.message, { variant: 'error' })
+    }
+  },
+  fetchBuilderHelmVersions: async () => {
+    try {
+      const helmBuilderVersions = await Engine.instance.api.service(helmBuilderVersionPath).find()
+      dispatchAction(
+        AdminHelmSettingActions.helmBuilderVersionsRetrieved({ adminHelmBuilderVersions: helmBuilderVersions })
+      )
+    } catch (err) {
+      NotificationService.dispatchNotify(err.message, { variant: 'error' })
+    }
+  },
+  patchHelmSetting: async (data: { main: string; builder: string }, id: string) => {
+    try {
+      await Engine.instance.api.service(helmSettingPath).patch(id, data)
+      dispatchAction(AdminHelmSettingActions.helmSettingPatched({}))
+    } catch (err) {
+      NotificationService.dispatchNotify(err.message, { variant: 'error' })
+    }
+  }
+}
+
+export class AdminHelmSettingActions {
+  static helmSettingRetrieved = defineAction({
+    type: 'ee.client.AdminHelmSetting.ADMIN_HELM_SETTING_FETCHED' as const,
+    adminHelmSetting: matches.object as Validator<unknown, Paginated<HelmSettingType>>
+  })
+
+  static helmSettingPatched = defineAction({
+    type: 'ee.client.AdminHelmSetting.ADMIN_HELM_SETTING_PATCHED' as const
+  })
+
+  static helmMainVersionsRetrieved = defineAction({
+    type: 'ee.client.AdminHelmSetting.ADMIN_HELM_MAIN_VERSIONS_FETCHED' as const,
+    adminHelmMainVersions: matches.array as Validator<unknown, string[]>
+  })
+
+  static helmBuilderVersionsRetrieved = defineAction({
+    type: 'ee.client.AdminHelmSetting.ADMIN_HELM_BUILDER_VERSIONS_FETCHED' as const,
+    adminHelmBuilderVersions: matches.array as Validator<unknown, string[]>
+  })
+}

--- a/packages/client-core/src/admin/services/Setting/InstanceServerSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/InstanceServerSettingService.ts
@@ -26,13 +26,13 @@ Ethereal Engine. All Rights Reserved.
 import { Paginated } from '@feathersjs/feathers'
 
 import { matches, Validator } from '@etherealengine/engine/src/common/functions/MatchesUtils'
+import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import {
   instanceServerSettingPath,
   InstanceServerSettingType
 } from '@etherealengine/engine/src/schemas/setting/instance-server-setting.schema'
 import { defineAction, defineState, dispatchAction, getMutableState } from '@etherealengine/hyperflux'
 
-import { API } from '../../../API'
 import { NotificationService } from '../../../common/services/NotificationService'
 
 export const AdminInstanceServerSettingsState = defineState({
@@ -57,7 +57,7 @@ export const AdminInstanceServerReceptors = {
 export const InstanceServerSettingService = {
   fetchedInstanceServerSettings: async (inDec?: 'increment' | 'decrement') => {
     try {
-      const instanceServerSettings = (await API.instance.client
+      const instanceServerSettings = (await Engine.instance.api
         .service(instanceServerSettingPath)
         .find()) as Paginated<InstanceServerSettingType>
       dispatchAction(InstanceServerSettingActions.fetchedInstanceServer({ instanceServerSettings }))

--- a/packages/client-core/src/admin/services/Setting/ProjectSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/ProjectSettingService.ts
@@ -24,9 +24,8 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { matches, Validator } from '@etherealengine/engine/src/common/functions/MatchesUtils'
+import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { defineAction, defineState, dispatchAction, getMutableState } from '@etherealengine/hyperflux'
-
-import { API } from '../../../API'
 
 export const PROJECT_PAGE_LIMIT = 100
 
@@ -57,7 +56,7 @@ export const ProjectSettingReceptors = {
 
 export const ProjectSettingService = {
   fetchProjectSetting: async (projectId: string) => {
-    const projectSettings = await API.instance.client.service('project-setting').find({
+    const projectSettings = await Engine.instance.api.service('project-setting').find({
       query: {
         $limit: 1,
         id: projectId,
@@ -69,7 +68,7 @@ export const ProjectSettingService = {
 
   // restricted to admin scope
   updateProjectSetting: async (projectId: string, data: ProjectSettingValue[]) => {
-    await API.instance.client.service('project-setting').patch(projectId, { settings: JSON.stringify(data) })
+    await Engine.instance.api.service('project-setting').patch(projectId, { settings: JSON.stringify(data) })
     ProjectSettingService.fetchProjectSetting(projectId)
   }
 }

--- a/packages/client-core/src/admin/services/Setting/RedisSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/RedisSettingService.ts
@@ -26,10 +26,10 @@ Ethereal Engine. All Rights Reserved.
 import { Paginated } from '@feathersjs/feathers'
 
 import { matches, Validator } from '@etherealengine/engine/src/common/functions/MatchesUtils'
+import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { redisSettingPath, RedisSettingType } from '@etherealengine/engine/src/schemas/setting/redis-setting.schema'
 import { defineAction, defineState, dispatchAction, getMutableState } from '@etherealengine/hyperflux'
 
-import { API } from '../../../API'
 import { NotificationService } from '../../../common/services/NotificationService'
 
 export const AdminRedisSettingsState = defineState({
@@ -55,7 +55,7 @@ export const RedisSettingReceptors = {
 export const RedisSettingService = {
   fetchRedisSetting: async () => {
     try {
-      const redisSetting = (await API.instance.client.service(redisSettingPath).find()) as Paginated<RedisSettingType>
+      const redisSetting = (await Engine.instance.api.service(redisSettingPath).find()) as Paginated<RedisSettingType>
       dispatchAction(AdminRedisSettingActions.redisSettingRetrieved({ adminRedisSetting: redisSetting }))
     } catch (err) {
       NotificationService.dispatchNotify(err.message, { variant: 'error' })

--- a/packages/client-core/src/admin/services/Setting/ServerSettingService.ts
+++ b/packages/client-core/src/admin/services/Setting/ServerSettingService.ts
@@ -26,6 +26,7 @@ Ethereal Engine. All Rights Reserved.
 import { Paginated } from '@feathersjs/feathers'
 
 import { matches, Validator } from '@etherealengine/engine/src/common/functions/MatchesUtils'
+import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import {
   ServerSettingPatch,
   serverSettingPath,
@@ -33,7 +34,6 @@ import {
 } from '@etherealengine/engine/src/schemas/setting/server-setting.schema'
 import { defineAction, defineState, dispatchAction, getMutableState } from '@etherealengine/hyperflux'
 
-import { API } from '../../../API'
 import { NotificationService } from '../../../common/services/NotificationService'
 
 export const AdminServerSettingsState = defineState({
@@ -62,7 +62,7 @@ export const ServerSettingReceptors = {
 export const ServerSettingService = {
   fetchServerSettings: async (inDec?: 'increment' | 'decrement') => {
     try {
-      const serverSettings = (await API.instance.client
+      const serverSettings = (await Engine.instance.api
         .service(serverSettingPath)
         .find()) as Paginated<ServerSettingType>
       dispatchAction(AdminServerSettingActions.fetchedSeverInfo({ serverSettings }))
@@ -72,7 +72,7 @@ export const ServerSettingService = {
   },
   patchServerSetting: async (data: ServerSettingPatch, id: string) => {
     try {
-      await API.instance.client.service(serverSettingPath).patch(id, data)
+      await Engine.instance.api.service(serverSettingPath).patch(id, data)
       dispatchAction(AdminServerSettingActions.serverSettingPatched({}))
     } catch (err) {
       NotificationService.dispatchNotify(err.message, { variant: 'error' })

--- a/packages/client-core/src/admin/services/Setting/TaskServerSettingsService.ts
+++ b/packages/client-core/src/admin/services/Setting/TaskServerSettingsService.ts
@@ -26,13 +26,13 @@ Ethereal Engine. All Rights Reserved.
 import { Paginated } from '@feathersjs/feathers'
 
 import { matches, Validator } from '@etherealengine/engine/src/common/functions/MatchesUtils'
+import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import {
   taskServerSettingPath,
   TaskServerSettingType
 } from '@etherealengine/engine/src/schemas/setting/task-server-setting.schema'
 import { defineAction, defineState, dispatchAction, getMutableState } from '@etherealengine/hyperflux'
 
-import { API } from '../../../API'
 import { NotificationService } from '../../../common/services/NotificationService'
 
 export const AdminTaskServerSettingsState = defineState({
@@ -55,7 +55,7 @@ export const TaskServerSettingReceptors = {
 export const AdminSettingTaskServerService = {
   fetchSettingsTaskServer: async (inDec?: 'increment' | 'decrement') => {
     try {
-      const taskServerSettings = (await API.instance.client
+      const taskServerSettings = (await Engine.instance.api
         .service(taskServerSettingPath)
         .find()) as Paginated<TaskServerSettingType>
       dispatchAction(AdminTaskServerSettingActions.fetchedTaskServers({ taskServerSettings }))

--- a/packages/client-core/src/admin/styles/admin.module.scss
+++ b/packages/client-core/src/admin/styles/admin.module.scss
@@ -805,3 +805,16 @@
     }
   }
 }
+
+.helmSubheader {
+  color: var(--textColor);
+  text-align: center;
+  margin-bottom: 10px;
+  font-weight: 300;
+  font-size: 18px;
+  display: flex;
+
+  a {
+    margin-left: 2px;
+  }
+}

--- a/packages/client-core/src/systems/AdminSystem.tsx
+++ b/packages/client-core/src/systems/AdminSystem.tsx
@@ -64,6 +64,7 @@ import {
 // import { ClientSettingActions, ClientSettingReceptors } from '../admin/services/Setting/ClientSettingService'
 import { AdminCoilSettingActions, CoilSettingReceptors } from '../admin/services/Setting/CoilSettingService'
 import { EmailSettingActions, EmailSettingReceptors } from '../admin/services/Setting/EmailSettingService'
+import { AdminHelmSettingActions, HelmSettingReceptors } from '../admin/services/Setting/HelmSettingService'
 import {
   AdminInstanceServerReceptors,
   InstanceServerSettingActions
@@ -90,6 +91,10 @@ const awsSettingPatchedQueue = defineActionQueue(AdminAwsSettingActions.awsSetti
 const fetchedCoilQueue = defineActionQueue(AdminCoilSettingActions.fetchedCoil.matches)
 const fetchedEmailQueue = defineActionQueue(EmailSettingActions.fetchedEmail.matches)
 const emailSettingPatchedQueue = defineActionQueue(EmailSettingActions.emailSettingPatched.matches)
+const fetchedHelmQueue = defineActionQueue(AdminHelmSettingActions.helmSettingRetrieved.matches)
+const patchedHelmQueue = defineActionQueue(AdminHelmSettingActions.helmSettingPatched.matches)
+const fetchedHelmMainVersionsQueue = defineActionQueue(AdminHelmSettingActions.helmMainVersionsRetrieved.matches)
+const fetchedHelmBuilderVersionsQueue = defineActionQueue(AdminHelmSettingActions.helmBuilderVersionsRetrieved.matches)
 const patchInstanceserverQueue = defineActionQueue(AdminInstanceserverActions.patchInstanceserver.matches)
 const patchedInstanceserverQueue = defineActionQueue(AdminInstanceserverActions.patchedInstanceserver.matches)
 const projectSettingFetchedQueue = defineActionQueue(AdminProjectSettingsActions.projectSettingFetched.matches)
@@ -183,6 +188,11 @@ const execute = () => {
   for (const action of fetchedCoilQueue()) CoilSettingReceptors.fetchedCoilReceptor(action)
   for (const action of fetchedEmailQueue()) EmailSettingReceptors.fetchedEmailReceptor(action)
   for (const action of emailSettingPatchedQueue()) EmailSettingReceptors.emailSettingPatchedReceptor(action)
+  for (const action of fetchedHelmQueue()) HelmSettingReceptors.helmSettingRetrievedReceptor(action)
+  for (const action of patchedHelmQueue()) HelmSettingReceptors.helmSettingPatchedReceptor(action)
+  for (const action of fetchedHelmMainVersionsQueue()) HelmSettingReceptors.helmMainVersionsRetrievedReceptor(action)
+  for (const action of fetchedHelmBuilderVersionsQueue())
+    HelmSettingReceptors.helmBuilderVersionsRetrievedReceptor(action)
   for (const action of patchInstanceserverQueue()) InstanceServerSettingReceptors.patchInstanceserverReceptor(action)
   for (const action of patchedInstanceserverQueue())
     InstanceServerSettingReceptors.patchedInstanceserverReceptor(action)

--- a/packages/engine/src/schemas/setting/helm-setting.schema.ts
+++ b/packages/engine/src/schemas/setting/helm-setting.schema.ts
@@ -1,0 +1,74 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+// For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
+import { querySyntax, Type } from '@feathersjs/typebox'
+import type { Static } from '@feathersjs/typebox'
+
+export const helmSettingPath = 'helm-setting'
+export const helmMainVersionPath = 'helm-main-version'
+export const helmBuilderVersionPath = 'helm-builder-version'
+
+export const helmSettingMethods = ['find', 'get', 'create', 'patch', 'remove'] as const
+
+// Main data model schema
+export const helmSettingSchema = Type.Object(
+  {
+    id: Type.String({
+      format: 'uuid'
+    }),
+    main: Type.String(),
+    builder: Type.String(),
+    createdAt: Type.String({ format: 'date-time' }),
+    updatedAt: Type.String({ format: 'date-time' })
+  },
+  { $id: 'HelmSetting', additionalProperties: false }
+)
+export type HelmSettingType = Static<typeof helmSettingSchema>
+
+export type HelmSettingDatabaseType = HelmSettingType
+// Schema for creating new entries
+export const helmSettingDataSchema = Type.Pick(helmSettingSchema, ['main', 'builder'], {
+  $id: 'HelmSettingData'
+})
+export type HelmSettingData = Static<typeof helmSettingDataSchema>
+
+// Schema for updating existing entries
+export const helmSettingPatchSchema = Type.Partial(helmSettingSchema, {
+  $id: 'HelmSettingPatch'
+})
+export type HelmSettingPatch = Static<typeof helmSettingPatchSchema>
+
+// Schema for allowed query properties
+export const helmSettingQueryProperties = Type.Pick(helmSettingSchema, ['id'])
+export const helmSettingQuerySchema = Type.Intersect(
+  [
+    querySyntax(helmSettingQueryProperties),
+    // Add additional query properties here
+    Type.Object({}, { additionalProperties: false })
+  ],
+  { additionalProperties: false }
+)
+export type HelmSettingQuery = Static<typeof helmSettingQuerySchema>

--- a/packages/server-core/src/setting/aws-setting/migrations/20230616173320_eks-column.ts
+++ b/packages/server-core/src/setting/aws-setting/migrations/20230616173320_eks-column.ts
@@ -47,6 +47,7 @@ export async function up(knex: Knex): Promise<void> {
   const keysColumnExists = await knex.schema.hasColumn(awsSettingPath, 'keys')
   if (keysColumnExists) {
     const awsSettings = await knex.table(awsSettingPath).first()
+    if (!awsSettings) return
     let keys = JSON.parse(awsSettings.keys)
     if (typeof keys === 'string') keys = JSON.parse(keys)
     let s3 = JSON.parse(awsSettings.s3)

--- a/packages/server-core/src/setting/helm-setting/helm-setting.class.ts
+++ b/packages/server-core/src/setting/helm-setting/helm-setting.class.ts
@@ -23,30 +23,21 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import Authentication from './authentication-setting/authentication.service'
-import Aws from './aws-setting/aws-setting'
-import Chargebee from './chargebee-setting/chargebee-setting'
-import ClientSetting from './client-setting/client-setting'
-import Coil from './coil-setting/coil-setting'
-import Email from './email-setting/email-setting'
-import Helm from './helm-setting/helm-setting'
-import InstanceServer from './instance-server-setting/instance-server-setting'
-import ProjectSetting from './project-setting/project-setting.service'
-import RedisSetting from './redis-setting/redis-setting'
-import ServerSetting from './server-setting/server-setting'
-import TaskServer from './task-server-setting/task-server-setting'
+import type { Params } from '@feathersjs/feathers'
+import { KnexService } from '@feathersjs/knex'
+import type { KnexAdapterParams } from '@feathersjs/knex'
 
-export default [
-  ServerSetting,
-  ClientSetting,
-  InstanceServer,
-  Email,
-  Authentication,
-  Aws,
-  Chargebee,
-  Coil,
-  RedisSetting,
-  TaskServer,
-  ProjectSetting,
-  Helm
-]
+import {
+  HelmSettingData,
+  HelmSettingPatch,
+  HelmSettingQuery,
+  HelmSettingType
+} from '@etherealengine/engine/src/schemas/setting/helm-setting.schema'
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface HelmSettingParams extends KnexAdapterParams<HelmSettingQuery> {}
+
+export class HelmSettingService<
+  T = HelmSettingType,
+  ServiceParams extends Params = HelmSettingParams
+> extends KnexService<HelmSettingType, HelmSettingData, HelmSettingParams, HelmSettingPatch> {}

--- a/packages/server-core/src/setting/helm-setting/helm-setting.docs.ts
+++ b/packages/server-core/src/setting/helm-setting/helm-setting.docs.ts
@@ -23,30 +23,24 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import Authentication from './authentication-setting/authentication.service'
-import Aws from './aws-setting/aws-setting'
-import Chargebee from './chargebee-setting/chargebee-setting'
-import ClientSetting from './client-setting/client-setting'
-import Coil from './coil-setting/coil-setting'
-import Email from './email-setting/email-setting'
-import Helm from './helm-setting/helm-setting'
-import InstanceServer from './instance-server-setting/instance-server-setting'
-import ProjectSetting from './project-setting/project-setting.service'
-import RedisSetting from './redis-setting/redis-setting'
-import ServerSetting from './server-setting/server-setting'
-import TaskServer from './task-server-setting/task-server-setting'
+import { createSwaggerServiceOptions } from 'feathers-swagger'
 
-export default [
-  ServerSetting,
-  ClientSetting,
-  InstanceServer,
-  Email,
-  Authentication,
-  Aws,
-  Chargebee,
-  Coil,
-  RedisSetting,
-  TaskServer,
-  ProjectSetting,
-  Helm
-]
+import {
+  helmSettingDataSchema,
+  helmSettingPatchSchema,
+  helmSettingQuerySchema,
+  helmSettingSchema
+} from '@etherealengine/engine/src/schemas/setting/helm-setting.schema'
+
+export default createSwaggerServiceOptions({
+  schemas: {
+    helmSettingDataSchema,
+    helmSettingPatchSchema,
+    helmSettingQuerySchema,
+    helmSettingSchema
+  },
+  docs: {
+    description: 'Helm setting service description',
+    securities: ['all']
+  }
+})

--- a/packages/server-core/src/setting/helm-setting/helm-setting.hooks.ts
+++ b/packages/server-core/src/setting/helm-setting/helm-setting.hooks.ts
@@ -1,0 +1,101 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import { hooks as schemaHooks } from '@feathersjs/schema'
+import { getValidator } from '@feathersjs/typebox'
+import { iff, isProvider } from 'feathers-hooks-common'
+
+import {
+  helmSettingDataSchema,
+  helmSettingPatchSchema,
+  helmSettingQuerySchema,
+  helmSettingSchema
+} from '@etherealengine/engine/src/schemas/setting/helm-setting.schema'
+import { dataValidator, queryValidator } from '@etherealengine/server-core/validators'
+
+import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
+import {
+  helmSettingDataResolver,
+  helmSettingExternalResolver,
+  helmSettingPatchResolver,
+  helmSettingQueryResolver,
+  helmSettingResolver
+} from './helm-setting.resolvers'
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const helmSettingValidator = getValidator(helmSettingSchema, dataValidator)
+const helmSettingDataValidator = getValidator(helmSettingDataSchema, dataValidator)
+const helmSettingPatchValidator = getValidator(helmSettingPatchSchema, dataValidator)
+const helmSettingQueryValidator = getValidator(helmSettingQuerySchema, queryValidator)
+
+export default {
+  around: {
+    all: [schemaHooks.resolveExternal(helmSettingExternalResolver), schemaHooks.resolveResult(helmSettingResolver)]
+  },
+
+  before: {
+    all: [
+      authenticate(),
+      iff(isProvider('external'), verifyScope('admin', 'admin')),
+      () => schemaHooks.validateQuery(helmSettingQueryValidator),
+      schemaHooks.resolveQuery(helmSettingQueryResolver)
+    ],
+    find: [iff(isProvider('external'), verifyScope('settings', 'read'))],
+    get: [iff(isProvider('external'), verifyScope('settings', 'read'))],
+    create: [
+      iff(isProvider('external'), verifyScope('settings', 'write')),
+      () => schemaHooks.validateData(helmSettingDataValidator),
+      schemaHooks.resolveData(helmSettingDataResolver)
+    ],
+    update: [iff(isProvider('external'), verifyScope('settings', 'write'))],
+    patch: [
+      iff(isProvider('external'), verifyScope('settings', 'write')),
+      () => schemaHooks.validateData(helmSettingPatchValidator),
+      schemaHooks.resolveData(helmSettingPatchResolver)
+    ],
+    remove: [iff(isProvider('external'), verifyScope('settings', 'write'))]
+  },
+
+  after: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+
+  error: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  }
+} as any

--- a/packages/server-core/src/setting/helm-setting/helm-setting.resolvers.ts
+++ b/packages/server-core/src/setting/helm-setting/helm-setting.resolvers.ts
@@ -23,30 +23,33 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import Authentication from './authentication-setting/authentication.service'
-import Aws from './aws-setting/aws-setting'
-import Chargebee from './chargebee-setting/chargebee-setting'
-import ClientSetting from './client-setting/client-setting'
-import Coil from './coil-setting/coil-setting'
-import Email from './email-setting/email-setting'
-import Helm from './helm-setting/helm-setting'
-import InstanceServer from './instance-server-setting/instance-server-setting'
-import ProjectSetting from './project-setting/project-setting.service'
-import RedisSetting from './redis-setting/redis-setting'
-import ServerSetting from './server-setting/server-setting'
-import TaskServer from './task-server-setting/task-server-setting'
+// For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
+import { resolve } from '@feathersjs/schema'
+import { v4 } from 'uuid'
 
-export default [
-  ServerSetting,
-  ClientSetting,
-  InstanceServer,
-  Email,
-  Authentication,
-  Aws,
-  Chargebee,
-  Coil,
-  RedisSetting,
-  TaskServer,
-  ProjectSetting,
-  Helm
-]
+import {
+  HelmSettingDatabaseType,
+  HelmSettingQuery,
+  HelmSettingType
+} from '@etherealengine/engine/src/schemas/setting/helm-setting.schema'
+import type { HookContext } from '@etherealengine/server-core/declarations'
+
+import { getDateTimeSql } from '../../util/get-datetime-sql'
+
+export const helmSettingResolver = resolve<HelmSettingType, HookContext>({})
+
+export const helmSettingExternalResolver = resolve<HelmSettingType, HookContext>({})
+
+export const helmSettingDataResolver = resolve<HelmSettingType, HookContext>({
+  id: async () => {
+    return v4()
+  },
+  createdAt: getDateTimeSql,
+  updatedAt: getDateTimeSql
+})
+
+export const helmSettingPatchResolver = resolve<HelmSettingType, HookContext>({
+  updatedAt: getDateTimeSql
+})
+
+export const helmSettingQueryResolver = resolve<HelmSettingQuery, HookContext>({})

--- a/packages/server-core/src/setting/helm-setting/helm-setting.seed.ts
+++ b/packages/server-core/src/setting/helm-setting/helm-setting.seed.ts
@@ -1,0 +1,65 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import { Knex } from 'knex'
+import { v4 } from 'uuid'
+
+import {
+  HelmSettingDatabaseType,
+  helmSettingPath
+} from '@etherealengine/engine/src/schemas/setting/helm-setting.schema'
+import appConfig from '@etherealengine/server-core/src/appconfig'
+
+import { getDateTimeSql } from '../../util/get-datetime-sql'
+
+export async function seed(knex: Knex): Promise<void> {
+  const { testEnabled } = appConfig
+  const { forceRefresh } = appConfig.db
+
+  const seedData: HelmSettingDatabaseType[] = await Promise.all(
+    [
+      {
+        main: '',
+        builder: ''
+      }
+    ].map(async (item) => ({ ...item, id: v4(), createdAt: await getDateTimeSql(), updatedAt: await getDateTimeSql() }))
+  )
+
+  if (forceRefresh || testEnabled) {
+    // Deletes ALL existing entries
+    await knex(helmSettingPath).del()
+
+    // Inserts seed entries
+    await knex(helmSettingPath).insert(seedData)
+  } else {
+    const existingData = await knex(helmSettingPath).count({ count: '*' })
+
+    if (existingData.length === 0 || existingData[0].count === 0) {
+      for (const item of seedData) {
+        await knex(helmSettingPath).insert(item)
+      }
+    }
+  }
+}

--- a/packages/server-core/src/setting/helm-setting/helm-setting.ts
+++ b/packages/server-core/src/setting/helm-setting/helm-setting.ts
@@ -1,0 +1,110 @@
+import fetch from 'node-fetch'
+import semver from 'semver'
+
+import {
+  helmBuilderVersionPath,
+  helmMainVersionPath,
+  helmSettingMethods,
+  helmSettingPath
+} from '@etherealengine/engine/src/schemas/setting/helm-setting.schema'
+
+import { Application } from '../../../declarations'
+import { updateAppConfig } from '../../updateAppConfig'
+import { HelmSettingService } from './helm-setting.class'
+import helmSettingDocs from './helm-setting.docs'
+import hooks from './helm-setting.hooks'
+
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+export const MAIN_CHART_REGEX = /etherealengine-([0-9]+.[0-9]+.[0-9]+)/g
+export const BUILDER_CHART_REGEX = /etherealengine-builder-([0-9]+.[0-9]+.[0-9]+)/g
+
+declare module '@etherealengine/common/declarations' {
+  interface ServiceTypes {
+    [helmSettingPath]: HelmSettingService
+    [helmMainVersionPath]: { find: () => Promise<string[]> }
+    [helmBuilderVersionPath]: { find: () => Promise<string[]> }
+  }
+}
+
+export default (app: Application): void => {
+  const options = {
+    name: helmSettingPath,
+    paginate: app.get('paginate'),
+    Model: app.get('knexClient'),
+    multi: true
+  }
+
+  app.use(helmSettingPath, new HelmSettingService(options), {
+    // A list of all methods this service exposes externally
+    methods: helmSettingMethods,
+    // You can add additional custom events to be sent to clients here
+    events: [],
+    docs: helmSettingDocs
+  })
+
+  const service = app.service(helmSettingPath)
+  service.hooks(hooks)
+
+  service.on('patched', () => {
+    updateAppConfig()
+  })
+
+  app.use(helmMainVersionPath, {
+    find: async () => {
+      const versions: string[] = []
+      const response = await fetch('https://helm.etherealengine.org')
+      const chart = Buffer.from(await response.arrayBuffer()).toString()
+
+      let ended = false
+      while (!ended) {
+        const match = MAIN_CHART_REGEX.exec(chart)
+        if (match) {
+          //Need 5.1.3 or greater for API servers to have required cluster roles to run helm upgrade
+          if (versions.indexOf(match[1]) < 0 && semver.gte(match[1], '5.1.3')) versions.push(match[1])
+        } else ended = true
+      }
+      return versions
+    }
+  })
+
+  app.use(helmBuilderVersionPath, {
+    find: async () => {
+      const versions: string[] = []
+      const response = await fetch('https://helm.etherealengine.org')
+      const chart = Buffer.from(await response.arrayBuffer()).toString()
+
+      let ended = false
+      while (!ended) {
+        const match = BUILDER_CHART_REGEX.exec(chart)
+        if (match) {
+          if (versions.indexOf(match[1]) < 0) versions.push(match[1])
+        } else ended = true
+      }
+      return versions
+    }
+  })
+}

--- a/packages/server-core/src/setting/helm-setting/migrations/20230628170000_helm-setting.ts
+++ b/packages/server-core/src/setting/helm-setting/migrations/20230628170000_helm-setting.ts
@@ -23,30 +23,37 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import Authentication from './authentication-setting/authentication.service'
-import Aws from './aws-setting/aws-setting'
-import Chargebee from './chargebee-setting/chargebee-setting'
-import ClientSetting from './client-setting/client-setting'
-import Coil from './coil-setting/coil-setting'
-import Email from './email-setting/email-setting'
-import Helm from './helm-setting/helm-setting'
-import InstanceServer from './instance-server-setting/instance-server-setting'
-import ProjectSetting from './project-setting/project-setting.service'
-import RedisSetting from './redis-setting/redis-setting'
-import ServerSetting from './server-setting/server-setting'
-import TaskServer from './task-server-setting/task-server-setting'
+import type { Knex } from 'knex'
 
-export default [
-  ServerSetting,
-  ClientSetting,
-  InstanceServer,
-  Email,
-  Authentication,
-  Aws,
-  Chargebee,
-  Coil,
-  RedisSetting,
-  TaskServer,
-  ProjectSetting,
-  Helm
-]
+import { helmSettingPath } from '@etherealengine/engine/src/schemas/setting/helm-setting.schema'
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex: Knex): Promise<void> {
+  const tableExists = await knex.schema.hasTable(helmSettingPath)
+
+  if (tableExists === false) {
+    await knex.schema.createTable(helmSettingPath, (table) => {
+      //@ts-ignore
+      table.uuid('id').collate('utf8mb4_bin').primary()
+      table.string('main', 255).nullable()
+      table.string('builder', 255).nullable()
+      table.dateTime('createdAt').notNullable()
+      table.dateTime('updatedAt').notNullable()
+    })
+  }
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex: Knex): Promise<void> {
+  const tableExists = await knex.schema.hasTable(helmSettingPath)
+
+  if (tableExists === true) {
+    await knex.schema.dropTable(helmSettingPath)
+  }
+}

--- a/packages/server-core/src/setting/seeder-config.ts
+++ b/packages/server-core/src/setting/seeder-config.ts
@@ -32,6 +32,7 @@ import * as chargebeeSeed from './chargebee-setting/chargebee-setting.seed'
 import * as clientSeed from './client-setting/client-setting.seed'
 import * as coilSeed from './coil-setting/coil-setting.seed'
 import * as emailSeed from './email-setting/email-setting.seed'
+import * as helmSeed from './helm-setting/helm-setting.seed'
 import * as instanceServerSeed from './instance-server-setting/instance-server-setting.seed'
 import * as redisSeed from './redis-setting/redis-setting.seed'
 import * as serverSeed from './server-setting/server-setting.seed'
@@ -50,5 +51,6 @@ export const settingSeeds: Array<KnexSeed> = [
   coilSeed,
   emailSeed,
   redisSeed,
-  awsSeed
+  awsSeed,
+  helmSeed
 ]

--- a/packages/ui/src/primitives/mui/Icon/index.tsx
+++ b/packages/ui/src/primitives/mui/Icon/index.tsx
@@ -121,6 +121,7 @@ import {
   PersonAdd,
   PersonOff,
   Phone,
+  Poll,
   Portrait,
   QrCode2,
   RecordVoiceOver,
@@ -443,6 +444,8 @@ const Icon = ({ type, ...props }: SvgIconProps & { type: string }) => {
       return <Phone {...props} />
     case 'FlipCameraAndroid':
       return <FlipCameraAndroid {...props} />
+    case 'Poll':
+      return <Poll {...props} />
   }
 }
 

--- a/scripts/create-build-status.ts
+++ b/scripts/create-build-status.ts
@@ -23,36 +23,22 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { Type } from '@feathersjs/typebox'
-import type { Static } from '@feathersjs/typebox'
 import appRootPath from 'app-root-path'
 import cli from 'cli'
 /* eslint-disable @typescript-eslint/no-var-requires */
 import dotenv from 'dotenv-flow'
 import fs from 'fs'
 import knex from 'knex'
-import { v4 } from 'uuid'
+
+import {
+    BuildStatusType,
+    buildStatusPath
+} from '@etherealengine/engine/src/schemas/cluster/build-status.schema'
 
 dotenv.config({
   path: appRootPath.path,
   silent: true
 })
-
-export const buildStatusSchema = Type.Object(
-  {
-    id: Type.Integer(),
-    status: Type.String(),
-    dateStarted: Type.String(),
-    dateEnded: Type.String(),
-    logs: Type.String(),
-    commitSHA: Type.String(),
-    createdAt: Type.String({ format: 'date-time' }),
-    updatedAt: Type.String({ format: 'date-time' })
-  },
-  { $id: 'BuildStatus', additionalProperties: false }
-)
-export type BuildStatusType = Static<typeof buildStatusSchema>
-export const buildStatusPath = 'build-status'
 
 cli.enable('status')
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,6 +5,7 @@ TAG=$2
 
 #kubectl delete job $STAGE-etherealengine-testbot
 
+npx cross-env ts-node --swc scripts/fetch-helm-versions.ts --stage=${RELEASE_NAME}
 docker manifest inspect $ECR_URL/$REPO_NAME-api:$TAG >api-image.txt 2>&1
 if [ "$SERVE_CLIENT_FROM_API" != "true" ]
 then
@@ -12,6 +13,8 @@ then
 fi
 docker manifest inspect $ECR_URL/$REPO_NAME-instanceserver:$TAG > instanceserver-image.txt 2>&1
 docker manifest inspect $ECR_URL/$REPO_NAME-taskserver:$TAG > taskserver-image.txt 2>&1
+
+HELM_MAIN_VERSION=$(cat helm-main-version.txt)
 
 if [ ! -f "api-image.txt" ] || [ -z "$(grep -L "no such manifest" api-image.txt)" ]
 then
@@ -32,8 +35,8 @@ then
 else
   if [ "$SERVE_CLIENT_FROM_API" = "true" ]
   then
-    helm upgrade --reuse-values --set taskserver.image.repository=$ECR_URL/$REPO_NAME-taskserver,taskserver.image.tag=$TAG,api.image.repository=$ECR_URL/$REPO_NAME-api,api.image.tag=$TAG,instanceserver.image.repository=$ECR_URL/$REPO_NAME-instanceserver,instanceserver.image.tag=$TAG,testbot.image.repository=$ECR_URL/$REPO_NAME-testbot,testbot.image.tag=$TAG $STAGE etherealengine/etherealengine
+    helm upgrade --reuse-values --version $HELM_MAIN_VERSION --set taskserver.image.repository=$ECR_URL/$REPO_NAME-taskserver,taskserver.image.tag=$TAG,api.image.repository=$ECR_URL/$REPO_NAME-api,api.image.tag=$TAG,instanceserver.image.repository=$ECR_URL/$REPO_NAME-instanceserver,instanceserver.image.tag=$TAG,testbot.image.repository=$ECR_URL/$REPO_NAME-testbot,testbot.image.tag=$TAG $STAGE etherealengine/etherealengine
   else
-    helm upgrade --reuse-values --set taskserver.image.repository=$ECR_URL/$REPO_NAME-taskserver,taskserver.image.tag=$TAG,api.image.repository=$ECR_URL/$REPO_NAME-api,api.image.tag=$TAG,instanceserver.image.repository=$ECR_URL/$REPO_NAME-instanceserver,instanceserver.image.tag=$TAG,testbot.image.repository=$ECR_URL/$REPO_NAME-testbot,testbot.image.tag=$TAG,client.image.repository=$ECR_URL/$REPO_NAME-client,client.image.tag=$TAG $STAGE etherealengine/etherealengine
+    helm upgrade --reuse-values --version $HELM_MAIN_VERSION --set taskserver.image.repository=$ECR_URL/$REPO_NAME-taskserver,taskserver.image.tag=$TAG,api.image.repository=$ECR_URL/$REPO_NAME-api,api.image.tag=$TAG,instanceserver.image.repository=$ECR_URL/$REPO_NAME-instanceserver,instanceserver.image.tag=$TAG,testbot.image.repository=$ECR_URL/$REPO_NAME-testbot,testbot.image.tag=$TAG,client.image.repository=$ECR_URL/$REPO_NAME-client,client.image.tag=$TAG $STAGE etherealengine/etherealengine
   fi
 fi

--- a/scripts/deploy_builder.sh
+++ b/scripts/deploy_builder.sh
@@ -5,4 +5,9 @@ STAGE=$1
 TAG=$2
 EEVERSION=$(jq -r .version ./packages/server-core/package.json)
 
-helm upgrade --install --reuse-values --set builder.image.tag="${EEVERSION}_${TAG}" $STAGE-builder etherealengine/etherealengine-builder
+DEPLOYED=$(helm history dev-builder | grep deployed)
+REGEX='etherealengine-builder-([0-9]+.[0-9]+.[0-9]+)'
+[[ $DEPLOYED =~ $REGEX ]]
+VERSION=${BASH_REMATCH[1]}
+
+helm upgrade --install --reuse-values --version $VERSION --set builder.image.tag="${EEVERSION}_${TAG}" $STAGE-builder etherealengine/etherealengine-builder

--- a/scripts/fetch-helm-versions.ts
+++ b/scripts/fetch-helm-versions.ts
@@ -1,0 +1,106 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and
+provide for limited attribution for the Original Developer. In addition,
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023
+Ethereal Engine. All Rights Reserved.
+*/
+
+import appRootPath from 'app-root-path'
+import { exec } from 'child_process'
+import cli from 'cli'
+import dotenv from 'dotenv-flow'
+import fs from 'fs'
+import knex from 'knex'
+import path from 'path'
+import { promisify } from 'util'
+
+import {
+    helmSettingPath,
+    HelmSettingType
+} from '@etherealengine/engine/src/schemas/setting/helm-setting.schema'
+import {
+    MAIN_CHART_REGEX,
+    BUILDER_CHART_REGEX
+} from '@etherealengine/server-core/src/setting/helm-setting/helm-setting'
+
+dotenv.config({
+    path: appRootPath.path,
+    silent: true
+})
+
+const execAsync = promisify(exec)
+
+cli.enable('status')
+
+
+const options = cli.parse({
+    stage: [true, 'dev, prod, etc; deployment stage', 'string']
+})
+
+cli.main(async () => {
+    try {
+        const knexClient = knex({
+            client: 'mysql',
+            connection: {
+                user: process.env.MYSQL_USER ?? 'server',
+                password: process.env.MYSQL_PASSWORD ?? 'password',
+                host: process.env.MYSQL_HOST ?? '127.0.0.1',
+                port: parseInt(process.env.MYSQL_PORT || '3306'),
+                database: process.env.MYSQL_DATABASE ?? 'etherealengine',
+                charset: 'utf8mb4'
+            }
+        })
+
+        const [helmSettings] = await knexClient
+            .select()
+            .from<HelmSettingType>(helmSettingPath)
+
+        const helmMainVersionName = path.join(appRootPath.path, 'helm-main-version.txt')
+        const helmBuilderVersionName = path.join(appRootPath.path, 'helm-builder-version.txt')
+
+        if (helmSettings) {
+            if (helmSettings.main && helmSettings.main.length > 0)
+                fs.writeFileSync(helmMainVersionName, helmSettings.main)
+            else {
+                const { stdout } = await execAsync(`helm history ${options.stage} | grep deployed`)
+                const mainChartVersion = MAIN_CHART_REGEX.exec(stdout)
+                if (mainChartVersion) fs.writeFileSync(helmMainVersionName, mainChartVersion[1])
+            }
+            if (helmSettings.builder && helmSettings.builder.length > 0)
+                fs.writeFileSync(helmBuilderVersionName, helmSettings.builder)
+            else {
+                const { stdout } = await execAsync(`helm history ${options.stage}-builder | grep deployed`)
+                const builderChartVersion = BUILDER_CHART_REGEX.exec(stdout)
+                if (builderChartVersion) fs.writeFileSync(helmBuilderVersionName, builderChartVersion[1])
+            }
+        } else {
+            const { stdout } = await execAsync(`helm history ${options.stage} | grep deployed`)
+            const mainChartVersion = MAIN_CHART_REGEX.exec(stdout)
+            if (mainChartVersion) fs.writeFileSync(helmMainVersionName, mainChartVersion[1])
+            const builderChartVersion = BUILDER_CHART_REGEX.exec(stdout)
+            if (builderChartVersion) fs.writeFileSync(helmBuilderVersionName, builderChartVersion[1])
+        }
+        cli.exit(0)
+    } catch (err) {
+        console.log(err)
+        cli.fatal(err)
+    }
+})

--- a/scripts/push-client-to-s3.ts
+++ b/scripts/push-client-to-s3.ts
@@ -41,8 +41,6 @@ import { getFilesRecursive } from '@etherealengine/server-core/src/util/fsHelper
 
 cli.enable('status')
 
-const options = cli.parse({})
-
 cli.main(async () => {
   try {
     await createDefaultStorageProvider()
@@ -50,7 +48,7 @@ cli.main(async () => {
     const clientPath = path.resolve(appRootPath.path, `packages/client/dist`)
     const files = getFilesRecursive(clientPath)
     let filesToPruneResponse = await storageProvider.getObject('client/S3FilesToRemove.json')
-    const filesToPush = []
+    const filesToPush: string[] = []
     await Promise.all(
       files.map((file) => {
         return new Promise(async (resolve) => {
@@ -58,7 +56,7 @@ cli.main(async () => {
             const fileResult = fs.readFileSync(file)
             let filePathRelative = processFileName(file.slice(clientPath.length))
             let contentType = getContentType(file)
-            const putData = {
+            const putData: any = {
               Body: fileResult,
               ContentType: contentType,
               Key: `client${filePathRelative}`
@@ -71,7 +69,7 @@ cli.main(async () => {
             }
             await storageProvider.putObject(putData, { isDirectory: false })
             filesToPush.push(`client${filePathRelative}`)
-            resolve()
+            resolve(null)
           } catch (e) {
             logger.error(e)
             resolve(null)

--- a/scripts/record-build-error.ts
+++ b/scripts/record-build-error.ts
@@ -23,34 +23,21 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { Static, Type } from '@feathersjs/typebox'
 import appRootPath from 'app-root-path'
 import cli from 'cli'
 import dotenv from 'dotenv-flow'
 import fs from 'fs'
 import knex from 'knex'
 
+import {
+  BuildStatusType,
+  buildStatusPath
+} from '@etherealengine/engine/src/schemas/cluster/build-status.schema'
+
 dotenv.config({
   path: appRootPath.path,
   silent: true
 })
-
-export const buildStatusSchema = Type.Object(
-  {
-    id: Type.Integer(),
-    status: Type.String(),
-    dateStarted: Type.String(),
-    dateEnded: Type.String(),
-    logs: Type.String(),
-    commitSHA: Type.String(),
-    createdAt: Type.String({ format: 'date-time' }),
-    updatedAt: Type.String({ format: 'date-time' })
-  },
-  { $id: 'BuildStatus', additionalProperties: false }
-)
-
-export type BuildStatusType = Static<typeof buildStatusSchema>
-export const buildStatusPath = 'build-status'
 
 cli.enable('status')
 

--- a/scripts/record-build-success.ts
+++ b/scripts/record-build-success.ts
@@ -23,34 +23,21 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { Static, Type } from '@feathersjs/typebox'
 import appRootPath from 'app-root-path'
 import cli from 'cli'
 import dotenv from 'dotenv-flow'
 import fs from 'fs'
 import knex from 'knex'
 
+import {
+    BuildStatusType,
+    buildStatusPath
+} from '@etherealengine/engine/src/schemas/cluster/build-status.schema'
+
 dotenv.config({
   path: appRootPath.path,
   silent: true
 })
-
-export const buildStatusSchema = Type.Object(
-  {
-    id: Type.Integer(),
-    status: Type.String(),
-    dateStarted: Type.String(),
-    dateEnded: Type.String(),
-    logs: Type.String(),
-    commitSHA: Type.String(),
-    createdAt: Type.String({ format: 'date-time' }),
-    updatedAt: Type.String({ format: 'date-time' })
-  },
-  { $id: 'BuildStatus', additionalProperties: false }
-)
-
-export type BuildStatusType = Static<typeof buildStatusSchema>
-export const buildStatusPath = 'build-status'
 
 cli.enable('status')
 


### PR DESCRIPTION
## Summary

There is a new settings table, helm-setting. It stores the version of the main and builder Helm charts that should be used when running deployments. Build scripts have been updated to reflect this.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

