### PR TITLE
Add SmartToy to Icon component, and change Bots icon in Dashboard

### DIFF
--- a/packages/ui/src/primitives/mui/DashboardItems/index.tsx
+++ b/packages/ui/src/primitives/mui/DashboardItems/index.tsx
@@ -96,7 +96,7 @@ export const SidebarItems = (allowedRoutes) => [
   allowedRoutes.bot && {
     name: 'user:dashboard.bots',
     path: '/admin/bots',
-    icon: <Icon type="Toys" style={{ color: 'white' }} />
+    icon: <Icon type="SmartToy" style={{ color: 'white' }} />
   },
   allowedRoutes.recording && {
     name: 'user:dashboard.recordings',

--- a/packages/ui/src/primitives/mui/Icon/index.stories.tsx
+++ b/packages/ui/src/primitives/mui/Icon/index.stories.tsx
@@ -160,7 +160,8 @@ const argTypes = {
       'ChevronRight',
       'Sync',
       'Download',
-      'Save'
+      'Save',
+      'SmartToy'
     ]
   }
 }

--- a/packages/ui/src/primitives/mui/Icon/index.tsx
+++ b/packages/ui/src/primitives/mui/Icon/index.tsx
@@ -137,6 +137,7 @@ import {
   Send,
   Settings,
   Shuffle,
+  SmartToy,
   SportsScore,
   SquareFoot,
   StopCircle,
@@ -448,6 +449,8 @@ const Icon = ({ type, ...props }: SvgIconProps & { type: string }) => {
       return <Timeline {...props} />
     case 'Toys':
       return <Toys {...props} />
+    case 'SmartToy':
+      return <SmartToy {...props} />
     case 'Phone':
       return <Phone {...props} />
     case 'FlipCameraAndroid':


### PR DESCRIPTION
## Summary

The admin panel Icon for Bots was a toy car. It should convey Bots so it has been changed to a toy robot icon.


## References

closes #8529 


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

<img width="1792" alt="image" src="https://github.com/EtherealEngine/etherealengine/assets/3631206/38908af8-b68f-44ad-b655-17c100edba17">
