### PR TITLE
Fixed issues with static resource naming.

### DIFF
--- a/packages/server-core/src/media/static-resource/static-resource-helper.ts
+++ b/packages/server-core/src/media/static-resource/static-resource-helper.ts
@@ -61,7 +61,7 @@ export type MediaUploadArguments = {
 
 /**
  * Get the files to upload for a given resource
- * @param data
+ * @param url
  * @param download - if true, will download the file and return it as a buffer, otherwise will return the url
  * @returns
  */
@@ -113,8 +113,7 @@ const absoluteProjectPath = path.join(appRootPath.path, '/packages/projects/proj
 export const isAssetFromProject = (url: string, project: string) => {
   const storageProvider = getStorageProvider()
   const storageProviderPath = path.join(storageProvider.cacheDomain, 'projects/', project)
-  const isFromProject = url.includes(storageProviderPath) || url.includes(path.join(absoluteProjectPath, project))
-  return isFromProject
+  return url.includes(storageProviderPath) || url.includes(path.join(absoluteProjectPath, project))
 }
 
 export const getKeyForAsset = (url: string, project: string, isFromProject: boolean) => {
@@ -126,8 +125,7 @@ export const getKeyForAsset = (url: string, project: string, isFromProject: bool
     .split('/')
     .slice(0, -1)
     .join('/')
-  const key = isFromProject ? `projects/${project}${projectPath}` : `static-resources/${project}/`
-  return key
+  return isFromProject ? `projects/${project}${projectPath}` : `static-resources/${project}/`
 }
 
 /**
@@ -166,14 +164,12 @@ export const addAssetFromProject = async (
 
   const file = await downloadResourceAndMetadata(mainURL, forceDownload)
 
-  const staticResource = await addAssetAsStaticResource(app, file, {
+  return addAssetAsStaticResource(app, file, {
     hash: hash,
     // use key for when downloading the asset, otherwise pass the url directly to be inserted into the database
     path: isFromProject || download ? key : mainURL,
     project
   })
-
-  return staticResource
 }
 
 export const getStats = async (buffer: Buffer | string, mimeType: string): Promise<Record<string, any>> => {
@@ -323,9 +319,7 @@ export const getImageStats = async (
       }
     })
   } else {
-    if (typeof file === 'string') {
-      file = (await (await fetch(file)).arrayBuffer()) as Buffer
-    }
+    if (typeof file === 'string') file = Buffer.from(await (await fetch(file)).arrayBuffer())
     const stream = new Readable()
     stream.push(file)
     stream.push(null)

--- a/packages/server-core/src/media/storageprovider/ipfs.storage.ts
+++ b/packages/server-core/src/media/storageprovider/ipfs.storage.ts
@@ -44,6 +44,9 @@ import {
  * Storage provide class to communicate with InterPlanetary File System (IPFS) using Mutable File System (MFS).
  */
 export class IPFSStorage implements StorageProviderInterface {
+  constructor() {
+    this.getOriginURLs().then((result) => (this.originURLs = result))
+  }
   private _client: IPFSHTTPClient
   private _blobStore: IPFSBlobStore
   private _pathPrefix = '/'
@@ -52,7 +55,8 @@ export class IPFSStorage implements StorageProviderInterface {
   /**
    * Domain address of cache.
    */
-  cacheDomain: string
+  cacheDomain = ''
+  originURLs = [this.cacheDomain]
 
   /**
    * Check if an object exists in the IPFS storage.
@@ -231,6 +235,10 @@ export class IPFSStorage implements StorageProviderInterface {
    */
   async createInvalidation() {
     return Promise.resolve()
+  }
+
+  async getOriginURLs() {
+    return [this.cacheDomain]
   }
 
   async associateWithFunction() {

--- a/packages/server-core/src/media/storageprovider/local.storage.ts
+++ b/packages/server-core/src/media/storageprovider/local.storage.ts
@@ -65,6 +65,8 @@ export class LocalStorage implements StorageProviderInterface {
    */
   cacheDomain = config.server.localStorageProvider
 
+  originURLs = [this.cacheDomain]
+
   /**
    * Constructor of LocalStorage class.
    */
@@ -84,6 +86,7 @@ export class LocalStorage implements StorageProviderInterface {
         stdio: 'inherit'
       })
     }
+    this.getOriginURLs().then((result) => (this.originURLs = result))
   }
 
   /**
@@ -206,6 +209,10 @@ export class LocalStorage implements StorageProviderInterface {
    * @param invalidationItems List of keys.
    */
   createInvalidation = async (): Promise<any> => Promise.resolve()
+
+  async getOriginURLs(): Promise<string[]> {
+    return [this.cacheDomain]
+  }
 
   associateWithFunction = async (): Promise<any> => Promise.resolve()
 
@@ -344,7 +351,7 @@ export class LocalStorage implements StorageProviderInterface {
       res.type = path.extname(res.key).substring(1) // remove '.' from extension
       res.name = path.basename(res.key, '.' + res.type)
       res.size = this._formatBytes(fs.lstatSync(pathString).size)
-      res.url = signedUrl.url + path.sep + signedUrl.fields.Key
+      res.url = signedUrl.url + path.sep + signedUrl.fields.key
     }
 
     return res

--- a/packages/server-core/src/media/storageprovider/storageprovider.interface.ts
+++ b/packages/server-core/src/media/storageprovider/storageprovider.interface.ts
@@ -168,11 +168,15 @@ export interface StorageProviderInterface {
    */
   cacheDomain: string
 
+  originURLs: string[]
+
   /**
    * Invalidate items in the storage provider.
    * @param invalidationItems List of keys.
    */
   createInvalidation(invalidationItems: string[]): Promise<any>
+
+  getOriginURLs(): Promise<string[]>
 
   associateWithFunction(functionARN: string): Promise<any>
 


### PR DESCRIPTION
## Summary

PR #8642 introduced bugs with adding files to scenes, primarily related to resources with the same name. Since the file browser was getting back Cloudfront URLs, it was using those URLs to get metadata about files that were being added as static resources. If a different file had been cached under that Cloudfront URL, then new files that had been renamed could be erroneously marked as being a different file, and would serve up the wrong information.

The solution was to go back to the file browser serving up the S3 URL, and for static resource matching/creation to check if URLs are from one of Cloudfront's origin URLs. File hash generation now uses origin URLs so that cached file information never serves up outdated files. When saving as a new static resource, origin URLs are saved with the cache domain instead.

## References

closes #8670 


## Checklist
- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [x] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd
- [ ] Changes reviewed by at least 2 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

