### PR TITLE
Track Missing Materials in Material Library

### DIFF
--- a/packages/client-core/src/components/Debug/index.tsx
+++ b/packages/client-core/src/components/Debug/index.tsx
@@ -289,7 +289,7 @@ export const Debug = ({ showingStateRef }: { showingStateRef: React.MutableRefOb
         <h1>{t('common:debug.state')}</h1>
         <JSONTree
           data={Engine.instance.store.stateMap}
-          postprocessValue={(v: any) => (v?.value && v?.get(NO_PROXY)) ?? v}
+          postprocessValue={(v: any) => (v?.value && v.get(NO_PROXY)) ?? v}
         />
       </div>
       <ActionsPanel />

--- a/packages/engine/src/assets/exporters/gltf/GLTFExporter.js
+++ b/packages/engine/src/assets/exporters/gltf/GLTFExporter.js
@@ -1391,7 +1391,7 @@ export class GLTFWriter {
 			sampler: this.processSampler( map )
 		}
 
-		if ( mimeType === 'image/ktx2' ) {
+		if ( mimeType === 'image/ktx2' || map.isCompressedTexture ) {
 			//textureDef.source = this.processImage( map.mipmaps[0], map.format, map.flipY, mimeType )
 		} else {
 			textureDef.source = this.processImage( map.image, map.format, map.flipY, mimeType )

--- a/packages/engine/src/assets/exporters/gltf/extensions/EEMaterialExporterExtension.ts
+++ b/packages/engine/src/assets/exporters/gltf/extensions/EEMaterialExporterExtension.ts
@@ -36,7 +36,12 @@ export type EEMaterialExtensionType = {
   uuid: string
   name: string
   prototype: string
-  args: { [field: string]: any }
+  args: {
+    [field: string]: {
+      type: string
+      contents: any
+    }
+  }
   plugins: string[]
 }
 
@@ -54,25 +59,23 @@ export default class EEMaterialExporterExtension extends ExporterExtension {
     if (!argData) return
     const result: any = {}
     Object.entries(argData).map(([k, v]) => {
-      switch (v.type) {
-        case 'texture':
-          if (material[k]) {
-            if (k === 'envMap') return //for skipping environment maps which cause errors
-            if ((material[k] as CubeTexture).isCubeTexture) return //for skipping environment maps which cause errors
-            const texture = material[k] as Texture
-            const mapDef = {
-              index: this.writer.processTexture(texture),
-              texCoord: k === 'lightMap' ? 1 : 0
-            }
-            this.writer.options.flipY && (texture.repeat.y *= -1)
-            this.writer.applyTextureTransform(mapDef, texture)
-            result[k] = mapDef
-          } else result[k] = material[k]
-          break
-        default:
-          result[k] = material[k]
-          break
+      const argEntry = {
+        type: v.type,
+        contents: material[k]
       }
+      if (v.type === 'texture' && material[k]) {
+        if (k === 'envMap') return //for skipping environment maps which cause errors
+        if ((material[k] as CubeTexture).isCubeTexture) return //for skipping environment maps which cause errors
+        const texture = material[k] as Texture
+        const mapDef = {
+          index: this.writer.processTexture(texture),
+          texCoord: k === 'lightMap' ? 1 : 0
+        }
+        this.writer.options.flipY && (texture.repeat.y *= -1)
+        this.writer.applyTextureTransform(mapDef, texture)
+        argEntry.contents = mapDef
+      }
+      result[k] = argEntry
     })
     delete materialDef.pbrMetallicRoughness
     delete materialDef.normalTexture

--- a/packages/engine/src/assets/loaders/gltf/GLTFLoader.js
+++ b/packages/engine/src/assets/loaders/gltf/GLTFLoader.js
@@ -3359,7 +3359,7 @@ class GLTFParser {
 
 			if ( ! cachedMaterial ) {
 
-				cachedMaterial = material.clone();
+				cachedMaterial = material//.clone();
 
 				if ( useVertexColors ) cachedMaterial.vertexColors = true;
 				if ( useFlatShading ) cachedMaterial.flatShading = true;

--- a/packages/engine/src/assets/loaders/gltf/extensions/EEMaterialImporterExtension.ts
+++ b/packages/engine/src/assets/loaders/gltf/extensions/EEMaterialImporterExtension.ts
@@ -30,7 +30,8 @@ import { getState } from '@etherealengine/hyperflux'
 import {
   materialIdToDefaultArgs,
   protoIdToFactory,
-  prototypeFromId
+  prototypeFromId,
+  PrototypeNotFoundError
 } from '../../../../renderer/materials/functions/MaterialLibraryFunctions'
 import { MaterialLibraryState } from '../../../../renderer/materials/MaterialLibrary'
 import { EEMaterialExtensionType } from '../../../exporters/gltf/extensions/EEMaterialExporterExtension'
@@ -45,10 +46,19 @@ export class EEMaterialImporterExtension extends ImporterExtension implements GL
     const materialDef = parser.json.materials[materialIndex]
     if (!materialDef.extensions?.[this.name]) return null
     const eeMaterial: EEMaterialExtensionType = materialDef.extensions[this.name]
-    const factory = protoIdToFactory(eeMaterial.prototype)
+    let factory: ((parms: any) => Material) | null = null
+    try {
+      factory = protoIdToFactory(eeMaterial.prototype)
+    } catch (e) {
+      if (e instanceof PrototypeNotFoundError) {
+        console.warn('prototype ' + eeMaterial.prototype + ' not found')
+      } else {
+        throw e
+      }
+    }
     return factory
       ? (function (args) {
-          const material = factory(args)
+          const material = factory!(args)
           typeof eeMaterial.uuid === 'string' && (material.uuid = eeMaterial.uuid)
           return material
         } as unknown as typeof Material)
@@ -64,28 +74,53 @@ export class EEMaterialImporterExtension extends ImporterExtension implements GL
       if (!materialDef.extras) materialDef.extras = {}
       materialDef.extras['plugins'] = extension.plugins
     }
-    const defaultArgs = getState(MaterialLibraryState).materials[extension.uuid]
-      ? materialIdToDefaultArgs(extension.uuid)!
-      : prototypeFromId(extension.prototype).arguments
+    const materialLibrary = getState(MaterialLibraryState)
+    const materialComponent = materialLibrary.materials[extension.uuid]
+    let defaultArgs: { [_: string]: any } = {}
+    let foundPrototype = false
+    if (materialComponent) {
+      foundPrototype = !!materialLibrary.prototypes[materialComponent.prototype]
+      defaultArgs = materialIdToDefaultArgs(extension.uuid)!
+    } else {
+      try {
+        defaultArgs = prototypeFromId(extension.prototype).arguments
+        foundPrototype = true
+      } catch (e) {
+        if (e instanceof PrototypeNotFoundError) {
+          console.warn('prototype ' + extension.prototype + ' not found')
+        } else {
+          throw e
+        }
+      }
+    }
+    if (!foundPrototype) {
+      materialDef.extras = materialDef.extras || {}
+      materialDef.extras['args'] = extension.args
+    }
+    //if we found a prototype, we populate the materialParams as normal.
+    //if we didn't find a prototype, we populate the materialDef.extras.args to hold for later.
+    const parseTarget = foundPrototype ? materialParams : materialDef.extras.args
     return Promise.all(
       Object.entries(extension.args).map(async ([k, v]) => {
-        switch (defaultArgs[k]?.type) {
+        switch (v.type) {
           case undefined:
             break
           case 'texture':
-            if (v) {
-              await parser.assignTexture(materialParams, k, v)
+            if (v.contents) {
+              await parser.assignTexture(parseTarget, k, v.contents)
+            } else {
+              parseTarget[k] = null
             }
             break
           case 'color':
-            if (v && !(v as Color).isColor) {
-              materialParams[k] = new Color(v)
+            if (v.contents !== null && !(v.contents as Color).isColor) {
+              parseTarget[k] = new Color(v.contents)
             } else {
-              materialParams[k] = v
+              parseTarget[k] = v.contents
             }
             break
           default:
-            materialParams[k] = v
+            parseTarget[k] = v.contents
             break
         }
       })

--- a/packages/engine/src/renderer/materials/components/MaterialComponent.ts
+++ b/packages/engine/src/renderer/materials/components/MaterialComponent.ts
@@ -30,10 +30,13 @@ import { MaterialSource } from './MaterialSource'
 
 export type MaterialWithEntity = Material & { entity: Entity }
 
+export type MaterialStatus = 'LOADED' | 'MISSING' | 'UNLOADED'
+
 export type MaterialComponentType = {
   prototype: string
   material: Material
   parameters: { [field: string]: any }
   plugins: string[]
   src: MaterialSource
+  status: MaterialStatus
 }

--- a/packages/engine/src/renderer/materials/systems/MaterialLibrarySystem.tsx
+++ b/packages/engine/src/renderer/materials/systems/MaterialLibrarySystem.tsx
@@ -25,12 +25,13 @@ Ethereal Engine. All Rights Reserved.
 
 import React, { ReactElement, useEffect } from 'react'
 
-import { getMutableState, useState } from '@etherealengine/hyperflux'
+import { NO_PROXY, getMutableState, useState } from '@etherealengine/hyperflux'
 
 import { defineSystem } from '../../../ecs/functions/SystemFunctions'
+import { MaterialLibraryState, initializeMaterialLibrary } from '../MaterialLibrary'
 import { NoiseOffsetSystem } from '../constants/plugins/NoiseOffsetPlugin'
+import { protoIdToFactory, registerMaterial, replaceMaterial } from '../functions/MaterialLibraryFunctions'
 import { applyMaterialPlugin, removeMaterialPlugin } from '../functions/MaterialPluginFunctions'
-import { initializeMaterialLibrary, MaterialLibraryState } from '../MaterialLibrary'
 
 function MaterialReactor({ materialId }: { materialId: string }) {
   const materialLibrary = useState(getMutableState(MaterialLibraryState))
@@ -65,6 +66,27 @@ function reactor(): ReactElement {
   }, [])
 
   const materialLibrary = useState(getMutableState(MaterialLibraryState))
+
+  useEffect(() => {
+    const materialIds = materialLibrary.materials.keys
+    for (const materialId of materialIds) {
+      const component = materialLibrary.materials[materialId]
+      //if the material is missing, check if its prototype is present now
+      if (component.status.value === 'MISSING' && !!materialLibrary.prototypes[component.prototype.value]) {
+        //if the prototype is present, create the material
+        const material = component.material.get(NO_PROXY)
+        const parms = material.userData.args
+        const factory = protoIdToFactory(component.prototype.value)
+        const newMaterial = factory(parms)
+        replaceMaterial(material, newMaterial)
+        newMaterial.uuid = material.uuid
+        newMaterial.userData = material.userData
+        delete newMaterial.userData.args
+        registerMaterial(newMaterial, component.src.value)
+      }
+    }
+  }, [materialLibrary.prototypes])
+
   const plugins = materialLibrary.plugins
   return (
     <>

--- a/packages/engine/src/renderer/materials/systems/MaterialLibrarySystem.tsx
+++ b/packages/engine/src/renderer/materials/systems/MaterialLibrarySystem.tsx
@@ -30,7 +30,12 @@ import { NO_PROXY, getMutableState, useState } from '@etherealengine/hyperflux'
 import { defineSystem } from '../../../ecs/functions/SystemFunctions'
 import { MaterialLibraryState, initializeMaterialLibrary } from '../MaterialLibrary'
 import { NoiseOffsetSystem } from '../constants/plugins/NoiseOffsetPlugin'
-import { protoIdToFactory, registerMaterial, replaceMaterial } from '../functions/MaterialLibraryFunctions'
+import {
+  protoIdToFactory,
+  registerMaterial,
+  replaceMaterial,
+  unregisterMaterial
+} from '../functions/MaterialLibraryFunctions'
 import { applyMaterialPlugin, removeMaterialPlugin } from '../functions/MaterialPluginFunctions'
 
 function MaterialReactor({ materialId }: { materialId: string }) {
@@ -79,10 +84,12 @@ function reactor(): ReactElement {
         const factory = protoIdToFactory(component.prototype.value)
         const newMaterial = factory(parms)
         replaceMaterial(material, newMaterial)
-        newMaterial.uuid = material.uuid
         newMaterial.userData = material.userData
         delete newMaterial.userData.args
-        registerMaterial(newMaterial, component.src.value)
+        const comp = component.get(NO_PROXY)
+        const src = JSON.parse(JSON.stringify(component.src.value))
+        registerMaterial(newMaterial, src)
+        unregisterMaterial(material)
       }
     }
   }, [materialLibrary.prototypes])

--- a/packages/engine/src/scene/systems/SceneObjectSystem.tsx
+++ b/packages/engine/src/scene/systems/SceneObjectSystem.tsx
@@ -104,7 +104,7 @@ export function setupObject(obj: Object3DWithEntity, forceBasicMaterials = false
 
         child.material = nuMaterial
         child.userData.lastMaterial = prevMaterial
-        prevMatEntry && registerMaterial(nuMaterial, prevMatEntry.src)
+        prevMatEntry && registerMaterial(nuMaterial, prevMatEntry.src, prevMatEntry.parameters)
       }
       // normalTexture.dispose()
     }

--- a/packages/server-core/src/assets/extensions/EE_MaterialTransformer.ts
+++ b/packages/server-core/src/assets/extensions/EE_MaterialTransformer.ts
@@ -36,13 +36,16 @@ import {
   WriterContext
 } from '@gltf-transform/core'
 
-import { prototypeFromId } from '@etherealengine/engine/src/renderer/materials/functions/MaterialLibraryFunctions'
-import { initializeMaterialLibrary } from '@etherealengine/engine/src/renderer/materials/MaterialLibrary'
 import { KHRTextureTransform } from '@gltf-transform/extensions'
 
 const EXTENSION_NAME = 'EE_material'
 
-interface IEEMaterialArgs extends IProperty {
+interface IEEArgEntry extends IProperty {
+  type: string
+  contents: any
+}
+
+interface IEEArgs extends IProperty {
   [field: string]: any
 }
 
@@ -54,21 +57,35 @@ interface IEEMaterial extends IProperty {
   plugins: string[]
 }
 
+interface EEArgsDef {
+  type?: string
+  contents?: any
+}
+
+interface EEArgs {
+  [field: string]: EEArgsDef
+}
+
 interface EEMaterialDef {
   uuid?: string
   name?: string
   prototype?: string
-  args?: Record<string, any>
+  args?: EEArgs
   plugins?: string[]
 }
 
-export class EEMaterialArgs extends Property<IEEMaterialArgs> {
-  public declare propertyType: 'EEMaterial-Arguments'
-  protected init(): Nullable<IEEMaterialArgs> {
-    return {
-      name: '',
+export class EEMaterialArgs extends Property<IEEArgs> {
+  public declare propertyType: 'EEMaterialArgs'
+  public declare parentTypes: ['EEMaterial']
+  protected init(): void {
+    this.propertyType = 'EEMaterialArgs'
+    this.parentTypes = ['EEMaterial']
+  }
+
+  protected getDefaults(): Nullable<IEEArgs> {
+    return Object.assign(super.getDefaults() as IProperty, {
       extras: {}
-    }
+    })
   }
 
   public getProp(field: string) {
@@ -84,6 +101,37 @@ export class EEMaterialArgs extends Property<IEEMaterialArgs> {
   }
   public setPropRef(field: string, value: any) {
     this.setRef(field, value)
+  }
+}
+
+export class EEArgEntry extends Property<IEEArgEntry> {
+  public declare propertyType: 'EEMaterialArgEntry'
+  public declare parentTypes: ['EEMaterialArgs']
+  protected init(): void {
+    this.propertyType = 'EEMaterialArgEntry'
+    this.parentTypes = ['EEMaterialArgs']
+  }
+
+  protected getDefaults(): Nullable<IEEArgEntry> {
+    return Object.assign(super.getDefaults() as IProperty, {
+      name: '',
+      type: '',
+      contents: null,
+      extras: {}
+    })
+  }
+
+  public get type() {
+    return this.get('type')
+  }
+  public set type(val: string) {
+    this.set('type', val)
+  }
+  public get contents() {
+    return this.get('contents')
+  }
+  public set contents(val) {
+    this.set('contents', val)
   }
 }
 
@@ -146,11 +194,11 @@ export class EEMaterialExtension extends Extension {
   public static readonly EXTENSION_NAME = EXTENSION_NAME
 
   textureInfoMap: Map<string, TextureInfo> = new Map()
-
+  materialInfoMap: Map<string, string[]> = new Map()
   public read(readerContext: ReaderContext): this {
-    initializeMaterialLibrary()
     const materialDefs = readerContext.jsonDoc.json.materials || []
-    let uuidIndex = 0
+    let textureUuidIndex = 0
+    let materialUuidIndex = 0
     materialDefs.map((def, idx) => {
       if (def.extensions?.[EXTENSION_NAME]) {
         const eeMaterial = new EEMaterial(this.document.getGraph())
@@ -170,12 +218,15 @@ export class EEMaterialExtension extends Extension {
         if (eeDef.args) {
           //eeMaterial.args = eeDef.args
           const processedArgs = new EEMaterialArgs(this.document.getGraph())
-          const defaultArgs = prototypeFromId(eeDef.prototype!).arguments
-          Object.entries(eeDef.args).map(([field, value]) => {
-            if (!defaultArgs[field]) {
-              return //ignore deprecated fields
-            }
-            if (defaultArgs[field].type === 'texture') {
+          const materialArgsInfo = Object.keys(eeDef.args)
+          const materialUuid = materialUuidIndex.toString()
+          this.materialInfoMap.set(materialUuid, materialArgsInfo)
+          processedArgs.setExtras({ uuid: materialUuid })
+          Object.entries(eeDef.args).map(([field, argDef]) => {
+            const nuArgDef = new EEArgEntry(this.document.getGraph())
+            nuArgDef.type = argDef.type!
+            if (argDef.type === 'texture') {
+              const value = argDef.contents
               const texture = value ? readerContext.textures[value.index] : null
               if (texture) {
                 const textureInfo = new TextureInfo(this.document.getGraph())
@@ -189,14 +240,16 @@ export class EEMaterialExtension extends Extension {
                   extensionData.texCoord && transform.setTexCoord(extensionData.texCoord)
                   textureInfo.setExtension('KHR_texture_transform', transform)
                 }
-                const uuid = uuidIndex.toString()
-                uuidIndex++
+                const uuid = textureUuidIndex.toString()
+                textureUuidIndex++
                 texture.setExtras({ uuid })
                 this.textureInfoMap.set(uuid, textureInfo)
               }
-              processedArgs.setPropRef(field, texture)
+              nuArgDef.contents = texture
+              processedArgs.setPropRef(field, nuArgDef)
             } else {
-              processedArgs.setProp(field, value)
+              nuArgDef.contents = argDef.contents
+              processedArgs.setProp(field, nuArgDef)
             }
           })
           eeMaterial.args = processedArgs
@@ -228,19 +281,29 @@ export class EEMaterialExtension extends Extension {
           const matArgs = eeMaterial.args
           if (matArgs) {
             extensionDef.args = {}
-            const defaultArgs = prototypeFromId(eeMaterial.prototype).arguments
-            Object.entries(defaultArgs).map(([field, value]) => {
+            const materialArgsInfo = this.materialInfoMap.get(matArgs.getExtras().uuid as string)!
+            materialArgsInfo.map((field) => {
+              let value: EEArgEntry
+              try {
+                value = matArgs.getPropRef(field) as EEArgEntry
+              } catch (e) {
+                value = matArgs.getProp(field) as EEArgEntry
+              }
               if (value.type === 'texture') {
-                const texture = matArgs.getPropRef(field) as Texture
+                const argEntry = new EEArgEntry(this.document.getGraph())
+                argEntry.type = 'texture'
+                const texture = value.contents as Texture
                 if (texture) {
                   const uuid = texture.getExtras().uuid as string
                   const textureInfo = this.textureInfoMap.get(uuid)!
-                  extensionDef.args![field] = writerContext.createTextureInfoDef(texture, textureInfo)
+
+                  argEntry.contents = writerContext.createTextureInfoDef(texture, textureInfo)
                 } else {
-                  extensionDef.args![field] = null
+                  argEntry.contents = null
                 }
+                extensionDef.args![field] = argEntry
               } else {
-                extensionDef.args![field] = matArgs.getProp(field)
+                extensionDef.args![field] = value
               }
             })
           }


### PR DESCRIPTION
Before, if a custom material is imported and its prototype is not present, the gltf loader would throw an error.
Now, it creates a placeholder material, stores the deserialized material parameters in the placeholder's userdata, and creates a material component with the status 'MISSING'. Whenever a material prototype is registered in the material library, a reactor now iterates through all materials and checks if any missing materials can now be created. If so, it creates the new material and populates the scene with the no longer missing material.