### PR TITLE
fix: projects page empty space and feat: scenes loading

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -25,6 +25,7 @@
   "uploadingSceneMsg": "Uploading scene: {{percentage}}%",
   "envMapError": "Error loading cubemap images {{files}}",
   "lbl-return": "Return",
+  "loadingScenes": "Loading Scenes",
   "menubar": {
     "newScene": "New Scene",
     "saveScene": "Save Scene",

--- a/packages/editor/src/components/assets/ScenesPanel.tsx
+++ b/packages/editor/src/components/assets/ScenesPanel.tsx
@@ -38,6 +38,8 @@ import { dispatchAction, getMutableState, useHookstate } from '@etherealengine/h
 import { MoreVert } from '@mui/icons-material'
 import { ClickAwayListener, IconButton, InputBase, Menu, MenuItem, Paper } from '@mui/material'
 
+import { LoadingCircle } from '@etherealengine/client-core/src/components/LoadingCircle'
+import Typography from '@etherealengine/ui/src/primitives/mui/Typography'
 import { deleteScene, getScenes, renameScene } from '../../functions/sceneFunctions'
 import { EditorState } from '../../services/EditorServices'
 import ErrorDialog from '../dialogs/ErrorDialog'
@@ -63,7 +65,7 @@ export default function ScenesPanel({ loadScene, newScene, toggleRefetchScenes }
   const [activeScene, setActiveScene] = useState<SceneData | null>(null)
   const editorState = useHookstate(getMutableState(EditorState))
   const [DialogComponent, setDialogComponent] = useDialog()
-  const [fetched, setFetch] = useState(false)
+  const [scenesLoading, setScenesLoading] = useState(true)
 
   const [thumbnails, setThumbnails] = useState<Map<string, string>>(new Map<string, string>())
   const fetchItems = async () => {
@@ -74,10 +76,10 @@ export default function ScenesPanel({ loadScene, newScene, toggleRefetchScenes }
         thumbnails.set(data[i].name, ktx2url)
       }
       setScenes(data ?? [])
-      console.log(data)
     } catch (error) {
       logger.error(error, 'Error fetching scenes')
     }
+    setScenesLoading(false)
   }
 
   useEffect(() => {
@@ -173,10 +175,17 @@ export default function ScenesPanel({ loadScene, newScene, toggleRefetchScenes }
             {t(`editor:newScene`)}
           </Button>
         </div>
-        <div className={styles.contentContainer + ' ' + styles.sceneGridContainer}>
-          {scenes.map((scene, i) => {
-            return (
-              <div className={styles.sceneContainer} key={i}>
+        {scenesLoading ? (
+          <div className={styles.loadingContainer}>
+            <div>
+              <LoadingCircle />
+              <Typography className={styles.primaryText}>{t('editor:loadingScenes')}</Typography>
+            </div>
+          </div>
+        ) : (
+          <div className={styles.contentContainer + ' ' + styles.sceneGridContainer}>
+            {scenes.map((scene) => (
+              <div className={styles.sceneContainer} key={scene.name}>
                 <a onClick={(e) => onClickExisting(e, scene)}>
                   <div className={styles.thumbnailContainer}>
                     <img src={thumbnails.get(scene.name)} alt="" crossOrigin="anonymous" />
@@ -210,9 +219,9 @@ export default function ScenesPanel({ loadScene, newScene, toggleRefetchScenes }
                   </div>
                 </a>
               </div>
-            )
-          })}
-        </div>
+            ))}
+          </div>
+        )}
       </div>
       <Menu
         id="menu"

--- a/packages/editor/src/components/assets/styles.module.scss
+++ b/packages/editor/src/components/assets/styles.module.scss
@@ -161,12 +161,22 @@
   }
 }
 
-.container {
+%container {
   height: 100%;
   background: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.container {
+  @extend %container;
+}
+
+.loadingContainer {
+  @extend %container;
+
+  background: transparent;
 }
 
 .error {

--- a/packages/editor/src/components/projects/styles.module.scss
+++ b/packages/editor/src/components/projects/styles.module.scss
@@ -212,6 +212,7 @@
       .listContainer {
         display: flex;
         flex-wrap: wrap;
+        justify-content: center;
         gap: 15px;
 
         .itemContainer {


### PR DESCRIPTION
## Summary

- shows a scenes indicator (similar to file browser) when fetching files
- fixes empty space which appeared like empty column in the projects page

![image](https://github.com/EtherealEngine/etherealengine/assets/55396651/69730ff6-39b2-47ae-a56a-9a7389a95d73)

![image](https://github.com/EtherealEngine/etherealengine/assets/55396651/09837a2a-ee89-4828-9614-438a36c72fc7)

## References

solves part of https://github.com/EtherealEngine/etherealengine/issues/8164


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

