### PR TITLE
Three - Use colorSpace instead of encoding

### DIFF
--- a/packages/engine/src/assets/functions/createReadableTexture.ts
+++ b/packages/engine/src/assets/functions/createReadableTexture.ts
@@ -205,6 +205,6 @@ export default async function createReadableTexture(
   }
   finalTexture.wrapS = map.wrapS
   finalTexture.wrapT = map.wrapT
-  finalTexture.encoding = map.encoding
+  finalTexture.colorSpace = map.colorSpace
   return finalTexture
 }


### PR DESCRIPTION
As detailed here: https://github.com/mrdoob/three.js/wiki/Migration-Guide#151--152