### PR TITLE
Updated location setting seed and migration to use transaction in order to avoid running on different pool

### DIFF
--- a/packages/server-core/src/social/location-setting/migrations/20230620123610_location-setting.ts
+++ b/packages/server-core/src/social/location-setting/migrations/20230620123610_location-setting.ts
@@ -44,35 +44,37 @@ export async function up(knex: Knex): Promise<void> {
   const tableExists = await knex.schema.hasTable(locationSettingPath)
 
   if (tableExists === false) {
-    try {
-      await knex.raw('SET FOREIGN_KEY_CHECKS=0')
+    // Added transaction here in order to ensure both below queries run on same pool.
+    // https://github.com/knex/knex/issues/218#issuecomment-56686210
+    const trx = await knex.transaction()
+    await trx.raw('SET FOREIGN_KEY_CHECKS=0')
 
-      await knex.schema.createTable(locationSettingPath, (table) => {
-        //@ts-ignore
-        table.uuid('id').collate('utf8mb4_bin').primary()
+    await trx.schema.createTable(locationSettingPath, (table) => {
+      //@ts-ignore
+      table.uuid('id').collate('utf8mb4_bin').primary()
 
-        table.boolean('videoEnabled').defaultTo(false)
-        table.boolean('audioEnabled').defaultTo(false)
-        table.boolean('screenSharingEnabled').defaultTo(false)
-        table.boolean('faceStreamingEnabled').defaultTo(false)
+      table.boolean('videoEnabled').defaultTo(false)
+      table.boolean('audioEnabled').defaultTo(false)
+      table.boolean('screenSharingEnabled').defaultTo(false)
+      table.boolean('faceStreamingEnabled').defaultTo(false)
 
-        //@ts-ignore
-        table.uuid('locationId').collate('utf8mb4_bin').nullable().index()
-        table.string('locationType', 255).nullable().index()
-        table.dateTime('createdAt').notNullable()
-        table.dateTime('updatedAt').notNullable()
+      //@ts-ignore
+      table.uuid('locationId').collate('utf8mb4_bin').nullable().index()
+      table.string('locationType', 255).nullable().index()
+      table.dateTime('createdAt').notNullable()
+      table.dateTime('updatedAt').notNullable()
 
-        table.foreign('locationId').references('id').inTable(locationPath).onDelete('CASCADE').onUpdate('CASCADE')
-        table
-          .foreign('locationType')
-          .references('type')
-          .inTable(locationTypePath)
-          .onDelete('SET NULL')
-          .onUpdate('CASCADE')
-      })
-    } finally {
-      await knex.raw('SET FOREIGN_KEY_CHECKS=1')
-    }
+      table.foreign('locationId').references('id').inTable(locationPath).onDelete('CASCADE').onUpdate('CASCADE')
+      table
+        .foreign('locationType')
+        .references('type')
+        .inTable(locationTypePath)
+        .onDelete('SET NULL')
+        .onUpdate('CASCADE')
+    })
+    await trx.raw('SET FOREIGN_KEY_CHECKS=1')
+
+    await trx.commit()
   }
 }
 

--- a/packages/server-core/src/social/location-setting/migrations/20230620123610_location-setting.ts
+++ b/packages/server-core/src/social/location-setting/migrations/20230620123610_location-setting.ts
@@ -86,6 +86,12 @@ export async function down(knex: Knex): Promise<void> {
   const tableExists = await knex.schema.hasTable(locationSettingPath)
 
   if (tableExists === true) {
-    await knex.schema.dropTable(locationSettingPath)
+    const trx = await knex.transaction()
+
+    await trx.raw('SET FOREIGN_KEY_CHECKS=0')
+    await trx.schema.dropTable(locationSettingPath)
+    await trx.raw('SET FOREIGN_KEY_CHECKS=1')
+
+    await trx.commit()
   }
 }


### PR DESCRIPTION
## Summary

Currently we get foreign key issue when running location-setting migration/seed on a fresh database. This is despite having foreign key constraints being turned off. It appears knex uses multiple pools to run queries. Without transaction the foreign key constraints would be running on one pool while our insert/update queries would have been running on separate pool.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

