### PR TITLE
Set MediaComponent on Volumetric entity if it doesn't exist

### DIFF
--- a/packages/engine/src/scene/components/VolumetricComponent.ts
+++ b/packages/engine/src/scene/components/VolumetricComponent.ts
@@ -23,7 +23,8 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { defineComponent } from '../../ecs/functions/ComponentFunctions'
+import { defineComponent, hasComponent, setComponent } from '../../ecs/functions/ComponentFunctions'
+import { MediaComponent } from './MediaComponent'
 
 export const VolumetricComponent = defineComponent({
   name: 'EE_volumetric',
@@ -44,6 +45,9 @@ export const VolumetricComponent = defineComponent({
   onSet: (entity, component, json) => {
     if (typeof json?.useLoadingEffect === 'boolean' && json.useLoadingEffect !== component.useLoadingEffect.value)
       component.useLoadingEffect.set(json.useLoadingEffect)
+    if (!hasComponent(entity, MediaComponent)) {
+      setComponent(entity, MediaComponent)
+    }
   }
 })
 

--- a/packages/engine/src/scene/components/VolumetricComponent.ts
+++ b/packages/engine/src/scene/components/VolumetricComponent.ts
@@ -23,7 +23,7 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { defineComponent, hasComponent, setComponent } from '../../ecs/functions/ComponentFunctions'
+import { defineComponent, setComponent } from '../../ecs/functions/ComponentFunctions'
 import { MediaComponent } from './MediaComponent'
 
 export const VolumetricComponent = defineComponent({
@@ -45,9 +45,7 @@ export const VolumetricComponent = defineComponent({
   onSet: (entity, component, json) => {
     if (typeof json?.useLoadingEffect === 'boolean' && json.useLoadingEffect !== component.useLoadingEffect.value)
       component.useLoadingEffect.set(json.useLoadingEffect)
-    if (!hasComponent(entity, MediaComponent)) {
-      setComponent(entity, MediaComponent)
-    }
+    setComponent(entity, MediaComponent)
   }
 })
 


### PR DESCRIPTION
## Summary

Fixes a small bug when `MediaComponent` doesn't exist on the entity.


## References

closes #8373


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

![image](https://github.com/EtherealEngine/etherealengine/assets/52322531/09cfcf68-da47-42c8-90e9-570d5ed81685)
