### PR TITLE
Fixed a bug where in-use service images could be pruned by failing builds

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -55,8 +55,8 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: move package.json
         run: mv package.json package.jsonmoved
-      - name: npm-install 'cli' and @aws-sdk/client-ecr(-public)
-        run: npm install cli @aws-sdk/client-ecr @aws-sdk/client-ecr-public
+      - name: npm-install 'cli', @aws-sdk/client-ecr(-public), and @kubernetes/client-node
+        run: npm install cli @aws-sdk/client-ecr @aws-sdk/client-ecr-public @kubernetes/client-node
       - name: restore package.json
         run: mv package.jsonmoved package.json
       - name: Expose GitHub Runtime

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -54,8 +54,8 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: move package.json
         run: mv package.json package.jsonmoved
-      - name: npm-install 'cli' and @aws-sdk/client-ecr(-public)
-        run: npm install cli @aws-sdk/client-ecr @aws-sdk/client-ecr-public
+      - name: npm-install 'cli', @aws-sdk/client-ecr(-public), and @kubernetes/client-node
+        run: npm install cli @aws-sdk/client-ecr @aws-sdk/client-ecr-public @kubernetes/client-node
       - name: restore package.json
         run: mv package.jsonmoved package.json
       - name: Expose GitHub Runtime

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "dev-server": "cd packages/server && npm run dev",
     "dev-windows": "npm run dev-docker && concurrently -n agones,server,client npm:dev-agones-silent npm:dev-server npm:dev-client",
     "diff": "lerna diff",
-    "format": "prettier --write \"packages/**/*.{ts,tsx}\"",
+    "format": "prettier --write \"packages/**/*.{ts,tsx}\" \"scripts/*.ts\"",
     "format-scss": "stylelint \"packages/**/*.scss\" --fix",
     "format-staged": "lint-staged",
     "init-db-production": "cross-env APP_ENV=production FORCE_DB_REFRESH=true EXIT_ON_DB_INIT=true ts-node --swc packages/server/src/index.ts",

