### PR TITLE
Fixed MUI box component attribute missing property

### DIFF
--- a/packages/client-core/src/admin/common/Table.tsx
+++ b/packages/client-core/src/admin/common/Table.tsx
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 import React from 'react'
 
-import Box from '@etherealengine/ui/src/primitives/mui/Box'
 import Table from '@etherealengine/ui/src/primitives/mui/Table'
 import TableBody from '@etherealengine/ui/src/primitives/mui/TableBody'
 import TableCell from '@etherealengine/ui/src/primitives/mui/TableCell'
@@ -34,8 +33,6 @@ import TableHead from '@etherealengine/ui/src/primitives/mui/TableHead'
 import TablePagination from '@etherealengine/ui/src/primitives/mui/TablePagination'
 import TableRow from '@etherealengine/ui/src/primitives/mui/TableRow'
 import TableSortLabel from '@etherealengine/ui/src/primitives/mui/TableSortLabel'
-
-import { visuallyHidden } from '@mui/utils'
 
 import styles from '../styles/table.module.scss'
 
@@ -139,9 +136,9 @@ const EnhancedTableHead = ({ order, orderBy, onRequestSort, columns }: EnhancedT
               >
                 {headCell.label}
                 {orderBy === headCell.id ? (
-                  <Box component="span" sx={visuallyHidden}>
+                  <span style={{ border: 0, clip: 'rect(0 0 0 0)' }}>
                     {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
-                  </Box>
+                  </span>
                 ) : null}
               </TableSortLabel>
             )}


### PR DESCRIPTION
## Summary

It seems like with latest mui (after running `npm run clean-node-modules`) there are tests failing due to `component` property not being in `Box` component.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

