### PR TITLE
Fixed improper generation of Cloudfront route redirects

### DIFF
--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -341,15 +341,22 @@ export class S3Provider implements StorageProviderInterface {
     let routeRegex = ''
     for (let route of routes)
       if (route !== '/')
-        routeRegex +=
-          route === '/location' ||
-          route === '/auth' ||
-          route === '/admin' ||
-          route === '/editor' ||
-          route === '/studio' ||
-          route === '/capture'
-            ? `^${route}/|`
-            : `^${route}|`
+        switch (route) {
+          case '/admin':
+          case '/editor':
+          case '/studio':
+            routeRegex += `^${route}$$|` // String.replace will convert this to a single $
+            routeRegex += `^${route}/|`
+            break
+          case '/location':
+          case '/auth':
+          case '/capture':
+            routeRegex += `^${route}/|`
+            break
+          default:
+            routeRegex += `^${route}$$|` // String.replace will convert this to a single $
+            break
+        }
     if (routes.length > 0) routeRegex = routeRegex.slice(0, routeRegex.length - 1)
     let publicRegex = ''
     fs.readdirSync(path.join(appRootPath.path, 'packages', 'client', 'dist'), { withFileTypes: true }).forEach(


### PR DESCRIPTION
## Summary

/admin and /studio (also /editor) need to handle both e.g. /admin and /admin/<subroute>

Non-builtin route matches are now exact-only, with a `$` at the end, to prevent fuzzy matches that likely wouldn't point to anything.


## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