--- a/packages/server-core/src/cluster/server-logs/server-logs-helper.ts
+++ b/packages/server-core/src/cluster/server-logs/server-logs-helper.ts
@@ -38,7 +38,7 @@ export const getServerLogs = async (podName: string, containerName: string, app:
   try {
     logger.info('Attempting to check k8s server logs')
 
-    if (podName.startsWith(`${config.server.releaseName}-`) === false) {
+    if (!podName.startsWith(`${config.server.releaseName}-`)) {
       logger.error('You can only request server logs for current deployment.')
       new BadRequest('You can only request server logs for current deployment.')
     }

--- a/scripts/build_docker_builder.sh
+++ b/scripts/build_docker_builder.sh
@@ -15,11 +15,9 @@ if [ $PRIVATE_ECR == "true" ]
 then
   aws ecr get-login-password --region $REGION | docker login -u AWS --password-stdin $ECR_URL
   aws ecr describe-repositories --repository-names $REPO_NAME-builder --region $REGION || aws ecr create-repository --repository-name $REPO_NAME-builder --region $REGION
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-builder --region $REGION
 else
   aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin $ECR_URL
   aws ecr-public describe-repositories --repository-names $REPO_NAME-builder --region us-east-1 || aws ecr-public create-repository --repository-name $REPO_NAME-builder --region us-east-1
-  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-builder --region us-east-1 --public
 fi
 
 if [ $PUBLISH_DOCKERHUB == 'true' ]
@@ -42,6 +40,13 @@ else
     -t $ECR_URL/$REPO_NAME-builder:latest_$STAGE \
     -t $ECR_URL/$REPO_NAME-builder:"${EEVERSION}_${TAG}" \
     -f dockerfiles/builder/Dockerfile-builder .
+fi
+
+if [ $PRIVATE_ECR == "true" ]
+then
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-builder --region $REGION --service builder --releaseName $STAGE
+else
+  node ./scripts/prune_ecr_images.js --repoName $REPO_NAME-builder --region us-east-1 --service builder --releaseName $STAGE --public
 fi
 
 # cache links to use once ECR supports cache manifests

--- a/scripts/prune_ecr_images.js
+++ b/scripts/prune_ecr_images.js
@@ -24,37 +24,117 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-
 /* eslint-disable @typescript-eslint/no-var-requires */
-const cli = require('cli')
+
 const { ECRClient } = require('@aws-sdk/client-ecr')
 const { BatchDeleteImageCommand, DescribeImagesCommand, ECRPUBLICClient } = require('@aws-sdk/client-ecr-public')
+const k8s = require('@kubernetes/client-node')
+const cli = require('cli')
 
 cli.enable('status')
 
 const options = cli.parse({
   repoName: [false, 'Name of repository', 'string'],
+  service: [true, 'Name of service', 'string'],
   public: [false, 'Whether or not the ECR repo is public', 'boolean'],
-  region: [false, 'Name of AWS region', 'string']
+  region: [false, 'Name of AWS region', 'string'],
+  releaseName: [true, 'Name of release', 'string']
 })
 
 cli.main(async () => {
   try {
-    const ecr =
+    let matchingPods,
+      excludedImageDigests = [],
+      currentImages = []
+    if (options.service !== 'builder') {
+      const kc = new k8s.KubeConfig()
+      kc.loadFromDefault()
+      const k8DefaultClient = kc.makeApiClient(k8s.CoreV1Api)
+      if (options.service === 'instanceserver') {
+        matchingPods = await k8DefaultClient.listNamespacedPod(
+          'default',
+          'false',
+          false,
+          undefined,
+          undefined,
+          `agones.dev/role=gameserver`
+        )
+        const regex = new RegExp(`${options.releaseName}-instanceserver`)
+        matchingPods.body.items = matchingPods.body.items.filter((item) =>
+          item.annotations.find((annotation) => regex.test(annotation))
+        )
+
+        currentImages = matchingPods.body.items.map(
+          (item) =>
+            item.template.spec.containers.find(
+              (container) => container.name === `${options.releaseName}-instanceserver`
+            ).image
+        )
+      } else if (options.repoName !== 'root') {
+        matchingPods = await k8DefaultClient.listNamespacedPod(
+          'default',
+          'false',
+          false,
+          undefined,
+          undefined,
+          `app.kubernetes.io/instance=${options.releaseName},app.kubernetes.io/component=${options.service}`
+        )
+
+        currentImages = matchingPods.body.items.map(
+          (item) => item.spec.containers.find((container) => container.name === 'etherealengine').image.split(':')[1]
+        )
+      }
+      currentImages = [...new Set(currentImages)]
+    }
+    const ecr = (
       options.public === true
         ? new ECRPUBLICClient({ region: 'us-east-1' })
         : new ECRClient({ region: options.region || 'us-east-1' })
+    )
     const input = { repositoryName: options.repoName || 'etherealengine' }
     const command = new DescribeImagesCommand(input)
     const response = await ecr.send(command)
     const images = response.imageDetails
-    const withoutLatest = images.filter(
-      (image) =>
-        image.imageTags == null ||
-        (image.imageTags && image.imageTags.indexOf('latest_dev') < 0 && image.imageTags.indexOf('latest_prod') < 0)
+    if (!images) return
+    const latestImage = images.find(
+      (image) => image.imageTags && image.imageTags.indexOf(`latest_${options.releaseName}`) >= 0
     )
-    const sorted = withoutLatest.sort((a, b) => b.imagePushedAt - a.imagePushedAt)
-    const toBeDeleted = sorted.slice(10)
+    if (latestImage) {
+      const latestImageTime = latestImage.imagePushedAt.getTime()
+      // ECR automatically supports multi-architecture builds, which results in multiple images/image indexes. In order
+      // to not accidentally delete related images, we need to keep all of them for a given tag. Ran into problems
+      // trying to inspect the image (and pulling it would be time-consuming), so just checking for images that
+      // were made within 10 seconds of the tagged manifest.
+      excludedImageDigests.push(
+        ...images
+          .filter(
+            (image) =>
+              latestImageTime - image.imagePushedAt.getTime() <= 10000 &&
+              latestImageTime - image.imagePushedAt.getTime() >= 0
+          )
+          .map((image) => image.imageDigest)
+      )
+    }
+    const currentTaggedImages = images.filter(
+      (image) => image.imageTags && image.imageTags.some((item) => currentImages.includes(item))
+    )
+    if (currentTaggedImages) {
+      for (let currentTaggedImage of currentTaggedImages) {
+        const currentTaggedImageTime = currentTaggedImage.imagePushedAt.getTime()
+        excludedImageDigests.push(
+          ...images
+            .filter(
+              (image) =>
+                currentTaggedImageTime - image.imagePushedAt.getTime() <= 10000 &&
+                currentTaggedImageTime - image.imagePushedAt.getTime() >= 0
+            )
+            .map((image) => image.imageDigest)
+        )
+      }
+    }
+    const withoutLatestOrCurrent = images.filter((image) => excludedImageDigests.indexOf(image.imageDigest) < 0)
+    const sorted = withoutLatestOrCurrent.sort((a, b) => b.imagePushedAt.getTime() - a.imagePushedAt.getTime())
+    const toBeDeleted = sorted.slice(3)
     if (toBeDeleted.length > 0) {
       const deleteCommand = new BatchDeleteImageCommand({
         imageIds: toBeDeleted.map((image) => {
@@ -64,7 +144,7 @@ cli.main(async () => {
       })
       await ecr.send(deleteCommand)
       process.exit(0)
-    }
+    } else process.exit(0)
   } catch (err) {
     console.log('Error in deleting old ECR images:')
     console.log(err)


### PR DESCRIPTION
## Summary

If a service's build ran to completion but another one failed, the successful service would upload and prune images without deploying the new image. If the builder failed too many times in a row, this could lead to the image that that service was still using being pruned away.

Created a new prune_ecr_images.ts for build_and_publish_package.sh to use. This checks which images are in use by existing pods of that service and omits them from the list of prunable images.

Updated criteria for which images to save. Previously, it was just the most recent 10 images that weren't the latest. Due to the way ECR handles multi- architecture builds, this could remove some images that were tied to others, particularly with in-use images. Now, it finds all images that were uploaded within 10 seconds of a tagged image - these are going to be the related images, with the tagged one being the the image index file. Downloading and parsing the image index was likely going to be too time-intensive for the benefit.

Added TS scripts to 'format' npm command.

## References

closes #8199 


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

