### PR TITLE
Switched from caching in S3 to caching in registry

### DIFF
--- a/scripts/prune_ecr_images.js
+++ b/scripts/prune_ecr_images.js
@@ -122,7 +122,7 @@ cli.main(async () => {
     const images = await getAllImages(ecr, options.repoName || 'etherealengine', undefined, [])
     if (!images) return
     const latestImage = images.find(
-      (image) => image.imageTags && image.imageTags.indexOf(`latest_${options.releaseName}`) >= 0
+      (image) => image.imageTags && (image.imageTags.indexOf(`latest_${options.releaseName}`) >= 0 || image.imageTags.indexOf(`latest_${options.releaseName}_cache`) >= 0)
     )
     if (latestImage) {
       const latestImageTime = latestImage.imagePushedAt.getTime()

--- a/scripts/record-build-error.ts
+++ b/scripts/record-build-error.ts
@@ -63,8 +63,8 @@ cli.main(async () => {
     const buildErrors = fs.readFileSync(`${options.service}-build-error.txt`).toString()
     const builderRun = fs.readFileSync('builder-run.txt').toString()
     if (options.isDocker) {
-      const cacheMissRegex = new RegExp(`${options.service}:latest_${process.env.RELEASE_NAME}: not found`)
-      if (/ERROR:/.test(buildErrors) && !cacheMissRegex.test(buildErrors)) {
+      const cacheMissRegex = new RegExp(`${options.service}:latest_${process.env.RELEASE_NAME}_cache: not found`)
+      if (/exit code: 1/.test(buildErrors) || (/ERROR:/.test(buildErrors) && !cacheMissRegex.test(buildErrors))) {
         const combinedLogs = `Docker task that errored: ${options.service}\n\nTask logs:\n\n${buildErrors}`
         await knexClient
           .from<BuildStatusType>(buildStatusPath)


### PR DESCRIPTION
## Summary

BuildKit now supports caching in ECR. build_and_publish_package.sh now uses BuildKit 12.0 and caches to and from the registry. Cache image is tagged as latest_<release>_cache. prune_ecr_images.js updated to ignore this image.

Fixed an issue with record-build-error.ts If there was a miss on the build cache and another error occurred, the logic was ignoring errors and returning as if everything had succeeded. Now checking if exit code 1 was part of the output logs to better catch legitimate errors.

## References

closes #7984 


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

