### PR TITLE
Fix the docs workflow while purging git commit history.

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -74,6 +74,7 @@ jobs:
           npm install --legacy-peer-deps
           git clone https://github.com/etherealengine/etherealengine-docs.git docs
           echo "Starting to remove commit history for gh-pages branch"
+          cd docs
           git checkout gh-pages
           git checkout --orphan temp-gh-pages
           git add -A
@@ -83,7 +84,6 @@ jobs:
           git push origin gh-pages --force
           git branch -D temp-gh-pages
           echo "gh-pages commit history has been cleared"
-          cd docs
           cp .env.local.default .env.local
           npm install --legacy-peer-deps
           npm run deploy


### PR DESCRIPTION
## Summary

Route into the "docs" directory before purging commit history. 

## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [x] Changes reviewed by at least 2 approved reviewer