### PR TITLE
Updated instance-authorized-user migration.

### DIFF
--- a/packages/server-core/src/networking/instance-authorized-user/migrations/20230731111938_instance-authorized-user.ts
+++ b/packages/server-core/src/networking/instance-authorized-user/migrations/20230731111938_instance-authorized-user.ts
@@ -35,10 +35,12 @@ export async function up(knex: Knex): Promise<void> {
   const oldTableName = 'instance_authorized_user'
 
   const oldNamedTableExists = await knex.schema.hasTable(oldTableName)
+  const tableExists = await knex.schema.hasTable(instanceAuthorizedUserPath)
   if (oldNamedTableExists) {
+    // In case sequelize creates the new table before we migrate the old table
+    if (tableExists) await knex.schema.dropTable(instanceAuthorizedUserPath)
     await knex.schema.renameTable(oldTableName, instanceAuthorizedUserPath)
   }
-  const tableExists = await knex.schema.hasTable(instanceAuthorizedUserPath)
 
   if (tableExists === false) {
     await knex.schema.createTable(instanceAuthorizedUserPath, (table) => {

--- a/packages/server-core/src/sequelize.ts
+++ b/packages/server-core/src/sequelize.ts
@@ -81,6 +81,7 @@ export default (app: Application): void => {
           `select table_schema as etherealengine,count(*) as tables from information_schema.tables where table_type = \'BASE TABLE\' and table_schema not in (\'information_schema\', \'sys\', \'performance_schema\', \'mysql\') group by table_schema order by table_schema;`
         )
         const prepareDb = process.env.PREPARE_DATABASE === 'true' || (isDev && tableCount[0] && !tableCount[0][0])
+
         // Sync to the database
         for (const model of Object.keys(sequelize.models)) {
           const sequelizeModel = sequelize.models[model]


### PR DESCRIPTION
## Summary

In the current state where not everything has been converted off of sequelize, some sequelize BelongsToMany (join table) associations are bugging because they are being made under new names without all of the required fields before the knex migration can create it properly.

Specifically, instance_authorized_user was renamed to instance-authorized-user. The sequelize BelongsToMany relationship between user and instance is making a new instance-authorized-user table just based on that relationship, which doesn't know about the 'id' field. Then the knex migration tries to run, and fails because the instance-authorized-user table already exists. The deployment then has bugs because the table schema isn't correct.

The solution was to make the migration delete the new table if it exists if it detects that the old table still exists. This probably needs to be done for other join table/BelongsToMany conversions.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

