### PR TITLE
Add More Compression Options to Model Transform

### DIFF
--- a/packages/editor/src/components/properties/GLTFTransformProperties.tsx
+++ b/packages/editor/src/components/properties/GLTFTransformProperties.tsx
@@ -243,6 +243,42 @@ export default function GLTFTransformProperties({
               mediumStep={1}
               largeStep={2}
             />
+            {transformParms.textureCompressionType.value === 'uastc' && (
+              <>
+                <InputGroup name="UASTC Level" label={t('editor:properties.model.transform.uastcLevel')}>
+                  <NumericInput
+                    value={transformParms.uastcLevel.value}
+                    onChange={onChangeTransformParm(transformParms.uastcLevel)}
+                    max={4}
+                    min={0}
+                    smallStep={1}
+                    mediumStep={1}
+                    largeStep={1}
+                  />
+                </InputGroup>
+              </>
+            )}
+            {transformParms.textureCompressionType.value === 'etc1' && (
+              <>
+                <NumericInputGroup
+                  name="Compression Level"
+                  label={t('editor:properties.model.transform.etc1Level')}
+                  value={transformParms.compLevel.value}
+                  onChange={onChangeTransformParm(transformParms.compLevel)}
+                  min={1}
+                  max={5}
+                  smallStep={1}
+                  mediumStep={1}
+                  largeStep={1}
+                />
+                <InputGroup name="Max Codebooks" label={t('editor:properties.model.transform.maxCodebooks')}>
+                  <BooleanInput
+                    value={transformParms.maxCodebooks.value}
+                    onChange={onChangeTransformParm(transformParms.maxCodebooks)}
+                  />
+                </InputGroup>
+              </>
+            )}
           </>
         )}
         <CollapsibleBlock label={t('editor:properties.model.transform.resourceOverrides')}>

--- a/packages/engine/src/assets/classes/ModelTransform.ts
+++ b/packages/engine/src/assets/classes/ModelTransform.ts
@@ -84,6 +84,9 @@ export type ExtractedImageTransformParameters = {
   textureFormat: 'default' | 'jpg' | 'ktx2' | 'png' | 'webp'
   textureCompressionType: 'etc1' | 'uastc'
   textureCompressionQuality: number
+  uastcLevel: number
+  compLevel: number
+  maxCodebooks: boolean
 }
 
 export type GeometryTransformParameters = ResourceParameters<{
@@ -171,6 +174,9 @@ export const DefaultModelTransformParameters: ModelTransformParameters = {
   },
   textureFormat: 'ktx2',
   textureCompressionType: 'etc1',
+  uastcLevel: 4,
+  compLevel: 4,
+  maxCodebooks: true,
   flipY: false,
   linear: true,
   textureCompressionQuality: 128,

--- a/packages/server-core/src/assets/model-transform/model-transform.helpers.ts
+++ b/packages/server-core/src/assets/model-transform/model-transform.helpers.ts
@@ -505,7 +505,7 @@ export async function transformModel(app: Application, args: ModelTransformArgum
         const img = await sharp(oldPath)
         const metadata = await img.metadata()
         let resizedDimension = 2
-        while (resizedDimension * 2 < Math.min(mergedParms.maxTextureSize, Math.min(metadata.width, metadata.height))) {
+        while (resizedDimension * 2 < Math.min(mergedParms.maxTextureSize, Math.max(metadata.width, metadata.height))) {
           resizedDimension *= 2
         }
         //resize the image to be no larger than the max texture size
@@ -526,6 +526,12 @@ export async function transformModel(app: Application, args: ModelTransformArgum
         document.createExtension(KHRTextureBasisu).setRequired(true)
         const basisArgs = `-ktx2 ${resizedPath} -q ${mergedParms.textureCompressionQuality} ${
           mergedParms.textureCompressionType === 'uastc' ? '-uastc' : ''
+        } ${mergedParms.textureCompressionType === 'uastc' ? '-uastc_level ' + mergedParms.uastcLevel : ''} ${
+          mergedParms.textureCompressionType === 'etc1' ? '-comp_level ' + mergedParms.compLevel : ''
+        } ${
+          mergedParms.textureCompressionType === 'etc1' && mergedParms.maxCodebooks
+            ? '-max_endpoints 16128 -max_selectors 16128'
+            : ''
         } ${mergedParms.linear ? '-linear' : ''} ${mergedParms.flipY ? '-y_flip' : ''}`
           .split(/\s+/)
           .filter((x) => !!x)


### PR DESCRIPTION
Add "compression level", and "max codebooks" option for etc1 and "UASTC level" for uastc ktx2 compression. 