### PR TITLE
Fixed a bug in GitHub OAuth.

### DIFF
--- a/packages/common/src/dbmodels/IdentityProvider.ts
+++ b/packages/common/src/dbmodels/IdentityProvider.ts
@@ -39,4 +39,5 @@ export interface IdentityProviderInterface {
   resetExpires: string
   type: string
   userId: UserId
+  oauthToken?: string
 }

--- a/packages/server-core/src/user/strategies/github.ts
+++ b/packages/server-core/src/user/strategies/github.ts
@@ -77,7 +77,12 @@ export class GithubStrategy extends CustomOAuthStrategy {
       })) as UserInterface
       entity.userId = newUser.id
       await this.app.service('identity-provider').patch(entity.id, {
-        userId: newUser.id
+        userId: newUser.id,
+        oauthToken: params.access_token
+      })
+    } else {
+      await this.app.service('identity-provider').patch(entity.id, {
+        oauthToken: params.access_token
       })
     }
     const identityProvider = authResult['identity-provider']


### PR DESCRIPTION
## Summary

The GitHub OAuth flow updates the user's allowed repos using their OAuth token stored on the identity-provider. This occurs before the identity-provider has been updated, so if the user's token is outdated or invalid, API calls to GitHub will fail and make login impossible. Now updating the identity-provider with the new token before those calls are made.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

