### PR TITLE
Serialized uploading of scenes to storage provider

### DIFF
--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -167,30 +167,26 @@ export const uploadLocalProjectToProvider = async (
   // upload new files to storage provider
   const projectPath = path.resolve(projectsRootFolder, projectName)
   const files = getFilesRecursive(projectPath)
-  const results = await Promise.all(
-    files
-      .filter((file) => !file.includes(`projects/${projectName}/.git/`))
-      .map((file: string) => {
-        return new Promise(async (resolve) => {
-          try {
-            const fileResult = await uploadSceneToStaticResources(app, projectName, file, storageProviderName)
-            const filePathRelative = processFileName(file.slice(projectPath.length))
-            await storageProvider.putObject(
-              {
-                Body: fileResult,
-                ContentType: getContentType(file),
-                Key: `projects/${projectName}${filePathRelative}`
-              },
-              { isDirectory: false }
-            )
-            resolve(getCachedURL(`projects/${projectName}${filePathRelative}`, cacheDomain))
-          } catch (e) {
-            logger.error(e)
-            resolve(null)
-          }
-        })
-      })
-  )
+  const filtered = files.filter((file) => !file.includes(`projects/${projectName}/.git/`))
+  const results = [] as (string | null)[]
+  for (let file of filtered) {
+    try {
+      const fileResult = await uploadSceneToStaticResources(app, projectName, file, storageProviderName)
+      const filePathRelative = processFileName(file.slice(projectPath.length))
+      await storageProvider.putObject(
+        {
+          Body: fileResult,
+          ContentType: getContentType(file),
+          Key: `projects/${projectName}${filePathRelative}`
+        },
+        { isDirectory: false }
+      )
+      results.push(getCachedURL(`projects/${projectName}${filePathRelative}`, cacheDomain))
+    } catch (e) {
+      logger.error(e)
+      results.push(null)
+    }
+  }
   logger.info(`uploadLocalProjectToProvider for project "${projectName}" ended at "${new Date()}".`)
   return results.filter((success) => !!success) as string[]
 }


### PR DESCRIPTION
## Summary

Certain projects with multiple scenes that had very large files, like uvols, could crash the API server when installed fresh. Even though each scene's media files get uploaded sequentially, the scenes were being run in parallel, leading to simultaneous uploads of those large files. Made uploadLocalProjectToProvider process each file sequentially to avoid this.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

