### PR TITLE
Changed detection of running processes.

### DIFF
--- a/packages/instanceserver/package.json
+++ b/packages/instanceserver/package.json
@@ -54,7 +54,6 @@
     "@google-cloud/agones-sdk": "1.30.0",
     "@swc/core": "1.3.41",
     "cross-env": "7.0.3",
-    "detect-port": "^1.5.1",
     "ffmpeg-static": "^5.1.0",
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
## Summary

detect-port does not detect UDP processes running on a port. Switched to running lsof and searching through its outputs to determine if a port is in use.

## References

closes #8464 


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

