### PR TITLE
Prevent asset load errors from blocking scene loading

### DIFF
--- a/packages/engine/src/scene/components/ModelComponent.ts
+++ b/packages/engine/src/scene/components/ModelComponent.ts
@@ -181,6 +181,10 @@ function ModelReactor() {
                   totalAmount: onprogress.total
                 }
               })
+            },
+            (err) => {
+              console.error(err)
+              removeComponent(entity, SceneAssetPendingTagComponent)
             }
           )
           break


### PR DESCRIPTION
When an asset fails to load, this PR allows the scene to continue loading in spite of the missing asset. An error is printed in the console. 