### PR TITLE
XR session nodes

### DIFF
--- a/packages/engine/src/behave-graph/nodes/Profiles/Engine/Values/CustomNodes.ts
+++ b/packages/engine/src/behave-graph/nodes/Profiles/Engine/Values/CustomNodes.ts
@@ -53,6 +53,7 @@ import { StandardCallbacks, getCallback } from '../../../../../scene/components/
 import { MediaComponent } from '../../../../../scene/components/MediaComponent'
 import { VideoComponent } from '../../../../../scene/components/VideoComponent'
 import { PlayMode } from '../../../../../scene/constants/PlayMode'
+import { endXRSession, requestXRSession } from '../../../../../xr/XRSessionFunctions'
 import { ContentFitType } from '../../../../../xrui/functions/ObjectFitFunctions'
 
 export const playVideo = makeFlowNodeDefinition({
@@ -371,6 +372,44 @@ export const setCameraZoom = makeFlowNodeDefinition({
     const entity = Engine.instance.cameraEntity
     const zoom = read<number>('zoom')
     setComponent(entity, FollowCameraComponent, { zoomLevel: zoom })
+    commit('flow')
+  }
+})
+
+export const startXRSession = makeFlowNodeDefinition({
+  typeName: 'engine/xr/startSession',
+  category: NodeCategory.Action,
+  label: 'Start XR Session',
+  in: {
+    flow: 'flow',
+    XRmode: (_, graphApi) => {
+      const choices = ['inline', 'immersive-ar', 'immersive-vr']
+      return {
+        valueType: 'string',
+        choices: choices
+      }
+    }
+  },
+  out: { flow: 'flow' },
+  initialState: undefined,
+  triggered: ({ read, commit, graph: { getDependency } }) => {
+    const XRmode = read<'inline' | 'immersive-ar' | 'immersive-vr'>('XRmode')
+    requestXRSession({ mode: XRmode })
+    commit('flow')
+  }
+})
+
+export const finishXRSession = makeFlowNodeDefinition({
+  typeName: 'engine/xr/endSession',
+  category: NodeCategory.Action,
+  label: 'End XR Session',
+  in: {
+    flow: 'flow'
+  },
+  out: { flow: 'flow' },
+  initialState: undefined,
+  triggered: ({ read, commit, graph: { getDependency } }) => {
+    endXRSession()
     commit('flow')
   }
 })


### PR DESCRIPTION
## Summary

two nodes 

start XR session. 
end XR session 

Internally uses requestXRsession and endXrsession
from XRSession functions


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

