### PR TITLE
Use multipart upload on large files

### DIFF
--- a/packages/common/src/constants/FileSizeConstants.ts
+++ b/packages/common/src/constants/FileSizeConstants.ts
@@ -1,0 +1,32 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and
+provide for limited attribution for the Original Developer. In addition,
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023
+Ethereal Engine. All Rights Reserved.
+*/
+
+//s3.putObject has an upper limit on file size before it starts erroring out. On paper the limit is around 5 GB, but
+//in practice, errors were seen at around 2 GB. Setting the limit to 1 GB for safety; above this, files will be
+//uploaded via multipart upload instead of a single putObject operation. Part size is set to 100 MB.
+//nodejs has an upper limit of 1 or 2 GB on direct file reads and writes (32-bit and 64-bit systems, respectively).
+//1 GB is the cutoff for using read/write streams for those as well for consistency
+export const MULTIPART_CUTOFF_SIZE = 1000 * 1000 * 1000
+export const MULTIPART_CHUNK_SIZE = 100 * 1000 * 1000

--- a/packages/server-core/src/media/recursive-archiver/archiver.class.ts
+++ b/packages/server-core/src/media/recursive-archiver/archiver.class.ts
@@ -47,7 +47,6 @@ export interface ArchiveParams extends UserParams {
 
 const archive = async (directory, params?: UserParams): Promise<string> => {
   if (directory.at(0) === '/') directory = directory.slice(1)
-  if (directory.at(-1) === '/') directory = directory.slice(0, -1)
   if (!directory.startsWith('projects/') || ['projects', 'projects/'].includes(directory)) {
     return Promise.reject(new Error('Cannot archive non-project directories'))
   }

--- a/packages/server-core/src/media/storageprovider/storageprovider.interface.ts
+++ b/packages/server-core/src/media/storageprovider/storageprovider.interface.ts
@@ -59,6 +59,13 @@ export interface StorageObjectInterface {
   Metadata?: object
 }
 
+export interface StorageMultipartStartInterface {
+  Bucket: string
+  Key: string
+  ContentType: string
+  ContentEncoding?: string
+}
+
 export interface StorageObjectPutInterface extends Omit<StorageObjectInterface, 'Body'> {
   Body: Buffer | PassThrough
 }


### PR DESCRIPTION
## Summary

While S3's documentation says that putObject should work on files up to 5 GB, in practice problems were occurring with archive files that were around 2 GB. Updated the S3 storage provider putObject function to perform a multipart upload on files >= 1 GB.

## References

closes #_insert number here_


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

