### PR TITLE
Fixed a few issues with admin avatar drawer.

### DIFF
--- a/packages/client-core/src/admin/components/Avatars/AvatarDrawer.tsx
+++ b/packages/client-core/src/admin/components/Avatars/AvatarDrawer.tsx
@@ -548,31 +548,29 @@ const AvatarDrawerContent = ({ open, mode, selectedAvatar, onClose }: Props) => 
         </Box>
       )}
 
-      {editMode.value && (
-        <Box
-          className={styles.preview}
-          style={{ width: '100px', height: '100px', position: 'relative', marginBottom: 15 }}
-        >
-          <img src={thumbnailSrc} crossOrigin="anonymous" />
-          {((state.source.value === 'file' && !state.thumbnailFile.value) ||
-            (state.source.value === 'url' && !state.thumbnailUrl.value)) && (
-            <Typography
-              sx={{
-                position: 'absolute',
-                top: 0,
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                textAlign: 'center',
-                height: '100%',
-                fontSize: 14
-              }}
-            >
-              {t('admin:components.avatar.thumbnailPreview')}
-            </Typography>
-          )}
-        </Box>
-      )}
+      <Box
+        className={styles.preview}
+        style={{ width: '100px', height: '100px', position: 'relative', marginBottom: 15 }}
+      >
+        <img src={thumbnailSrc} crossOrigin="anonymous" />
+        {((state.source.value === 'file' && !state.thumbnailFile.value) ||
+          (state.source.value === 'url' && !state.thumbnailUrl.value)) && (
+          <Typography
+            sx={{
+              position: 'absolute',
+              top: 0,
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              textAlign: 'center',
+              height: '100%',
+              fontSize: 14
+            }}
+          >
+            {t('admin:components.avatar.thumbnailPreview')}
+          </Typography>
+        )}
+      </Box>
 
       <DialogActions>
         <Button className={styles.outlinedButton} onClick={handleCancel}>

--- a/packages/server-core/src/user/avatar/avatar-helper.ts
+++ b/packages/server-core/src/user/avatar/avatar-helper.ts
@@ -215,10 +215,14 @@ export const uploadAvatarStaticResource = async (
 
   if (data.avatarId) {
     try {
-      await app.service(avatarPath).patch(data.avatarId, {
-        modelResourceId: modelResource.id,
-        thumbnailResourceId: thumbnailResource.id
-      })
+      await app.service(avatarPath).patch(
+        data.avatarId,
+        {
+          modelResourceId: modelResource.id,
+          thumbnailResourceId: thumbnailResource.id
+        },
+        params
+      )
     } catch (err) {
       console.log(err)
     }


### PR DESCRIPTION
## Summary

Newly-created avatars did not have thumbnails/models show up until a page refresh or another avatar was created. This was due to the switch to FeathersHooks; the avatar is created but did not have the model or thumbnail yet, then it uploads the model and thumbnail, but useFind() was only being triggered by the creation, not the resources getting added. Added a patched handler on avatar.ts that will notify people with that avatar and the user who made the request. Passing params to avatar.patch in uploadAvatarStaticResource to make this happen.

Thumbnail preview was not showing in AvatarDrawer in create mode because it was set to only show in edit mode. Removed this restriction, as it is helpful to show the thumbnail during creation too.

## References

closes #8454 


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

