### PR TITLE
fix(archiver): output directory name correction

### DIFF
--- a/packages/server-core/src/media/recursive-archiver/archiver.class.ts
+++ b/packages/server-core/src/media/recursive-archiver/archiver.class.ts
@@ -50,7 +50,8 @@ export class Archiver implements Partial<ServiceMethods<any>> {
   async setup(app: Application, path: string) {}
 
   async get(directory: string, params?: UserParams): Promise<string> {
-    if (directory[0] === '/') directory = directory.slice(1)
+    if (directory.at(0) === '/') directory = directory.slice(1)
+    if (directory.at(-1) === '/') directory = directory.slice(0, -1)
     if (!directory.startsWith('projects/') || ['projects', 'projects/'].includes(directory)) {
       return Promise.reject(new Error('Cannot archive non-project directories'))
     }
@@ -92,7 +93,9 @@ export class Archiver implements Partial<ServiceMethods<any>> {
 
     const generated = await zip.generateAsync({ type: 'blob', streamFiles: true })
 
-    const zipOutputDirectory = `'temp'${directory.substring(directory.lastIndexOf('/'))}.zip`
+    const zipOutputDirectory = `temp${directory.substring(directory.lastIndexOf('/'))}.zip`
+
+    logger.info(`Uploading ${zipOutputDirectory} to storage provider`)
 
     await storageProvider.putObject({
       Key: zipOutputDirectory,


### PR DESCRIPTION
## Summary

The name of the zipped directory uploaded to S3 had a trailing slash. Made the correction.

## References

closes #8430


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

