### PR TITLE
Purge all commit history from gh-pages before pushing from the "dev" branch.

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -71,6 +71,8 @@ jobs:
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "gh-actions"
+          npm install --legacy-peer-deps
+          git clone https://github.com/etherealengine/etherealengine-docs.git docs
           echo "Starting to remove commit history for gh-pages branch"
           git checkout --orphan temp-gh-pages
           git add -A
@@ -80,8 +82,6 @@ jobs:
           git push origin gh-pages --force
           git branch -D temp-gh-pages
           echo "gh-pages commit history is clean now"
-          npm install --legacy-peer-deps
-          git clone https://github.com/etherealengine/etherealengine-docs.git docs
           cd docs
           cp .env.local.default .env.local
           npm install --legacy-peer-deps

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -82,7 +82,7 @@ jobs:
           git reset --hard temp-gh-pages
           git push origin gh-pages --force
           git branch -D temp-gh-pages
-          echo "gh-pages commit history is clean now"
+          echo "gh-pages commit history has been cleared"
           cd docs
           cp .env.local.default .env.local
           npm install --legacy-peer-deps

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -74,6 +74,7 @@ jobs:
           npm install --legacy-peer-deps
           git clone https://github.com/etherealengine/etherealengine-docs.git docs
           echo "Starting to remove commit history for gh-pages branch"
+          git checkout gh-pages
           git checkout --orphan temp-gh-pages
           git add -A
           git commit -m "Update docs to latest commit only"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -35,7 +35,7 @@ jobs:
       - name: install main repository
         run: npm install --legacy-peer-deps
       - name: clone etherealengine docs
-        run: git clone https://github.com/etherealengine/etherealengine-docs.git docs --depth 1
+        run: git clone https://github.com/etherealengine/etherealengine-docs.git docs
       - name: install docs npm packages
         working-directory: docs
         run: npm install --legacy-peer-deps
@@ -71,8 +71,17 @@ jobs:
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "gh-actions"
+          echo "Starting to remove commit history for gh-pages branch"
+          git checkout --orphan temp-gh-pages
+          git add -A
+          git commit -m "Update docs to latest commit only"
+          git checkout gh-pages
+          git reset --hard temp-gh-pages
+          git push origin gh-pages --force
+          git branch -D temp-gh-pages
+          echo "gh-pages commit history is clean now"
           npm install --legacy-peer-deps
-          git clone https://github.com/etherealengine/etherealengine-docs.git docs --depth 1
+          git clone https://github.com/etherealengine/etherealengine-docs.git docs
           cd docs
           cp .env.local.default .env.local
           npm install --legacy-peer-deps


### PR DESCRIPTION
## Summary

Whenever changes were pushed to the "dev" branch it would build and commit to "etherealengine-docs\gh-pages" branch which was maintaining history of all the commits. Since the frequency of the changes to "dev" branch were pretty high, the commits were piling up in the same branch and this was making the worflow quite slow. Also, it was increasing the size of the repo unnecessarily.


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [x] Changes reviewed by at least 2 approved reviewer


## QA Steps

Monitor the GitHub workflow for documentation and make sure it is clearing commit history for "gh-pages" branch each time the action triggers. 