### PR TITLE
Added hackfix for react-is issues.

### DIFF
--- a/dockerfiles/api/Dockerfile-api-client
+++ b/dockerfiles/api/Dockerfile-api-client
@@ -38,6 +38,8 @@ COPY patches/ ./patches/
 
 ARG NODE_ENV
 RUN npm install --loglevel notice --legacy-peer-deps --production
+# Hackfix for issue with broken installation of react-is
+RUN npm install react-is
 
 # copy then compile the code
 COPY . .

--- a/dockerfiles/client/Dockerfile-client
+++ b/dockerfiles/client/Dockerfile-client
@@ -16,6 +16,8 @@ COPY patches/ ./patches/
 
 ARG NODE_ENV
 RUN npm install --loglevel notice --legacy-peer-deps --production
+# Hackfix for issue with broken installation of react-is
+RUN npm install react-is
 
 # copy then compile the code
 COPY . .

--- a/dockerfiles/client/Dockerfile-client-serve-static
+++ b/dockerfiles/client/Dockerfile-client-serve-static
@@ -16,6 +16,8 @@ COPY patches/ ./patches/
 
 ARG NODE_ENV
 RUN npm install --loglevel notice --legacy-peer-deps --production
+# Hackfix for issue with broken installation of react-is
+RUN npm install react-is
 
 # copy then compile the code
 COPY . .

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -329,7 +329,6 @@ export default defineConfig(async () => {
         warnOnError: true
       },
       rollupOptions: {
-        external: ['dotenv-flow'],
         output: {
           dir: 'dist',
           format: 'es', // 'commonjs' | 'esm' | 'module' | 'systemjs'


### PR DESCRIPTION
## Summary

Recent commits caused problems with build-client in production; styled-components could not import 'react-is' properly despite it being a dependency of several packages. It seems like an npm install issue, and the quick fix is to manually install react-is after running npm install in builder client builds.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

