### PR TITLE
improve(editor): debounce snapshot creation in `updateProperty`

### DIFF
--- a/packages/editor/src/components/properties/Util.ts
+++ b/packages/editor/src/components/properties/Util.ts
@@ -23,6 +23,8 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
+import { debounce } from 'lodash'
+
 import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { Entity } from '@etherealengine/engine/src/ecs/classes/Entity'
 import { SceneState } from '@etherealengine/engine/src/ecs/classes/Scene'
@@ -77,7 +79,7 @@ export const updateProperties = <C extends Component>(
 
   EditorControlFunctions.modifyProperty(affectedNodes, component, properties)
 
-  dispatchAction(EditorHistoryAction.createSnapshot({}))
+  debounce(() => dispatchAction(EditorHistoryAction.createSnapshot({})), 100)
 }
 
 export function traverseScene<T>(


### PR DESCRIPTION
## Summary

Added a debounce to snapshot creation when a property is updated in the editor.


## References

closes #8185 


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

