### PR TITLE
Quick Fix for scene switching bug in studio

### DIFF
--- a/packages/engine/src/ecs/functions/ComponentFunctions.ts
+++ b/packages/engine/src/ecs/functions/ComponentFunctions.ts
@@ -54,7 +54,7 @@ globalThis.ComponentJSONIDMap = ComponentJSONIDMap
 
 type PartialIfObject<T> = T extends object ? Partial<T> : T
 
-type OnInitValidateNotState<T> = T extends State<any, object | unknown> ? 'onAdd must not return a State object' : T
+type OnInitValidateNotState<T> = T extends State<any, object | unknown> ? 'onInit must not return a State object' : T
 
 type SomeStringLiteral = 'a' | 'b' | 'c' // just a dummy string literal union
 type StringLiteral<T> = string extends T ? SomeStringLiteral : string

--- a/packages/engine/src/scene/components/ColliderComponent.ts
+++ b/packages/engine/src/scene/components/ColliderComponent.ts
@@ -108,7 +108,11 @@ export const ColliderComponent = defineComponent({
     /**
      * Add SceneAssetPendingTagComponent to tell scene loading system we should wait for this asset to load
      */
-    if (!getState(EngineState).sceneLoaded && hasComponent(entity, SceneObjectComponent))
+    if (
+      !getState(EngineState).sceneLoaded &&
+      hasComponent(entity, SceneObjectComponent) &&
+      !hasComponent(entity, RigidBodyComponent)
+    )
       setComponent(entity, SceneAssetPendingTagComponent)
 
     setComponent(entity, InputComponent)

--- a/packages/engine/src/scene/components/GroundPlaneComponent.ts
+++ b/packages/engine/src/scene/components/GroundPlaneComponent.ts
@@ -40,6 +40,7 @@ import {
 } from '../../ecs/functions/ComponentFunctions'
 import { useEntityContext } from '../../ecs/functions/EntityFunctions'
 import { Physics } from '../../physics/classes/Physics'
+import { RigidBodyComponent } from '../../physics/components/RigidBodyComponent'
 import { CollisionGroups } from '../../physics/enums/CollisionGroups'
 import { getInteractionGroups } from '../../physics/functions/getInteractionGroups'
 import { PhysicsState } from '../../physics/state/PhysicsState'
@@ -72,7 +73,11 @@ export const GroundPlaneComponent = defineComponent({
     /**
      * Add SceneAssetPendingTagComponent to tell scene loading system we should wait for this asset to load
      */
-    if (!getState(EngineState).sceneLoaded && hasComponent(entity, SceneObjectComponent))
+    if (
+      !getState(EngineState).sceneLoaded &&
+      hasComponent(entity, SceneObjectComponent) &&
+      !hasComponent(entity, RigidBodyComponent)
+    )
       setComponent(entity, SceneAssetPendingTagComponent)
   },
 


### PR DESCRIPTION
This is a quick fix how we are mishandling scene entities that exist in multiple scenes (e.g., the same ground plane UUID when switching scenes in the studio).

Our scene loading state and SceneAssetPendingTagComponent are too ambiguous, prone to multiple sources of truth conflicting with one another. We need to refactor this.