### PR TITLE
Add bounding box calculation for avatars

### DIFF
--- a/packages/engine/src/transform/systems/TransformSystem.ts
+++ b/packages/engine/src/transform/systems/TransformSystem.ts
@@ -31,6 +31,7 @@ import { insertionSort } from '@etherealengine/common/src/utils/insertionSort'
 import { getMutableState, getState, none } from '@etherealengine/hyperflux'
 
 import { AnimationComponent } from '../../avatar/components/AnimationComponent'
+import { AvatarComponent } from '../../avatar/components/AvatarComponent'
 import { CameraComponent } from '../../camera/components/CameraComponent'
 import { V_000 } from '../../common/constants/MathConstants'
 import { Engine } from '../../ecs/classes/Engine'
@@ -72,6 +73,7 @@ const groupQuery = defineQuery([GroupComponent, TransformComponent])
 
 const staticBoundingBoxQuery = defineQuery([GroupComponent, BoundingBoxComponent])
 const dynamicBoundingBoxQuery = defineQuery([GroupComponent, BoundingBoxComponent, BoundingBoxDynamicTag])
+const avatarBoundingBoxQuery = defineQuery([AvatarComponent, BoundingBoxComponent])
 
 const distanceFromLocalClientQuery = defineQuery([TransformComponent, DistanceFromLocalClientComponent])
 const distanceFromCameraQuery = defineQuery([TransformComponent, DistanceFromCameraComponent])
@@ -265,6 +267,14 @@ const computeBoundingBox = (entity: Entity) => {
   }
 }
 
+const updateAvatarBoundingBox = (entity: Entity) => {
+  //get avatar model
+  const avatarModel = getComponent(entity, AvatarComponent).model
+  const box = getComponent(entity, BoundingBoxComponent).box
+  box.makeEmpty()
+  if (avatarModel) box.expandByObject(avatarModel)
+}
+
 const updateBoundingBox = (entity: Entity) => {
   const box = getComponent(entity, BoundingBoxComponent).box
   const group = getComponent(entity, GroupComponent)
@@ -391,6 +401,7 @@ const execute = () => {
   for (const entity in TransformComponent.dirtyTransforms) TransformComponent.dirtyTransforms[entity] = false
 
   for (const entity of staticBoundingBoxQuery.enter()) computeBoundingBox(entity)
+  for (const entity of avatarBoundingBoxQuery()) updateAvatarBoundingBox(entity)
   for (const entity of dynamicBoundingBoxQuery()) updateBoundingBox(entity)
 
   const cameraPosition = getComponent(Engine.instance.cameraEntity, TransformComponent).position


### PR DESCRIPTION
## Summary

Fixes avatar bounding boxes not being calculated or updated in the transform system. Paired with bounding box frustum culling, this caused avatar skinned meshes to get incorrectly set as invisible.

## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

