### PR TITLE
Fixed a race condition in ProjectDrawer.

### DIFF
--- a/packages/client-core/src/admin/components/Project/ProjectDrawer.tsx
+++ b/packages/client-core/src/admin/components/Project/ProjectDrawer.tsx
@@ -105,10 +105,10 @@ const ProjectDrawer = ({ open, inputProject, existingProject = false, onClose, c
   }
 
   useEffect(() => {
-    if (open && inputProject) {
+    if (open && inputProject && projectUpdateStatus?.triggerSetDestination?.length === 0) {
       ProjectUpdateService.setTriggerSetDestination(project, inputProject.repositoryPath)
     }
-  }, [open])
+  }, [open, projectUpdateStatus?.triggerSetDestination])
 
   return (
     <DrawerView open={open} onClose={handleClose}>


### PR DESCRIPTION
## Summary

The useEffect on `open`, which would set the project destination field to kick off auto-population, was triggering before the call to initializeProjectFields in ProjectFields.tsx's initial render useEffect. This was resulting in the destination field getting reset to an empty string, and no auto-population was occurring.

Now the `open` useEffect also listens to projectUpdateState.triggerSetDestination, so that it will fire after the initialization occurs, and will only fire if the current value is an empty string.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

