### PR TITLE
fix(file-browser): paste with selected file/folder

### DIFF
--- a/packages/editor/src/components/assets/FileBrowserContentPanel.tsx
+++ b/packages/editor/src/components/assets/FileBrowserContentPanel.tsx
@@ -192,6 +192,8 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
               setOpenCompress={openCompress.set}
               setOpenConvert={openConvert.set}
               dropItemsOnPanel={dropItemsOnPanel}
+              isFilesLoading={isLoading}
+              refreshDirectory={onRefreshDirectory}
             />
           ))}
 
@@ -404,8 +406,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
     await onRefreshDirectory()
   }
 
-  const currentContent = null! as { item: FileDataType; isCopy: boolean }
-  const currentContentRef = useRef(currentContent)
+  const currentContentRef = useRef(null! as { item: FileDataType; isCopy: boolean })
 
   const headGrid = {
     display: 'flex',
@@ -505,7 +506,9 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
 
       <ContextMenu open={open} anchorEl={anchorEl.value} anchorPosition={anchorPosition.value} onClose={handleClose}>
         <MenuItem onClick={createNewFolder}>{t('editor:layout.filebrowser.addNewFolder')}</MenuItem>
-        <MenuItem onClick={pasteContent}>{t('editor:layout.filebrowser.pasteAsset')}</MenuItem>
+        <MenuItem disabled={!currentContentRef.current} onClick={pasteContent}>
+          {t('editor:layout.filebrowser.pasteAsset')}
+        </MenuItem>
       </ContextMenu>
 
       {openConvert.value && fileProperties.value && (

--- a/packages/editor/src/components/assets/FileBrowserGrid.tsx
+++ b/packages/editor/src/components/assets/FileBrowserGrid.tsx
@@ -28,10 +28,11 @@ import { useDrag, useDrop } from 'react-dnd'
 import { getEmptyImage } from 'react-dnd-html5-backend'
 import { useTranslation } from 'react-i18next'
 
+import { FileBrowserService } from '@etherealengine/client-core/src/common/services/FileBrowserService'
 import { KTX2EncodeArguments } from '@etherealengine/engine/src/assets/constants/CompressionParms'
 import { getComponent } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
 import { TransformComponent } from '@etherealengine/engine/src/transform/components/TransformComponent'
-import { State } from '@etherealengine/hyperflux'
+import { StateMethods } from '@etherealengine/hyperflux'
 
 import DescriptionIcon from '@mui/icons-material/Description'
 import FolderIcon from '@mui/icons-material/Folder'
@@ -106,10 +107,12 @@ type FileBrowserItemType = {
   setOpenPropertiesModal: any
   setOpenCompress: any
   setOpenConvert: any
+  isFilesLoading: StateMethods<boolean, {}>
   deleteContent: (contentPath: string, type: string) => void
   onClick: (params: FileDataType) => void
   dropItemsOnPanel: (data: any, dropOn?: FileDataType) => void
   moveContent: (oldName: string, newName: string, oldPath: string, newPath: string, isCopy?: boolean) => Promise<void>
+  refreshDirectory: () => Promise<void>
 }
 
 export function FileBrowserItem({
@@ -124,7 +127,9 @@ export function FileBrowserItem({
   deleteContent,
   onClick,
   dropItemsOnPanel,
-  moveContent
+  moveContent,
+  isFilesLoading,
+  refreshDirectory
 }: FileBrowserItemType) {
   const { t } = useTranslation()
   const [anchorPosition, setAnchorPosition] = React.useState<undefined | PopoverPosition>(undefined)
@@ -189,6 +194,23 @@ export function FileBrowserItem({
     currentContent.current = { item: item, isCopy: false }
 
     handleClose()
+  }
+
+  const pasteContent = async () => {
+    handleClose()
+
+    if (isFilesLoading.value) return
+    isFilesLoading.set(true)
+
+    await FileBrowserService.moveContent(
+      currentContent.current.item.fullName,
+      currentContent.current.item.fullName,
+      currentContent.current.item.path,
+      item.isFolder ? item.path + item.fullName : item.path,
+      currentContent.current.isCopy
+    )
+
+    await refreshDirectory()
   }
 
   const viewAssetProperties = () => {
@@ -284,6 +306,9 @@ export function FileBrowserItem({
           <MenuItem onClick={copyURL}>{t('editor:layout.assetGrid.copyURL')}</MenuItem>
           <MenuItem onClick={Cut}>{t('editor:layout.filebrowser.cutAsset')}</MenuItem>
           <MenuItem onClick={Copy}>{t('editor:layout.filebrowser.copyAsset')}</MenuItem>
+          <MenuItem disabled={!currentContent.current} onClick={pasteContent}>
+            {t('editor:layout.filebrowser.pasteAsset')}
+          </MenuItem>
           <MenuItem onClick={rename}>{t('editor:layout.filebrowser.renameAsset')}</MenuItem>
           <MenuItem onClick={deleteContentCallback}>{t('editor:layout.assetGrid.deleteAsset')}</MenuItem>
           <MenuItem onClick={viewAssetProperties}>{t('editor:layout.filebrowser.viewAssetProperties')}</MenuItem>


### PR DESCRIPTION
## Summary

- pasting will work with a file's context menu
- pasting will be disabled if there is no file to be copied/cut
- pasting on folder will move the content to that folder

## References

closes #8272 


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

