### PR TITLE
Updated builder to be run as a job instead of a deployment.

### DIFF
--- a/packages/client-core/src/admin/components/Project/index.tsx
+++ b/packages/client-core/src/admin/components/Project/index.tsx
@@ -125,6 +125,15 @@ const Projects = () => {
             onClick={() => buildStatusDrawerOpen.set(true)}
           >
             {t('admin:components.project.buildStatus')}
+            <div
+              className={`${styles.containerCircle} ${
+                projectState.succeeded.value === true
+                  ? styles.containerGreen
+                  : projectState.failed.value === true
+                  ? styles.containerRed
+                  : styles.containerYellow
+              }`}
+            />
           </Button>
         </Grid>
       </Grid>

--- a/packages/client-core/src/admin/styles/admin.module.scss
+++ b/packages/client-core/src/admin/styles/admin.module.scss
@@ -16,6 +16,12 @@
     opacity: 0.8;
   }
 
+  & > .containerCircle {
+    margin-right: 0 !important;
+    margin-left: 5px;
+    margin-top: -2px;
+  }
+
   @media (max-width: 900px) {
     font-size: 0.7rem;
   }
@@ -659,6 +665,10 @@
 
 .containerRed {
   background-color: red;
+}
+
+.containerYellow {
+  background-color: yellow;
 }
 
 .projectMismatchWarning,

