### PR TITLE
fixed file browser not visible in admin panel 

### DIFF
--- a/packages/editor/src/components/assets/FileBrowserContentPanel.tsx
+++ b/packages/editor/src/components/assets/FileBrowserContentPanel.tsx
@@ -402,7 +402,6 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
       <div
         ref={fileDropRef}
         onContextMenu={handleContextMenu}
-        id="file-browser-panel"
         className={styles.panelContainer}
         style={{ border: isFileDropOver ? '3px solid #ccc' : '' }}
       >
@@ -485,10 +484,11 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
           variant="body2"
         />
       )}
-
-      <DndWrapper id="file-browser-panel">
-        <DropArea />
-      </DndWrapper>
+      <div id="file-browser-panel">
+        <DndWrapper id="file-browser-panel">
+          <DropArea />
+        </DndWrapper>
+      </div>
 
       <ContextMenu open={open} anchorEl={anchorEl.value} anchorPosition={anchorPosition.value} onClose={handleClose}>
         <MenuItem onClick={createNewFolder}>{t('editor:layout.filebrowser.addNewFolder')}</MenuItem>

--- a/packages/editor/src/components/assets/ProjectBrowserPanel.tsx
+++ b/packages/editor/src/components/assets/ProjectBrowserPanel.tsx
@@ -29,6 +29,8 @@ import React from 'react'
 import { AssetSelectionChangePropsType, AssetsPreviewPanel } from './AssetsPreviewPanel'
 import FileBrowserContentPanel from './FileBrowserContentPanel'
 
+import { getMutableState } from '@etherealengine/hyperflux'
+import { EditorState } from '../../services/EditorServices'
 import { DockContainer } from '../EditorContainer'
 
 /**
@@ -37,7 +39,7 @@ import { DockContainer } from '../EditorContainer'
  */
 export default function ProjectBrowserPanel() {
   const assetsPreviewPanelRef = React.useRef()
-
+  const projectName = getMutableState(EditorState).projectName.value
   const onLayoutChangedCallback = () => {
     ;(assetsPreviewPanelRef as any).current?.onLayoutChanged?.()
   }
@@ -59,7 +61,12 @@ export default function ProjectBrowserPanel() {
                 {
                   id: 'filesPanel',
                   title: 'Project Files',
-                  content: <FileBrowserContentPanel onSelectionChanged={onSelectionChanged} />
+                  content: (
+                    <FileBrowserContentPanel
+                      selectedFile={projectName ?? undefined}
+                      onSelectionChanged={onSelectionChanged}
+                    />
+                  )
                 }
               ]
             }


### PR DESCRIPTION
## Summary

basically the file browser with the dnd logic was creating the div with id after checking for it in the DOM ( it wouldn't exist if you are checking for it before you created it !!!), 
in the studio we render/create everything on layout on startup before we open the files panel 

 in the admin panel the files are only rendered/created when drawer is created so the panel doesn't already exist 


fixed by simply wrapping the Dnd wrapper with a div element with the proper id.


also, in the studio we don't start off in the directory for the project we are working on, so i fixed that. 
## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

