### PR TITLE
Added helm repo update to updateBuilder.

### DIFF
--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -128,14 +128,14 @@ export const updateBuilder = async (
         const jobName = builderJob.body.items[0].metadata!.name
         if (helmSettings && helmSettings.builder && helmSettings.builder.length > 0)
           await execAsync(
-            `kubectl delete job --ignore-not-found=true ${jobName} && helm upgrade --reuse-values --version ${helmSettings.builder} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
+            `kubectl delete job --ignore-not-found=true ${jobName} && helm repo update && helm upgrade --reuse-values --version ${helmSettings.builder} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
           )
         else {
           const { stdout } = await execAsync(`helm history ${builderDeploymentName} | grep deployed`)
           const builderChartVersion = BUILDER_CHART_REGEX.exec(stdout)
           if (builderChartVersion)
             await execAsync(
-              `kubectl delete job --ignore-not-found=true ${jobName} && helm upgrade --reuse-values --version ${builderChartVersion} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
+              `kubectl delete job --ignore-not-found=true ${jobName} && helm repo update && helm upgrade --reuse-values --version ${builderChartVersion} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
             )
         }
       } else {
@@ -150,14 +150,14 @@ export const updateBuilder = async (
         const deploymentName = builderDeployments.body.items[0].metadata!.name
         if (helmSettings && helmSettings.builder && helmSettings.builder.length > 0)
           await execAsync(
-            `kubectl delete deployment --ignore-not-found=true ${deploymentName} && helm upgrade --reuse-values --version ${helmSettings.builder} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
+            `kubectl delete deployment --ignore-not-found=true ${deploymentName} && helm repo update && helm upgrade --reuse-values --version ${helmSettings.builder} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
           )
         else {
           const { stdout } = await execAsync(`helm history ${builderDeploymentName} | grep deployed`)
           const builderChartVersion = BUILDER_CHART_REGEX.exec(stdout)
           if (builderChartVersion)
             await execAsync(
-              `kubectl delete deployment --ignore-not-found=true ${deploymentName} && helm upgrade --reuse-values --version ${builderChartVersion} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
+              `kubectl delete deployment --ignore-not-found=true ${deploymentName} && helm repo update && helm upgrade --reuse-values --version ${builderChartVersion} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
             )
         }
       }


### PR DESCRIPTION
## Summary

An overlooked issue was that the helm repo status is set when the builder builds the API pods. If a new version of an EE-builder Helm chart is made after that, then trying to update the builder with the new version will throw an error since the API doesn't know about the new version. Running helm repo update right before helm upgrade fixes this.

## References

closes #8411 


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

