### PR TITLE
Use dynamic tag instead of avatar query, fix box compute error

### DIFF
--- a/packages/engine/src/avatar/functions/spawnAvatarReceptor.ts
+++ b/packages/engine/src/avatar/functions/spawnAvatarReceptor.ts
@@ -35,7 +35,7 @@ import { Engine } from '../../ecs/classes/Engine'
 import { Entity } from '../../ecs/classes/Entity'
 import { addComponent, getComponent, setComponent } from '../../ecs/functions/ComponentFunctions'
 import { LocalInputTagComponent } from '../../input/components/LocalInputTagComponent'
-import { BoundingBoxComponent } from '../../interaction/components/BoundingBoxComponents'
+import { BoundingBoxComponent, BoundingBoxDynamicTag } from '../../interaction/components/BoundingBoxComponents'
 import { GrabberComponent } from '../../interaction/components/GrabbableComponent'
 import {
   NetworkObjectComponent,
@@ -93,6 +93,8 @@ export const spawnAvatarReceptor = (entityUUID: EntityUUID) => {
 
   addComponent(entity, VisibleComponent, true)
 
+  setComponent(entity, BoundingBoxDynamicTag)
+  setComponent(entity, BoundingBoxComponent)
   setComponent(entity, DistanceFromCameraComponent)
   setComponent(entity, FrustumCullCameraComponent)
 
@@ -117,7 +119,6 @@ export const spawnAvatarReceptor = (entityUUID: EntityUUID) => {
   setComponent(entity, NetworkObjectSendPeriodicUpdatesTag)
 
   setComponent(entity, ShadowComponent)
-  setComponent(entity, BoundingBoxComponent)
   setComponent(entity, GrabberComponent)
 }
 

--- a/packages/engine/src/transform/systems/TransformSystem.ts
+++ b/packages/engine/src/transform/systems/TransformSystem.ts
@@ -31,7 +31,6 @@ import { insertionSort } from '@etherealengine/common/src/utils/insertionSort'
 import { getMutableState, getState, none } from '@etherealengine/hyperflux'
 
 import { AnimationComponent } from '../../avatar/components/AnimationComponent'
-import { AvatarComponent } from '../../avatar/components/AvatarComponent'
 import { CameraComponent } from '../../camera/components/CameraComponent'
 import { V_000 } from '../../common/constants/MathConstants'
 import { Engine } from '../../ecs/classes/Engine'
@@ -73,7 +72,6 @@ const groupQuery = defineQuery([GroupComponent, TransformComponent])
 
 const staticBoundingBoxQuery = defineQuery([GroupComponent, BoundingBoxComponent])
 const dynamicBoundingBoxQuery = defineQuery([GroupComponent, BoundingBoxComponent, BoundingBoxDynamicTag])
-const avatarBoundingBoxQuery = defineQuery([AvatarComponent, BoundingBoxComponent])
 
 const distanceFromLocalClientQuery = defineQuery([TransformComponent, DistanceFromLocalClientComponent])
 const distanceFromCameraQuery = defineQuery([TransformComponent, DistanceFromCameraComponent])
@@ -267,14 +265,6 @@ const computeBoundingBox = (entity: Entity) => {
   }
 }
 
-const updateAvatarBoundingBox = (entity: Entity) => {
-  //get avatar model
-  const avatarModel = getComponent(entity, AvatarComponent).model
-  const box = getComponent(entity, BoundingBoxComponent).box
-  box.makeEmpty()
-  if (avatarModel) box.expandByObject(avatarModel)
-}
-
 const updateBoundingBox = (entity: Entity) => {
   const box = getComponent(entity, BoundingBoxComponent).box
   const group = getComponent(entity, GroupComponent)
@@ -401,7 +391,6 @@ const execute = () => {
   for (const entity in TransformComponent.dirtyTransforms) TransformComponent.dirtyTransforms[entity] = false
 
   for (const entity of staticBoundingBoxQuery.enter()) computeBoundingBox(entity)
-  for (const entity of avatarBoundingBoxQuery()) updateAvatarBoundingBox(entity)
   for (const entity of dynamicBoundingBoxQuery()) updateBoundingBox(entity)
 
   const cameraPosition = getComponent(Engine.instance.cameraEntity, TransformComponent).position


### PR DESCRIPTION
## Summary

Slims down transform system logic for bounding box updates. Replaces avatar specific queries with a dynamic bounding box tag. Fixes computational error with group component world matrix conflicts in the expand bounding box function.


## References

closes #_insert number here_


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

