### PR TITLE
Fixed some bugs with the file browser and project paths.

### DIFF
--- a/packages/editor/src/components/assets/FileBrowserContentPanel.tsx
+++ b/packages/editor/src/components/assets/FileBrowserContentPanel.tsx
@@ -243,7 +243,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
     } else {
       await Promise.all(
         data.files.map(async (file) => {
-          if (!file.type) {
+          if (!file.type && !/\.glb$/.test(file.name)) {
             // file is directory
             await FileBrowserService.addNewFolder(`${path}${file.name}`)
           } else {

--- a/packages/server-core/src/media/storageprovider/local.storage.ts
+++ b/packages/server-core/src/media/storageprovider/local.storage.ts
@@ -176,7 +176,7 @@ export class LocalStorage implements StorageProviderInterface {
           reject(e)
         }
       })
-    } else if (data.Body.length > MULTIPART_CUTOFF_SIZE) {
+    } else if (data.Body?.length > MULTIPART_CUTOFF_SIZE) {
       return new Promise<boolean>((resolve, reject) => {
         try {
           const writeableStream = fs.createWriteStream(filePath)

--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -328,7 +328,7 @@ export class S3Provider implements StorageProviderInterface {
         'Content-Type': args.ContentType
       })
       return response
-    } else if (data.Body.length > MULTIPART_CUTOFF_SIZE) {
+    } else if (data.Body?.length > MULTIPART_CUTOFF_SIZE) {
       const multiPartStartArgs = {
         ACL: 'public-read',
         Bucket: this.bucket,

--- a/packages/server-core/src/projects/project/downloadProjects.ts
+++ b/packages/server-core/src/projects/project/downloadProjects.ts
@@ -58,7 +58,10 @@ export const download = async (projectName: string, storageProviderName?: string
       files.map(async (filePath) => {
         logger.info(`[ProjectLoader]: - downloading "${filePath}"`)
         const fileResult = await storageProvider.getObject(filePath)
-        if (fileResult.Body.length === 0) logger.info(`[ProjectLoader]: WARNING file "${filePath}" is empty`)
+        if (fileResult.Body.length === 0) {
+          logger.info(`[ProjectLoader]: WARNING file "${filePath}" is empty`)
+          return
+        }
         writeFileSyncRecursive(path.join(appRootPath.path, 'packages/projects', filePath), fileResult.Body)
       })
     )


### PR DESCRIPTION


## Summary

React-DND does not populate a type for GLBs. This was causing it to make them as folders, which was not correct. Could not figure out where the type was being populated from, so added a hard check on the file name to avoid this.

Large file check on S3 putObject was not accounting for being handed a path with no Body. Made that Body.length check optional to avoid errors. Made that on local putObject as well just in case.

downloadProjects was tying to write files even if their Body had no length, i.e. was a folder, which would error out.

## References

closes #8603 #8752

## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

