### PR TITLE
Fix skinned mesh lag spikes

### DIFF
--- a/packages/editor/src/components/properties/ModelNodeEditor.tsx
+++ b/packages/editor/src/components/properties/ModelNodeEditor.tsx
@@ -115,6 +115,7 @@ export const ModelNodeEditor: EditorComponentType = (props) => {
         <BooleanInput
           value={modelComponent.generateBVH.value}
           onChange={updateProperty(ModelComponent, 'generateBVH')}
+          disabled={modelComponent.hasSkinnedMesh.value}
         />
       </InputGroup>
       <InputGroup name="Avoid Camera Occlusion" label={t('editor:properties.model.lbl-avoidCameraOcclusion')}>

--- a/packages/engine/src/scene/components/ModelComponent.ts
+++ b/packages/engine/src/scene/components/ModelComponent.ts
@@ -24,7 +24,7 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { useEffect } from 'react'
-import { Mesh, Scene } from 'three'
+import { Mesh, Scene, SkinnedMesh } from 'three'
 
 import { getState } from '@etherealengine/hyperflux'
 
@@ -52,6 +52,7 @@ import { addError, removeError } from '../functions/ErrorFunctions'
 import { generateMeshBVH } from '../functions/bvhWorkerPool'
 import { parseGLTFModel } from '../functions/loadGLTFModel'
 import { enableObjectLayer } from '../functions/setObjectLayers'
+import iterateObject3D from '../util/iterateObject3D'
 import { GroupComponent, addObjectToGroup, removeObjectFromGroup } from './GroupComponent'
 import { SceneAssetPendingTagComponent } from './SceneAssetPendingTagComponent'
 import { SceneObjectComponent } from './SceneObjectComponent'
@@ -83,7 +84,8 @@ export const ModelComponent = defineComponent({
       avoidCameraOcclusion: false,
       // internal
       scene: null as Scene | null,
-      asset: null as VRM | GLTF | null
+      asset: null as VRM | GLTF | null,
+      hasSkinnedMesh: false
     }
   },
 
@@ -206,7 +208,16 @@ function ModelReactor() {
 
     let active = true
 
-    if (model.generateBVH) {
+    const skinnedMeshSearch = iterateObject3D(
+      scene,
+      () => true,
+      (ob: SkinnedMesh) => ob.isSkinnedMesh,
+      false,
+      true
+    )
+    if (skinnedMeshSearch[0]) modelComponent.hasSkinnedMesh.set(true)
+
+    if (model.generateBVH && !model.hasSkinnedMesh) {
       enableObjectLayer(scene, ObjectLayers.Camera, false)
       const bvhDone = [] as Promise<void>[]
       scene.traverse((obj: Mesh) => {

--- a/packages/engine/src/scene/components/ModelComponent.ts
+++ b/packages/engine/src/scene/components/ModelComponent.ts
@@ -215,9 +215,12 @@ function ModelReactor() {
       false,
       true
     )
-    if (skinnedMeshSearch[0]) modelComponent.hasSkinnedMesh.set(true)
+    if (skinnedMeshSearch[0]) {
+      modelComponent.hasSkinnedMesh.set(true)
+      modelComponent.generateBVH.set(false)
+    }
 
-    if (model.generateBVH && !model.hasSkinnedMesh) {
+    if (model.generateBVH) {
       enableObjectLayer(scene, ObjectLayers.Camera, false)
       const bvhDone = [] as Promise<void>[]
       scene.traverse((obj: Mesh) => {


### PR DESCRIPTION
## Summary

Fixes cases of skinned mesh lag spikes by disabling bvh generation and all following logic that enables threejs raycast layers for camera occlusion.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