--- a/packages/common/src/interfaces/BuildStatus.ts
+++ b/packages/common/src/interfaces/BuildStatus.ts
@@ -1,0 +1,29 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+export interface BuildStatus {
+  succeeded: boolean
+  failed: boolean
+}

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -108,34 +108,14 @@ export const updateBuilder = async (
   const helmSettingsResult = await app.service(helmSettingPath).find()
   const helmSettings = helmSettingsResult.total > 0 ? helmSettingsResult.data[0] : null
   const builderDeploymentName = `${config.server.releaseName}-builder`
+  const k8sAppsClient = getState(ServerState).k8AppsClient
+  const k8BatchClient = getState(ServerState).k8BatchClient
 
-  if (helmSettings && helmSettings.builder && helmSettings.builder.length > 0)
-    await execAsync(
-      `helm upgrade --reuse-values --version ${helmSettings.builder} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
-    )
-  else {
-    const { stdout } = await execAsync(`helm history ${builderDeploymentName} | grep deployed`)
-    const builderChartVersion = BUILDER_CHART_REGEX.exec(stdout)
-    if (builderChartVersion)
-      await execAsync(
-        `helm upgrade --reuse-values --version ${builderChartVersion} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
-      )
-  }
-}
-
-export const checkBuilderService = async (app: Application): Promise<boolean> => {
-  let isRebuilding = true
-  const k8DefaultClient = getState(ServerState).k8DefaultClient
-
-  // check k8s to find the status of builder service
-  if (k8DefaultClient && config.server.releaseName !== 'local') {
+  if (k8BatchClient && config.server.releaseName !== 'local') {
     try {
-      logger.info('Attempting to check k8s rebuild status')
-
       const builderLabelSelector = `app.kubernetes.io/instance=${config.server.releaseName}-builder`
-      const containerName = 'etherealengine-builder'
 
-      const builderPods = await k8DefaultClient.listNamespacedPod(
+      const builderJob = await k8BatchClient.listNamespacedJob(
         'default',
         undefined,
         false,
@@ -143,41 +123,128 @@ export const checkBuilderService = async (app: Application): Promise<boolean> =>
         undefined,
         builderLabelSelector
       )
-      const runningBuilderPods = builderPods.body.items.filter((item) => item.status && item.status.phase === 'Running')
 
-      if (runningBuilderPods.length > 0) {
-        const podName = runningBuilderPods[0].metadata?.name
-
-        const builderLogs = await k8DefaultClient.readNamespacedPodLog(
-          podName!,
+      if (builderJob && builderJob.body.items.length > 0) {
+        const jobName = builderJob.body.items[0].metadata!.name
+        if (helmSettings && helmSettings.builder && helmSettings.builder.length > 0)
+          await execAsync(
+            `kubectl delete job --ignore-not-found=true ${jobName} && helm upgrade --reuse-values --version ${helmSettings.builder} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
+          )
+        else {
+          const { stdout } = await execAsync(`helm history ${builderDeploymentName} | grep deployed`)
+          const builderChartVersion = BUILDER_CHART_REGEX.exec(stdout)
+          if (builderChartVersion)
+            await execAsync(
+              `kubectl delete job --ignore-not-found=true ${jobName} && helm upgrade --reuse-values --version ${builderChartVersion} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
+            )
+        }
+      } else {
+        const builderDeployments = await k8sAppsClient.listNamespacedDeployment(
           'default',
-          containerName,
           undefined,
           false,
           undefined,
           undefined,
+          builderLabelSelector
+        )
+        const deploymentName = builderDeployments.body.items[0].metadata!.name
+        if (helmSettings && helmSettings.builder && helmSettings.builder.length > 0)
+          await execAsync(
+            `kubectl delete deployment --ignore-not-found=true ${deploymentName} && helm upgrade --reuse-values --version ${helmSettings.builder} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
+          )
+        else {
+          const { stdout } = await execAsync(`helm history ${builderDeploymentName} | grep deployed`)
+          const builderChartVersion = BUILDER_CHART_REGEX.exec(stdout)
+          if (builderChartVersion)
+            await execAsync(
+              `kubectl delete deployment --ignore-not-found=true ${deploymentName} && helm upgrade --reuse-values --version ${builderChartVersion} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
+            )
+        }
+      }
+    } catch (err) {
+      logger.error(err)
+      throw err
+    }
+  }
+}
+
+export const checkBuilderService = async (app: Application): Promise<{ failed: boolean; succeeded: boolean }> => {
+  let jobStatus = {
+    failed: false,
+    succeeded: false
+  }
+  const k8DefaultClient = getState(ServerState).k8DefaultClient
+  const k8BatchClient = getState(ServerState).k8BatchClient
+
+  // check k8s to find the status of builder service
+  if (k8DefaultClient && k8BatchClient && config.server.releaseName !== 'local') {
+    try {
+      logger.info('Attempting to check k8s build status')
+
+      const builderLabelSelector = `app.kubernetes.io/instance=${config.server.releaseName}-builder`
+
+      const builderJob = await k8BatchClient.listNamespacedJob(
+        'default',
+        undefined,
+        false,
+        undefined,
+        undefined,
+        builderLabelSelector
+      )
+
+      if (builderJob && builderJob.body.items.length > 0) {
+        const succeeded = builderJob.body.items.filter((item) => item.status && item.status.succeeded === 1)
+        const failed = builderJob.body.items.filter((item) => item.status && item.status.failed === 1)
+        jobStatus.succeeded = succeeded.length > 0
+        jobStatus.failed = failed.length > 0
+
+        return jobStatus
+      } else {
+        const containerName = 'etherealengine-builder'
+
+        const builderPods = await k8DefaultClient.listNamespacedPod(
+          'default',
+          undefined,
+          false,
           undefined,
           undefined,
-          undefined,
-          undefined,
-          undefined
+          builderLabelSelector
         )
 
-        const isCompleted = builderLogs.body.includes('sleep infinity')
-        if (isCompleted) {
-          logger.info(podName, 'podName')
-          isRebuilding = false
+        const runningBuilderPods = builderPods.body.items.filter(
+          (item) => item.status && item.status.phase === 'Running'
+        )
+
+        if (runningBuilderPods.length > 0) {
+          const podName = runningBuilderPods[0].metadata?.name
+
+          const builderLogs = await k8DefaultClient.readNamespacedPodLog(
+            podName!,
+            'default',
+            containerName,
+            undefined,
+            false,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined
+          )
+
+          jobStatus.succeeded = builderLogs.body.includes('sleep infinity')
+
+          return jobStatus
         }
       }
     } catch (e) {
       logger.error(e)
       return e
     }
-  } else {
-    isRebuilding = false
   }
 
-  return isRebuilding
+  return jobStatus
 }
 
 const projectsRootFolder = path.join(appRootPath.path, 'packages/projects/projects/')

--- a/scripts/deploy_builder.sh
+++ b/scripts/deploy_builder.sh
@@ -10,4 +10,4 @@ REGEX='etherealengine-builder-([0-9]+.[0-9]+.[0-9]+)'
 [[ $DEPLOYED =~ $REGEX ]]
 VERSION=${BASH_REMATCH[1]}
 
-helm upgrade --install --reuse-values --version $VERSION --set builder.image.tag="${EEVERSION}_${TAG}" $STAGE-builder etherealengine/etherealengine-builder
+kubectl delete job --ignore-not-found=true "${STAGE}-builder-etherealengine-builder" && helm upgrade --install --reuse-values --version $VERSION --set builder.image.tag="${EEVERSION}_${TAG}" $STAGE-builder etherealengine/etherealengine-builder


### PR DESCRIPTION
## Summary

This allows the builder to stop if it fails too
many times in a row. It also allows the builder to be scaled better.

Modified the builder status so that what's returned is a succeeded or failed status, not just whether it is running or not. Added a visual indicator to /admin/projects of the builder's status (green dot for success, yellow for running, red for failed).


## References

closes #7780


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

