### PR TITLE
Fix for project files using S3 URL

### DIFF
--- a/packages/server-core/src/appconfig.ts
+++ b/packages/server-core/src/appconfig.ts
@@ -312,7 +312,10 @@ const aws = {
     s3DevMode: process.env.STORAGE_S3_DEV_MODE!
   },
   cloudfront: {
-    domain: process.env.SERVE_CLIENT_FROM_STORAGE_PROVIDER ? server.clientHost : process.env.STORAGE_CLOUDFRONT_DOMAIN!,
+    domain:
+      process.env.SERVE_CLIENT_FROM_STORAGE_PROVIDER === 'true'
+        ? server.clientHost
+        : process.env.STORAGE_CLOUDFRONT_DOMAIN!,
     distributionId: process.env.STORAGE_CLOUDFRONT_DISTRIBUTION_ID!,
     region: process.env.STORAGE_CLOUDFRONT_REGION || process.env.STORAGE_S3_REGION
   },

--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -122,6 +122,10 @@ export class FileBrowserService implements ServiceMethods<any> {
 
     result = result.slice(skip, skip + limit)
 
+    result = result.map((item) => {
+      item.url = `https://${storageProvider.cacheDomain}/${item.key}`
+      return item
+    })
     if (params.provider && !isAdmin) {
       const knexClient: Knex = this.app.get('knexClient')
       const projectPermissions = await knexClient

--- a/packages/server-core/src/setting/aws-setting/aws-setting.seed.ts
+++ b/packages/server-core/src/setting/aws-setting/aws-setting.seed.ts
@@ -52,9 +52,10 @@ export async function seed(knex: Knex): Promise<void> {
           secretAccessKey: process.env.EKS_AWS_ACCESS_KEY_SECRET
         }),
         cloudfront: JSON.stringify({
-          domain: process.env.SERVE_CLIENT_FROM_STORAGE_PROVIDER
-            ? process.env.APP_HOST
-            : process.env.STORAGE_CLOUDFRONT_DOMAIN!,
+          domain:
+            process.env.SERVE_CLIENT_FROM_STORAGE_PROVIDER === 'true'
+              ? process.env.APP_HOST
+              : process.env.STORAGE_CLOUDFRONT_DOMAIN!,
           distributionId: process.env.STORAGE_CLOUDFRONT_DISTRIBUTION_ID,
           region: process.env.STORAGE_CLOUDFRONT_REGION || process.env.STORAGE_S3_REGION
         }),


### PR DESCRIPTION
## Summary

Sometimes files added to projects would have an S3 URL. This seemed to be occurring when adding files from the file browser. The cause was that the image node was using the URL from the file browser. These URLs were coming from storageProvider.get, which for S3 returns the S3 URL.

## References

closes #8609


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

