### PR TITLE
Split Shadow Node Editor from Model Node Editor

### DIFF
--- a/packages/editor/src/components/properties/ModelNodeEditor.tsx
+++ b/packages/editor/src/components/properties/ModelNodeEditor.tsx
@@ -44,7 +44,6 @@ import ErrorPopUp from '../popup/ErrorPopUp'
 import ModelTransformProperties from './ModelTransformProperties'
 import NodeEditor from './NodeEditor'
 import ScreenshareTargetNodeEditor from './ScreenshareTargetNodeEditor'
-import ShadowProperties from './ShadowProperties'
 import { EditorComponentType, updateProperty } from './Util'
 
 /**
@@ -124,7 +123,6 @@ export const ModelNodeEditor: EditorComponentType = (props) => {
         />
       </InputGroup>
       <ScreenshareTargetNodeEditor entity={props.entity} multiEdit={props.multiEdit} />
-      <ShadowProperties entity={props.entity} />
       <ModelTransformProperties modelState={modelComponent} onChangeModel={(val) => modelComponent.src.set(val)} />
       {!exporting.value && modelComponent.src.value && (
         <Well>

--- a/packages/editor/src/components/properties/ShadowProperties.tsx
+++ b/packages/editor/src/components/properties/ShadowProperties.tsx
@@ -26,7 +26,7 @@ Ethereal Engine. All Rights Reserved.
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { hasComponent, useComponent } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
+import { useComponent } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
 import { ShadowComponent } from '@etherealengine/engine/src/scene/components/ShadowComponent'
 
 import BooleanInput from '../inputs/BooleanInput'
@@ -41,7 +41,6 @@ import { EditorComponentType, updateProperty } from './Util'
  */
 export const ShadowProperties: EditorComponentType = (props) => {
   const { t } = useTranslation()
-  if (!hasComponent(props.entity, ShadowComponent)) return <></>
   const shadowComponent = useComponent(props.entity, ShadowComponent)
   return (
     <NodeEditor

--- a/packages/editor/src/functions/ComponentEditors.tsx
+++ b/packages/editor/src/functions/ComponentEditors.tsx
@@ -77,6 +77,7 @@ import HemisphereLightNodeEditor from '../components/properties/HemisphereLightN
 import ImageNodeEditor from '../components/properties/ImageNodeEditor'
 // import InstancingNodeEditor from '../components/properties/InstancingNodeEditor'
 import { BehaveGraphComponent } from '@etherealengine/engine/src/behave-graph/components/BehaveGraphComponent'
+import { ShadowComponent } from '@etherealengine/engine/src/scene/components/ShadowComponent'
 import BehaveGraphNodeEditor from '../components/properties/BehaveGraphNodeEditor'
 import LoopAnimationNodeEditor from '../components/properties/LoopAnimationNodeEditor'
 import MediaNodeEditor from '../components/properties/MediaNodeEditor'
@@ -93,6 +94,7 @@ import { PrefabNodeEditor } from '../components/properties/PrefabNodeEditor'
 import { RenderSettingsEditor } from '../components/properties/RenderSettingsEditor'
 import SceneNodeEditor from '../components/properties/SceneNodeEditor'
 import ScenePreviewCameraNodeEditor from '../components/properties/ScenePreviewCameraNodeEditor'
+import ShadowProperties from '../components/properties/ShadowProperties'
 import SkyboxNodeEditor from '../components/properties/SkyboxNodeEditor'
 import SpawnPointNodeEditor from '../components/properties/SpawnPointNodeEditor'
 import { SplineNodeEditor } from '../components/properties/SplineNodeEditor'
@@ -119,6 +121,7 @@ EntityNodeEditor.set(PointLightComponent, PointLightNodeEditor)
 EntityNodeEditor.set(SpotLightComponent, SpotLightNodeEditor)
 EntityNodeEditor.set(GroundPlaneComponent, GroundPlaneNodeEditor)
 EntityNodeEditor.set(ModelComponent, ModelNodeEditor)
+EntityNodeEditor.set(ShadowComponent, ShadowProperties)
 EntityNodeEditor.set(LoopAnimationComponent, LoopAnimationNodeEditor)
 EntityNodeEditor.set(ParticleSystemComponent, ParticleSystemNodeEditor)
 EntityNodeEditor.set(PortalComponent, PortalNodeEditor)


### PR DESCRIPTION
Before we had the ShadowProperties.tsx only rendered from within the ModelNodeEditor.tsx. When deleting the Shadow Component, the ModelNodeEditor would throw an error about having a different number of hooks than before. This is resolved by decoupling the Shadow and Model editors from each other
