### PR TITLE
Move scale animation to it's own component, improve spatial input heuristics

### DIFF
--- a/packages/engine/src/input/components/InputComponent.ts
+++ b/packages/engine/src/input/components/InputComponent.ts
@@ -28,6 +28,7 @@ import { useLayoutEffect } from 'react'
 import { Entity } from '../../ecs/classes/Entity'
 import { defineComponent, removeComponent, setComponent, useComponent } from '../../ecs/functions/ComponentFunctions'
 import { useEntityContext } from '../../ecs/functions/EntityFunctions'
+import { AnimateScaleComponent } from '../../renderer/components/AnimateScaleComponent'
 import { HighlightComponent } from '../../renderer/components/HighlightComponent'
 
 export const InputComponent = defineComponent({
@@ -37,7 +38,8 @@ export const InputComponent = defineComponent({
     return {
       /** populated automatically by ClientInputSystem */
       inputSources: [] as Entity[],
-      highlight: true
+      highlight: true,
+      grow: false
       // priority: 0
     }
   },
@@ -46,6 +48,7 @@ export const InputComponent = defineComponent({
     if (!json) return
 
     if (typeof json.highlight === 'boolean') component.highlight.set(json.highlight)
+    if (typeof json.grow === 'boolean') component.grow.set(json.grow)
   },
 
   reactor: () => {
@@ -59,6 +62,14 @@ export const InputComponent = defineComponent({
         removeComponent(entity, HighlightComponent)
       }
     }, [input.inputSources, input.highlight])
+
+    useLayoutEffect(() => {
+      if (!input.inputSources.length || !input.grow.value) return
+      setComponent(entity, AnimateScaleComponent)
+      return () => {
+        removeComponent(entity, AnimateScaleComponent)
+      }
+    }, [input.inputSources, input.grow])
 
     return null
   }

--- a/packages/engine/src/input/systems/ClientInputSystem.ts
+++ b/packages/engine/src/input/systems/ClientInputSystem.ts
@@ -515,8 +515,8 @@ const execute = () => {
             if (distance < hitDistance) {
               assignedInputEntity = entity
               hitDistance = distance
+              break
             }
-            break
           }
         }
       }

--- a/packages/engine/src/renderer/components/AnimateScaleComponent.ts
+++ b/packages/engine/src/renderer/components/AnimateScaleComponent.ts
@@ -1,0 +1,98 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import { useEffect } from 'react'
+import { Vector3 } from 'three'
+
+import { Tween } from '@tweenjs/tween.js'
+import { Entity } from '../../ecs/classes/Entity'
+import {
+  defineComponent,
+  getComponent,
+  removeComponent,
+  setComponent,
+  useComponent
+} from '../../ecs/functions/ComponentFunctions'
+import { useEntityContext } from '../../ecs/functions/EntityFunctions'
+import { TransformComponent } from '../../transform/components/TransformComponent'
+import { TweenComponent } from '../../transform/components/TweenComponent'
+
+export const AnimateScaleComponent = defineComponent({
+  name: 'AnimateScaleComponent',
+
+  onInit(entity) {
+    return {
+      multiplier: 1.05
+    }
+  },
+
+  onSet(entity, component, json) {
+    if (!json) return
+
+    if (typeof json.multiplier === 'number') component.multiplier.set(json.multiplier)
+  },
+
+  reactor: function () {
+    const entity = useEntityContext()
+
+    const sizeMultiplier = useComponent(entity, AnimateScaleComponent).multiplier
+
+    useEffect(() => {
+      const transformComponent = getComponent(entity, TransformComponent)
+      const originalScale = transformComponent.scale.clone()
+
+      animateScale(entity, originalScale.clone().multiplyScalar(sizeMultiplier.value), true)
+
+      return () => {
+        animateScale(entity, originalScale, false)
+      }
+    }, [])
+
+    return null
+  }
+})
+
+const animateScale = (entity: Entity, newScale: Vector3, grow: boolean) => {
+  const highlight = { scaler: 0 }
+  const scale = getComponent(entity, TransformComponent).scale
+  setComponent(
+    entity,
+    TweenComponent,
+    new Tween<any>(highlight)
+      .to(
+        {
+          scaler: 1
+        },
+        300
+      )
+      .onUpdate(() => {
+        scale.lerp(newScale, highlight.scaler)
+      })
+      .start()
+      .onComplete(() => {
+        removeComponent(entity, TweenComponent)
+      })
+  )
+}

--- a/packages/engine/src/renderer/components/HighlightComponent.ts
+++ b/packages/engine/src/renderer/components/HighlightComponent.ts
@@ -30,13 +30,7 @@ import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
 
 import { Tween } from '@tweenjs/tween.js'
 import { Entity } from '../../ecs/classes/Entity'
-import {
-  defineComponent,
-  getComponent,
-  removeComponent,
-  setComponent,
-  useComponent
-} from '../../ecs/functions/ComponentFunctions'
+import { defineComponent, removeComponent, setComponent, useComponent } from '../../ecs/functions/ComponentFunctions'
 import { useEntityContext } from '../../ecs/functions/EntityFunctions'
 import { GroupComponent } from '../../scene/components/GroupComponent'
 import { TweenComponent } from '../../transform/components/TweenComponent'
@@ -79,7 +73,8 @@ export const HighlightComponent = defineComponent({
 
 const animateScale = (entity: Entity, obj: Mesh, grow: boolean) => {
   const highlight = { scaler: 0 }
-  const tween = getComponent(entity, TweenComponent)
+  const objscale = obj.scale.clone().add(new Vector3(-0.05, -0.05, -0.05))
+  const targetSacle = obj.scale.clone().add(new Vector3(0.05, 0.05, 0.05))
   setComponent(
     entity,
     TweenComponent,
@@ -91,7 +86,7 @@ const animateScale = (entity: Entity, obj: Mesh, grow: boolean) => {
         300
       )
       .onUpdate(() => {
-        const v = grow ? new Vector3(1.05, 1.05, 1.05) : new Vector3(1, 1, 1)
+        const v = grow ? targetSacle : objscale
         obj.scale.lerp(v, highlight.scaler)
       })
       .start()

--- a/packages/engine/src/renderer/components/HighlightComponent.ts
+++ b/packages/engine/src/renderer/components/HighlightComponent.ts
@@ -24,16 +24,13 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { useEffect } from 'react'
-import { Mesh, Vector3 } from 'three'
+import { Mesh } from 'three'
 
 import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
 
-import { Tween } from '@tweenjs/tween.js'
-import { Entity } from '../../ecs/classes/Entity'
-import { defineComponent, removeComponent, setComponent, useComponent } from '../../ecs/functions/ComponentFunctions'
+import { defineComponent, useComponent } from '../../ecs/functions/ComponentFunctions'
 import { useEntityContext } from '../../ecs/functions/EntityFunctions'
 import { GroupComponent } from '../../scene/components/GroupComponent'
-import { TweenComponent } from '../../transform/components/TweenComponent'
 import { RendererState } from '../RendererState'
 import { EngineRenderer, PostProcessingSettingsState } from '../WebGLRendererSystem'
 
@@ -53,7 +50,6 @@ export const HighlightComponent = defineComponent({
         object.traverse((obj) => {
           if (obj.type !== 'Mesh') return
           addToSelection(obj as Mesh)
-          animateScale(entity, obj as Mesh, true)
         })
       }
       return () => {
@@ -61,7 +57,6 @@ export const HighlightComponent = defineComponent({
           object.traverse((obj) => {
             if (obj.type !== 'Mesh') return
             removeFromSelection(obj as Mesh)
-            animateScale(entity, obj as Mesh, false)
           })
         }
       }
@@ -70,31 +65,6 @@ export const HighlightComponent = defineComponent({
     return null
   }
 })
-
-const animateScale = (entity: Entity, obj: Mesh, grow: boolean) => {
-  const highlight = { scaler: 0 }
-  const objscale = obj.scale.clone().add(new Vector3(-0.05, -0.05, -0.05))
-  const targetSacle = obj.scale.clone().add(new Vector3(0.05, 0.05, 0.05))
-  setComponent(
-    entity,
-    TweenComponent,
-    new Tween<any>(highlight)
-      .to(
-        {
-          scaler: 1
-        },
-        300
-      )
-      .onUpdate(() => {
-        const v = grow ? targetSacle : objscale
-        obj.scale.lerp(v, highlight.scaler)
-      })
-      .start()
-      .onComplete(() => {
-        removeComponent(entity, TweenComponent)
-      })
-  )
-}
 
 const addToSelection = (obj: Mesh) => {
   if (!EngineRenderer.instance.effectComposer?.HighlightEffect) return

--- a/packages/engine/src/scene/components/LinkComponent.ts
+++ b/packages/engine/src/scene/components/LinkComponent.ts
@@ -28,13 +28,15 @@ import { useEffect } from 'react'
 import { getState } from '@etherealengine/hyperflux'
 import { matches } from '../../common/functions/MatchesUtils'
 import { isClient } from '../../common/functions/getEnvironment'
+import { EngineState } from '../../ecs/classes/EngineState'
 import { SceneServices } from '../../ecs/classes/Scene'
 import {
   defineComponent,
   getComponent,
   getOptionalComponent,
   setComponent,
-  useComponent
+  useComponent,
+  useOptionalComponent
 } from '../../ecs/functions/ComponentFunctions'
 import { InputSystemGroup } from '../../ecs/functions/EngineFunctions'
 import { useEntityContext } from '../../ecs/functions/EntityFunctions'
@@ -42,6 +44,7 @@ import { useExecute } from '../../ecs/functions/SystemFunctions'
 import { InputComponent } from '../../input/components/InputComponent'
 import { InputSourceComponent } from '../../input/components/InputSourceComponent'
 import { XRStandardGamepadButton } from '../../input/state/ButtonState'
+import { BoundingBoxComponent } from '../../interaction/components/BoundingBoxComponents'
 import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { XRState } from '../../xr/XRState'
 import { addError, clearErrors } from '../functions/ErrorFunctions'
@@ -85,15 +88,16 @@ export const LinkComponent = defineComponent({
     }
   },
 
-  errors: ['INVALID_URL', 'INVALID_PATH'],
+  errors: ['INVALID_URL'],
 
   reactor: function () {
     if (!isClient) return null
     const entity = useEntityContext()
     const link = useComponent(entity, LinkComponent)
-    const input = useComponent(entity, InputComponent)
+    const input = useOptionalComponent(entity, InputComponent)
 
     useEffect(() => {
+      if (getState(EngineState).isEditor || !input) return
       const canvas = EngineRenderer.instance.renderer.domElement
       if (input.inputSources.length > 0) {
         canvas.style.cursor = 'pointer'
@@ -101,7 +105,7 @@ export const LinkComponent = defineComponent({
       return () => {
         canvas.style.cursor = 'auto'
       }
-    }, [input.inputSources])
+    }, [input?.inputSources])
 
     useEffect(() => {
       clearErrors(entity, LinkComponent)
@@ -115,11 +119,14 @@ export const LinkComponent = defineComponent({
     }, [link.url, link.sceneNav])
 
     useEffect(() => {
-      setComponent(entity, InputComponent)
+      setComponent(entity, BoundingBoxComponent)
+      setComponent(entity, InputComponent, { highlight: true, grow: true })
     }, [])
 
     useExecute(
       () => {
+        if (getState(EngineState).isEditor) return
+
         const linkComponent = getComponent(entity, LinkComponent)
         const inputComponent = getComponent(entity, InputComponent)
         const inputSourceEntity = inputComponent?.inputSources[0]

--- a/packages/engine/src/xrui/functions/createXRUI.tsx
+++ b/packages/engine/src/xrui/functions/createXRUI.tsx
@@ -75,7 +75,7 @@ export function createXRUI<S extends State<any> | null>(UIFunc: React.FC, state 
   setComponent(entity, DistanceFromCameraComponent)
   addComponent(entity, XRUIComponent, container)
   addComponent(entity, VisibleComponent, true)
-  setComponent(entity, InputComponent, { highlight: false })
+  setComponent(entity, InputComponent, { highlight: false, grow: true })
 
   return { entity, state, container }
 }


### PR DESCRIPTION
## Summary
Change the scale animation to just deterministically add or subtract 0.05.

## References
#8830 

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f8b4da8</samp>

*  Added variables to store original and target scales of object to be animated ([link](https://github.com/EtherealEngine/etherealengine/pull/8831/files?diff=unified&w=0#diff-4606d83f1b96fe350b5b6451b3fc6944144defb80b42824992bddd36725b828aL82-R77))
*  Updated scale animation to use the variables instead of hard-coded values ([link](https://github.com/EtherealEngine/etherealengine/pull/8831/files?diff=unified&w=0#diff-4606d83f1b96fe350b5b6451b3fc6944144defb80b42824992bddd36725b828aL94-R89))
*  Removed unused import of `getComponent` ([link](https://github.com/EtherealEngine/etherealengine/pull/8831/files?diff=unified&w=0#diff-4606d83f1b96fe350b5b6451b3fc6944144defb80b42824992bddd36725b828aL33-R33))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f8b4da8</samp>

> _Sing, O Muse, of the skillful refactorer_
> _Who made the `HighlightComponent` shine_
> _With variables for scales, both old and new_
> _Like Hephaestus shaping metal divine_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
