### PR TITLE
Networked avatar animation graph cleanup, fixes

### DIFF
--- a/packages/client-core/src/user/components/Panel3D/helperFunctions.ts
+++ b/packages/client-core/src/user/components/Panel3D/helperFunctions.ts
@@ -70,7 +70,7 @@ export const resetAnimationLogic = (entity: Entity) => {
   setComponent(entity, AvatarAnimationComponent, {
     animationGraph: {
       blendAnimation: undefined,
-      needsSkip: false,
+      fadingOut: false,
       blendStrength: 0,
       layer: 0
     },

--- a/packages/client-core/src/user/components/UserMenu/menus/EmoteMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/EmoteMenu.tsx
@@ -32,7 +32,7 @@ import Icon from '@etherealengine/ui/src/primitives/mui/Icon'
 
 import ClickAwayListener from '@mui/material/ClickAwayListener'
 
-import { animationStates } from '@etherealengine/engine/src/avatar/animation/Util'
+import { animationStates, defaultAnimationPath } from '@etherealengine/engine/src/avatar/animation/Util'
 import { AvatarNetworkAction } from '@etherealengine/engine/src/avatar/state/AvatarNetworkActions'
 import { getComponent } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
 import { UUIDComponent } from '@etherealengine/engine/src/scene/components/UUIDComponent'
@@ -146,9 +146,8 @@ export const useEmoteMenuHooks = () => {
     const entity = Engine.instance.localClientEntity
     dispatchAction(
       AvatarNetworkAction.setAnimationState({
-        animationState: stateName,
+        filePath: defaultAnimationPath + stateName + '.fbx',
         loop: false,
-        fileType: 'fbx',
         layer: 0,
         entityUUID: getComponent(entity, UUIDComponent)
       })

--- a/packages/engine/src/avatar/animation/AvatarAnimationGraph.ts
+++ b/packages/engine/src/avatar/animation/AvatarAnimationGraph.ts
@@ -23,7 +23,7 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { clamp, cloneDeep } from 'lodash'
+import { clamp, clone } from 'lodash'
 import { AnimationClip, AnimationMixer, LoopOnce, LoopRepeat, Object3D, Vector3 } from 'three'
 
 import { defineActionQueue, getState } from '@etherealengine/hyperflux'
@@ -120,7 +120,7 @@ export const loadAvatarAnimation = (entity: Entity, filePath: string, clipName?:
 /** Retargets a mixamo animation to the entity's avatar model, then blends in and out of the default locomotion state. */
 export const playAvatarAnimationFromMixamo = (
   entity: Entity,
-  animationsAsset: Object3D,
+  animationsScene: Object3D,
   loop?: boolean,
   clipName?: string
 ) => {
@@ -129,16 +129,17 @@ export const playAvatarAnimationFromMixamo = (
   const rigComponent = getComponent(entity, AvatarRigComponent)
   //if animation is already present on animation component, use it instead of retargeting again
   let retargetedAnimation = animationComponent.animations.find(
-    (clip) => clip.name == (clipName ?? animationsAsset.animations[0].name)
+    (clip) => clip.name == (clipName ?? animationsScene.animations[0].name)
   )
   //otherwise retarget and push to animation component's animations
   if (!retargetedAnimation) {
-    const animationToRetarget = cloneDeep(animationsAsset)
     retargetedAnimation = retargetMixamoAnimation(
-      clipName
-        ? animationToRetarget.animations.find((clip) => clip.name == clipName) ?? animationToRetarget.animations[0]
-        : animationToRetarget.animations[0],
-      animationToRetarget,
+      clone(
+        clipName
+          ? animationsScene.animations.find((clip) => clip.name == clipName) ?? animationsScene.animations[0]
+          : animationsScene.animations[0]
+      ),
+      animationsScene,
       rigComponent.vrm
     )
     animationComponent.animations.push(retargetedAnimation)

--- a/packages/engine/src/avatar/animation/AvatarAnimationGraph.ts
+++ b/packages/engine/src/avatar/animation/AvatarAnimationGraph.ts
@@ -23,7 +23,7 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { clamp, clone } from 'lodash'
+import { clamp, cloneDeep } from 'lodash'
 import { AnimationClip, AnimationMixer, LoopOnce, LoopRepeat, Object3D, Vector3 } from 'three'
 
 import { defineActionQueue, getState } from '@etherealengine/hyperflux'
@@ -134,7 +134,7 @@ export const playAvatarAnimationFromMixamo = (
   //otherwise retarget and push to animation component's animations
   if (!retargetedAnimation) {
     retargetedAnimation = retargetMixamoAnimation(
-      clone(
+      cloneDeep(
         clipName
           ? animationsScene.animations.find((clip) => clip.name == clipName) ?? animationsScene.animations[0]
           : animationsScene.animations[0]

--- a/packages/engine/src/avatar/animation/Util.ts
+++ b/packages/engine/src/avatar/animation/Util.ts
@@ -34,6 +34,7 @@ import {
   Vector3
 } from 'three'
 
+import config from '@etherealengine/common/src/config'
 import { matches, matchesVector3 } from '../../common/functions/MatchesUtils'
 
 export const ikTargets = {
@@ -64,14 +65,10 @@ export const animationStates = {
   falling: 'falling'
 }
 
-export const animationFileTypes = { fbx: 'fbx', glb: 'glb' }
+export const defaultAnimationPath = `${config.client.fileServer}/projects/default-project/assets/animations/`
 
 export const matchesIkTarget = matches.some(
   ...Object.keys(ikTargets).map((k: keyof typeof ikTargets) => matches.literal(k))
-)
-
-export const matchesAnimationFiles = matches.some(
-  ...Object.keys(animationFileTypes).map((k: keyof typeof animationFileTypes) => matches.literal(k))
 )
 
 const matchesMovementType = matches.shape({

--- a/packages/engine/src/avatar/components/AvatarAnimationComponent.ts
+++ b/packages/engine/src/avatar/components/AvatarAnimationComponent.ts
@@ -55,7 +55,7 @@ export const AvatarAnimationComponent = defineComponent({
     return {
       animationGraph: {
         blendAnimation: undefined as undefined | AnimationAction,
-        needsSkip: false,
+        fadingOut: false,
         blendStrength: 0,
         layer: 0
       },

--- a/packages/engine/src/avatar/functions/moveAvatar.ts
+++ b/packages/engine/src/avatar/functions/moveAvatar.ts
@@ -47,7 +47,7 @@ import { UUIDComponent } from '../../scene/components/UUIDComponent'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { computeAndUpdateWorldOrigin, updateWorldOrigin } from '../../transform/updateWorldOrigin'
 import { XRState, getCameraMode, hasMovementControls } from '../../xr/XRState'
-import { animationStates } from '../animation/Util'
+import { animationStates, defaultAnimationPath } from '../animation/Util'
 import { AvatarComponent } from '../components/AvatarComponent'
 import { AvatarControllerComponent } from '../components/AvatarControllerComponent'
 import { AvatarHeadDecapComponent } from '../components/AvatarIKComponents'
@@ -155,8 +155,7 @@ export function updateLocalAvatarPosition(additionalMovement?: Vector3) {
     if (controller.isInAir && !beganFalling) {
       dispatchAction(
         AvatarNetworkAction.setAnimationState({
-          animationState: animationStates.locomotion,
-          fileType: 'glb',
+          filePath: defaultAnimationPath + animationStates.locomotion + '.glb',
           clipName: 'Fall',
           loop: true,
           layer: 1,
@@ -169,8 +168,7 @@ export function updateLocalAvatarPosition(additionalMovement?: Vector3) {
       if (beganFalling) {
         dispatchAction(
           AvatarNetworkAction.setAnimationState({
-            animationState: animationStates.locomotion,
-            fileType: 'glb',
+            filePath: defaultAnimationPath + animationStates.locomotion + '.glb',
             clipName: 'Fall',
             loop: true,
             layer: 1,
@@ -179,7 +177,6 @@ export function updateLocalAvatarPosition(additionalMovement?: Vector3) {
           })
         )
       }
-
       beganFalling = false
       if (attached) originTransform.position.y = hit.position.y
       /** @todo after a physical jump, only apply viewer vertical movement once the user is back on the virtual ground */

--- a/packages/engine/src/avatar/state/AvatarNetworkActions.ts
+++ b/packages/engine/src/avatar/state/AvatarNetworkActions.ts
@@ -28,7 +28,7 @@ import matches from 'ts-matches'
 import { matchesEntityUUID } from '../../common/functions/MatchesUtils'
 import { NetworkTopics } from '../../networking/classes/Network'
 import { WorldNetworkAction } from '../../networking/functions/WorldNetworkAction'
-import { matchesAnimationFiles, matchesIkTarget } from '../animation/Util'
+import { matchesIkTarget } from '../animation/Util'
 
 export class AvatarNetworkAction {
   static spawn = defineAction({
@@ -39,10 +39,9 @@ export class AvatarNetworkAction {
   static setAnimationState = defineAction({
     type: 'ee.engine.avatar.SET_ANIMATION_STATE',
     entityUUID: matchesEntityUUID,
-    animationState: matches.string,
     clipName: matches.string.optional(),
-    fileType: matchesAnimationFiles,
-    loop: matches.boolean,
+    filePath: matches.string,
+    loop: matches.boolean.optional(),
     needsSkip: matches.boolean.optional(),
     layer: matches.number.optional(),
     $topic: NetworkTopics.world


### PR DESCRIPTION
## Summary

Cleanup of how networked avatar animations are handled, makes things a bit more consice and fixes animation manager animations being mutated by the retargeting function when avatar animations are played.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

