### PR TITLE
Fixed paginate: false for routes

### DIFF
--- a/packages/client-core/src/admin/services/ActiveRouteService.ts
+++ b/packages/client-core/src/admin/services/ActiveRouteService.ts
@@ -24,10 +24,11 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { matches, Validator } from '@etherealengine/engine/src/common/functions/MatchesUtils'
+import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { routePath, RouteType } from '@etherealengine/engine/src/schemas/route/route.schema'
 import { defineAction, defineState, dispatchAction, getMutableState } from '@etherealengine/hyperflux'
 
-import { API } from '../../API'
+import { Paginated } from '@feathersjs/feathers'
 import { NotificationService } from '../../common/services/NotificationService'
 import { AuthState } from '../../user/services/AuthService'
 
@@ -63,7 +64,7 @@ export const AdminActiveRouteService = {
     const user = getMutableState(AuthState).user
     try {
       if (user.scopes?.value?.find((scope) => scope.type === 'admin:admin')) {
-        await API.instance.client.service('route-activate').create({ project, route, activate })
+        await Engine.instance.api.service('route-activate').create({ project, route, activate })
         AdminActiveRouteService.fetchActiveRoutes()
       }
     } catch (err) {
@@ -74,11 +75,11 @@ export const AdminActiveRouteService = {
     const user = getMutableState(AuthState).user
     try {
       if (user.scopes?.value?.find((scope) => scope.type === 'admin:admin')) {
-        const routes = await API.instance.client.service(routePath).find({
+        const routes = (await Engine.instance.api.service(routePath).find({
           query: {
             $limit: ROUTE_PAGE_LIMIT
           }
-        })
+        })) as Paginated<RouteType>
         dispatchAction(AdminActiveRouteActions.activeRoutesRetrieved({ data: routes.data }))
       }
     } catch (err) {

--- a/packages/client-core/src/common/services/RouterService.ts
+++ b/packages/client-core/src/common/services/RouterService.ts
@@ -6,8 +6,8 @@ Version 1.0. (the "License"); you may not use this file except in compliance
 with the License. You may obtain a copy of the License at
 https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
 The License is based on the Mozilla Public License Version 1.1, but Sections 14
-and 15 have been added to cover use of software over a computer network and 
-provide for limited attribution for the Original Developer. In addition, 
+and 15 have been added to cover use of software over a computer network and
+provide for limited attribution for the Original Developer. In addition,
 Exhibit A has been modified to be consistent with Exhibit B.
 
 Software distributed under the License is distributed on an "AS IS" basis,
@@ -19,7 +19,7 @@ The Original Code is Ethereal Engine.
 The Original Developer is the Initial Developer. The Initial Developer of the
 Original Code is the Ethereal Engine team.
 
-All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023
 Ethereal Engine. All Rights Reserved.
 */
 
@@ -29,7 +29,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { matches } from '@etherealengine/engine/src/common/functions/MatchesUtils'
 import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
-import { routePath } from '@etherealengine/engine/src/schemas/route/route.schema'
+import { routePath, RouteType } from '@etherealengine/engine/src/schemas/route/route.schema'
 import {
   addActionReceptor,
   defineAction,
@@ -74,15 +74,15 @@ export type CustomRoute = {
  * @return {Promise}
  */
 export const getCustomRoutes = async (): Promise<CustomRoute[]> => {
-  const routes = (await Engine.instance.api.service(routePath).find({ paginate: false })) as any
+  const routes = (await Engine.instance.api.service(routePath).find({ query: { paginate: false } })) as RouteType[]
   console.log(routes)
 
   const elements: CustomRoute[] = []
 
-  if (!Array.isArray(routes.data) || routes.data == null) {
+  if (!Array.isArray(routes) || routes == null) {
     throw new Error(i18n.t('editor:errors.fetchingRouteError', { error: i18n.t('editor:errors.unknownError') }))
   } else {
-    for (const project of routes.data) {
+    for (const project of routes) {
       const routeLazyLoad = await loadRoute(project.project, project.route)
       if (routeLazyLoad)
         elements.push({

--- a/packages/engine/src/schemas/route/route.schema.ts
+++ b/packages/engine/src/schemas/route/route.schema.ts
@@ -64,7 +64,7 @@ export const routeQuerySchema = Type.Intersect(
   [
     querySyntax(routeQueryProperties),
     // Add additional query properties here
-    Type.Object({}, { additionalProperties: false })
+    Type.Object({ paginate: Type.Optional(Type.Boolean()) }, { additionalProperties: false })
   ],
   { additionalProperties: false }
 )

--- a/packages/server-core/src/media/oembed/oembed.service.ts
+++ b/packages/server-core/src/media/oembed/oembed.service.ts
@@ -28,7 +28,7 @@ import { Params } from '@feathersjs/feathers'
 import { Paginated } from '@feathersjs/feathers/lib'
 
 import { OEmbed } from '@etherealengine/common/src/interfaces/OEmbed'
-import { routePath } from '@etherealengine/engine/src/schemas/route/route.schema'
+import { routePath, RouteType } from '@etherealengine/engine/src/schemas/route/route.schema'
 import { clientSettingPath, ClientSettingType } from '@etherealengine/engine/src/schemas/setting/client-setting.schema'
 import { serverSettingPath, ServerSettingType } from '@etherealengine/engine/src/schemas/setting/server-setting.schema'
 
@@ -74,7 +74,7 @@ export default (app: Application): void => {
           query_url: queryURL
         } as OEmbed
 
-        const activeRoutes = await app.service(routePath).find({ paginate: false })
+        const activeRoutes = (await app.service(routePath).find({ query: { paginate: false } })) as RouteType[]
         const uniqueProjects = [...new Set<string>(activeRoutes.map((item) => item.project))]
 
         for (const projectName of uniqueProjects) {

--- a/packages/server-core/src/route/route/route.class.ts
+++ b/packages/server-core/src/route/route/route.class.ts
@@ -23,18 +23,51 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import type { Params } from '@feathersjs/feathers'
-import type { KnexAdapterParams } from '@feathersjs/knex'
-import { KnexService } from '@feathersjs/knex'
+import type { NullableId, Params } from '@feathersjs/feathers'
+import type { KnexAdapterOptions, KnexAdapterParams } from '@feathersjs/knex'
+import { KnexAdapter } from '@feathersjs/knex'
 
 import { RouteData, RoutePatch, RouteQuery, RouteType } from '@etherealengine/engine/src/schemas/route/route.schema'
+import { Id } from '@feathersjs/feathers'
+import { Application } from '../../../declarations'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface RouteParams extends KnexAdapterParams<RouteQuery> {}
 
-export class RouteService<T = RouteType, ServiceParams extends Params = RouteParams> extends KnexService<
+export class RouteService<T = RouteType, ServiceParams extends Params = RouteParams> extends KnexAdapter<
   RouteType,
   RouteData,
   RouteParams,
   RoutePatch
-> {}
+> {
+  app: Application
+
+  constructor(options: KnexAdapterOptions, app: Application) {
+    super(options)
+    this.app = app
+  }
+
+  async find(params?: RouteParams) {
+    if (params?.query?.paginate != null) {
+      if (params.query.paginate === false) params.paginate = params.query.paginate
+      delete params.query.paginate
+    }
+    return super._find(params)
+  }
+
+  async create(data: RouteData, params?: RouteParams) {
+    return super._create(data, params)
+  }
+
+  async get(id: Id, params?: RouteParams) {
+    return super._get(id, params)
+  }
+
+  async patch(id: Id, data: RouteData, params?: RouteParams) {
+    return super._patch(id, data, params)
+  }
+
+  async remove(id: NullableId, params?: RouteParams) {
+    return super._remove(id, params)
+  }
+}

--- a/packages/server-core/src/route/route/route.test.ts
+++ b/packages/server-core/src/route/route/route.test.ts
@@ -31,6 +31,8 @@ import { v4 as uuid } from 'uuid'
 
 import { destroyEngine } from '@etherealengine/engine/src/ecs/classes/Engine'
 
+import { RouteType } from '@etherealengine/engine/src/schemas/route/route.schema'
+import { Paginated } from '@feathersjs/feathers/lib'
 import { Application } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
 import { deleteFolderRecursive } from '../../util/fsHelperFunctions'
@@ -103,7 +105,7 @@ describe('route.test', () => {
   })
 
   it('should not be activated by default (the installed project)', async () => {
-    const route = await app.service('route').find({ query: { project: testProject } })
+    const route = (await app.service('route').find({ query: { project: testProject } })) as Paginated<RouteType>
     assert.equal(route.total, 0)
   })
 
@@ -111,7 +113,7 @@ describe('route.test', () => {
     const activateResult = await app
       .service('route-activate')
       .create({ project: testProject, route: testRoute, activate: true }, params)
-    const fetchResult = await app.service('route').find({ query: { project: testProject } })
+    const fetchResult = (await app.service('route').find({ query: { project: testProject } })) as Paginated<RouteType>
     const route = fetchResult.data.find((d) => d.project === testProject)
 
     assert.ok(activateResult)
@@ -124,7 +126,7 @@ describe('route.test', () => {
   it('should deactivate a route', async () => {
     await app.service('route-activate').create({ project: testProject, route: testRoute, activate: false }, params)
 
-    const route = await app.service('route').find({ query: { project: testProject } })
+    const route = (await app.service('route').find({ query: { project: testProject } })) as Paginated<RouteType>
     assert.equal(route.total, 0)
   })
 })

--- a/packages/server-core/src/route/route/route.ts
+++ b/packages/server-core/src/route/route/route.ts
@@ -28,7 +28,7 @@ import fs from 'fs'
 import path from 'path'
 
 import { InstalledRoutesInterface } from '@etherealengine/common/src/interfaces/Route'
-import { routeMethods, routePath } from '@etherealengine/engine/src/schemas/route/route.schema'
+import { routeMethods, routePath, RouteType } from '@etherealengine/engine/src/schemas/route/route.schema'
 import { ProjectConfigInterface } from '@etherealengine/projects/ProjectConfigInterface'
 
 import { Application } from '../../../declarations'
@@ -87,9 +87,9 @@ export const getInstalledRoutes = () => {
 
 export const activateRoute = (routeService: RouteService) => {
   return async (data: { project: string; route: string; activate: boolean }, params: Params = {}) => {
-    const activatedRoutes = await routeService.find({
+    const activatedRoutes = (await routeService.find({
       paginate: false
-    })
+    })) as RouteType[]
     const installedRoutes = (await getInstalledRoutes()()).data
     if (data.activate) {
       const routeToActivate = installedRoutes.find((r) => r.project === data.project && r.routes.includes(data.route))
@@ -123,7 +123,7 @@ export default (app: Application): void => {
     multi: true
   }
 
-  app.use(routePath, new RouteService(options), {
+  app.use(routePath, new RouteService(options, app), {
     // A list of all methods this service exposes externally
     methods: routeMethods,
     // You can add additional custom events to be sent to clients here

--- a/scripts/update-cloudfront-function.ts
+++ b/scripts/update-cloudfront-function.ts
@@ -34,7 +34,7 @@ import { ServerMode } from '@etherealengine/server-core/src/ServerState'
 
 cli.enable('status')
 
-const PAGE_SIZE = 1
+const PAGE_SIZE = 100
 
 const getAllRoutes = async (app: Application, routes: InstalledRoutesInterface[], skip: number) => {
   const routePage = await app.service(routePath).find({


### PR DESCRIPTION
## Summary

If the client passes paginate: false on params, it will not make it to the API server's handler for security reasons. Changed the find call to accept paginate: false as a query param, and to move it to the top of the params object if it's false.

Had to make changes to route's typing to support this. Made some changes to RouterService to handle the fact that the route.find call now returns an array rather than a paginated response. Cast several calls to route.find as either paginated or unpaginated based on what they are requesting.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

