### PR TITLE
Fixing some $like searches on projects

### DIFF
--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -496,7 +496,7 @@ export const checkProjectDestinationMatch = async (
     const projectExists = await app.service(projectPath).find({
       query: {
         name: {
-          $like: '%' + sourceContent.name + '%'
+          $like: sourceContent.name
         }
       }
     })
@@ -1468,7 +1468,7 @@ export const updateProject = async (
   const existingProjectResult = await app.service(projectPath)._find({
     query: {
       name: {
-        $like: `%${projectName}%`
+        $like: projectName
       }
     }
   })

--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -194,7 +194,7 @@ export class ProjectService<T = ProjectType, ServiceParams extends Params = Proj
         const result = (await super._find({
           query: {
             name: {
-              $like: `${projectName}%`
+              $like: projectName
             }
           }
         })) as Paginated<ProjectType>


### PR DESCRIPTION
## Summary

Some functions that were searching on project names via $like: %<name>% were returning hits that it shouldn't have gotten, e.g. finds on `project-name` getting hits on projects `project-name` and `project-name-avatars`. If the bad hits happened to come first in the array because their ID happened to come first, this would result in unwanted behavior like patching the wrong project.

Removed the %'s in these queries, which match additional characters. We only use $like for case-insensitivity purposes.


## References

closes #8694 


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

