### PR TITLE
Changes for services to use feathers 5 & its features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Ethereal Engine logo](https://user-images.githubusercontent.com/5104160/181167947-2cf42b34-7dd6-4e71-b840-c25b8cf850e6.png)
 
->  Manifest your dreams on the open social spatial web.
+> Manifest your dreams on the open social spatial web.
 
 ## Table of Contents
 

--- a/packages/server-core/src/sequelize.ts
+++ b/packages/server-core/src/sequelize.ts
@@ -106,7 +106,10 @@ export default (app: Application): void => {
           // We are running our migration:rollback here, so that tables in db are dropped 1st using knex.
           // TODO: Once sequelize is removed, we should add migrate:rollback as part of `dev-reinit-db` script in package.json
           await checkLock(knexClient, 0, promiseReject)
+
+          logger.info('Starting migration rollback')
           await knexClient.migrate.rollback(config.migrations, true)
+          logger.info('Ended migration rollback')
         }
 
         await sequelize.query('SET FOREIGN_KEY_CHECKS = 0')
@@ -160,7 +163,10 @@ export default (app: Application): void => {
           // on ta tables that are created using sequelize.
           // TODO: Once sequelize is removed, we should add migration as part of `dev-reinit-db` script in package.json
           await checkLock(knexClient, prepareDb ? 25000 : 0, promiseReject)
+
+          logger.info('Starting migration')
           await knexClient.migrate.latest(config.migrations)
+          logger.info('Ended migration')
         }
 
         try {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7ebb7d0</samp>

### Summary
:memo::wrench::loud_sound:

<!--
1.  :memo: - This emoji is often used for documentation updates, such as fixing typos or improving clarity. Removing an extra space in the README.md file is a minor documentation change that falls under this category.
2. :wrench: - This emoji is often used for configuration or tooling updates, such as adding or modifying scripts, dependencies, or settings. Adding logging messages to `sequelize.ts` is a tooling change that helps developers monitor and debug the migration and rollback process.
3. :loud_sound: - This emoji is often used for adding or updating logs, alerts, or notifications. Adding logging messages to `sequelize.ts` is also a logging change that provides more information and feedback to the console.
-->
This pull request adds logging functionality to the `server-core` package and fixes a minor typo in the `README.md` file. The logging messages help monitor the database migration and rollback process, while the typo correction enhances the documentation quality.

> _Sing, O Muse, of the code that was changed by the skillful developer_
> _Who removed the unwanted space from the README, the guide of the users_
> _As a sculptor who chisels the marble and makes the statue more graceful_
> _So he polished the document and made it more clear and more faithful_

### Walkthrough
*  Added logging messages to track the migration and rollback processes in `sequelize.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/8726/files?diff=unified&w=0#diff-ca65433e34aed36c94f4a70b7a5adcbd9fbe99d52c3e4cd7598c8bd14c8e9da4L109-R112), [link](https://github.com/EtherealEngine/etherealengine/pull/8726/files?diff=unified&w=0#diff-ca65433e34aed36c94f4a70b7a5adcbd9fbe99d52c3e4cd7598c8bd14c8e9da4L163-R169))
*  Removed extra space in `README.md` ([link](https://github.com/EtherealEngine/etherealengine/pull/8726/files?diff=unified&w=0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3))

