### PR TITLE
Ensure that Variant has been set on Model load

### DIFF
--- a/packages/engine/src/scene/components/ModelComponent.ts
+++ b/packages/engine/src/scene/components/ModelComponent.ts
@@ -54,6 +54,7 @@ import { GroupComponent, addObjectToGroup, removeObjectFromGroup } from './Group
 import { SceneAssetPendingTagComponent } from './SceneAssetPendingTagComponent'
 import { SceneObjectComponent } from './SceneObjectComponent'
 import { UUIDComponent } from './UUIDComponent'
+import { VariantComponent } from './VariantComponent'
 
 function clearMaterials(model: ComponentType<typeof ModelComponent>) {
   if (!model.scene) return
@@ -121,6 +122,7 @@ function ModelReactor() {
   const entity = useEntityContext()
   const modelComponent = useComponent(entity, ModelComponent)
   const groupComponent = useOptionalComponent(entity, GroupComponent)
+  const variantComponent = useOptionalComponent(entity, VariantComponent)
   const model = modelComponent.value
   const source = model.src
 
@@ -138,6 +140,8 @@ function ModelReactor() {
       if (!model.src) return
       const uuid = getComponent(entity, UUIDComponent)
       const fileExtension = model.src.split('.').pop()?.toLowerCase()
+      //wait for variant component to calculate if present
+      if (variantComponent && variantComponent.calculated.value === false) return
       switch (fileExtension) {
         case 'glb':
         case 'gltf':
@@ -179,7 +183,7 @@ function ModelReactor() {
       console.error(err)
       addError(entity, ModelComponent, 'LOADING_ERROR', err.message)
     }
-  }, [modelComponent.src])
+  }, [modelComponent.src, variantComponent?.calculated])
 
   // update scene
   useEffect(() => {

--- a/packages/engine/src/scene/components/VariantComponent.tsx
+++ b/packages/engine/src/scene/components/VariantComponent.tsx
@@ -52,7 +52,8 @@ export const VariantComponent = defineComponent({
 
   onInit: (entity) => ({
     levels: [] as VariantLevel[],
-    heuristic: 'MANUAL' as 'DISTANCE' | 'SCENE_SCALE' | 'MANUAL' | 'DEVICE'
+    heuristic: 'MANUAL' as 'DISTANCE' | 'SCENE_SCALE' | 'MANUAL' | 'DEVICE',
+    calculated: false
   }),
 
   onSet: (entity, component, json) => {
@@ -72,6 +73,7 @@ export const VariantComponent = defineComponent({
     ) {
       component.levels.set(json.levels)
     }
+    if (typeof json.calculated === 'boolean') component.calculated.set(json.calculated)
   },
 
   toJSON: (entity, component) => ({

--- a/packages/engine/src/scene/functions/loaders/VariantFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/VariantFunctions.ts
@@ -44,7 +44,9 @@ export function setModelVariant(entity: Entity) {
     const targetDevice = isMobile || isMobileXRHeadset ? 'MOBILE' : 'DESKTOP'
     //set model src to mobile variant src
     const deviceVariant = variantComponent.levels.find((level) => level.metadata['device'] === targetDevice)
-    deviceVariant && modelComponent.src.value !== deviceVariant.src.value && modelComponent.src.set(deviceVariant.src)
+    deviceVariant &&
+      modelComponent.src.value !== deviceVariant.src.value &&
+      modelComponent.src.set(deviceVariant.src.value)
   } else if (variantComponent.heuristic.value === 'DISTANCE') {
     const distance = DistanceFromCameraComponent.squaredDistance[entity]
     for (let i = 0; i < variantComponent.levels.length; i++) {
@@ -53,7 +55,7 @@ export function setModelVariant(entity: Entity) {
       const minDistance = Math.pow(level.metadata['minDistance'], 2)
       const maxDistance = Math.pow(level.metadata['maxDistance'], 2)
       const useLevel = minDistance <= distance && distance <= maxDistance
-      useLevel && modelComponent.src.value !== level.src.value && modelComponent.src.set(level.src)
+      useLevel && modelComponent.src.value !== level.src.value && modelComponent.src.set(level.src.value)
       if (useLevel) break
     }
   }

--- a/packages/engine/src/scene/functions/loaders/VariantFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/VariantFunctions.ts
@@ -2,7 +2,7 @@ import { DistanceFromCameraComponent } from '@etherealengine/engine/src/transfor
 
 import { isMobile } from '../../../common/functions/isMobile'
 import { Entity } from '../../../ecs/classes/Entity'
-import { getComponent, getMutableComponent } from '../../../ecs/functions/ComponentFunctions'
+import { getMutableComponent } from '../../../ecs/functions/ComponentFunctions'
 import { isMobileXRHeadset } from '../../../xr/XRState'
 import { ModelComponent } from '../../components/ModelComponent'
 import { VariantComponent } from '../../components/VariantComponent'
@@ -37,15 +37,15 @@ Ethereal Engine. All Rights Reserved.
  * @param entity
  */
 export function setModelVariant(entity: Entity) {
-  const variantComponent = getComponent(entity, VariantComponent)
+  const variantComponent = getMutableComponent(entity, VariantComponent)
   const modelComponent = getMutableComponent(entity, ModelComponent)
 
-  if (variantComponent.heuristic === 'DEVICE') {
+  if (variantComponent.heuristic.value === 'DEVICE') {
     const targetDevice = isMobile || isMobileXRHeadset ? 'MOBILE' : 'DESKTOP'
     //set model src to mobile variant src
     const deviceVariant = variantComponent.levels.find((level) => level.metadata['device'] === targetDevice)
-    deviceVariant && modelComponent.src.value !== deviceVariant.src && modelComponent.src.set(deviceVariant.src)
-  } else if (variantComponent.heuristic === 'DISTANCE') {
+    deviceVariant && modelComponent.src.value !== deviceVariant.src.value && modelComponent.src.set(deviceVariant.src)
+  } else if (variantComponent.heuristic.value === 'DISTANCE') {
     const distance = DistanceFromCameraComponent.squaredDistance[entity]
     for (let i = 0; i < variantComponent.levels.length; i++) {
       const level = variantComponent.levels[i]
@@ -53,8 +53,9 @@ export function setModelVariant(entity: Entity) {
       const minDistance = Math.pow(level.metadata['minDistance'], 2)
       const maxDistance = Math.pow(level.metadata['maxDistance'], 2)
       const useLevel = minDistance <= distance && distance <= maxDistance
-      useLevel && modelComponent.src.value !== level.src && modelComponent.src.set(level.src)
+      useLevel && modelComponent.src.value !== level.src.value && modelComponent.src.set(level.src)
       if (useLevel) break
     }
   }
+  variantComponent.calculated.set(true)
 }


### PR DESCRIPTION
Prevents race condition where sometimes a model's default src asset is loaded before the variant component has time to set the src to the correct value