### PR TITLE
Change default shadow resolution for non mobile to 2k

### DIFF
--- a/packages/engine/src/renderer/RendererState.ts
+++ b/packages/engine/src/renderer/RendererState.ts
@@ -45,7 +45,7 @@ export const RendererState = defineState({
     gridVisibility: false,
     gridHeight: 0,
     forceBasicMaterials: false,
-    shadowMapResolution: 256
+    shadowMapResolution: isMobile ? 256 : 2048
   }),
   onCreate: (store, state) => {
     syncStateWithLocalStorage(RendererState, [


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5cc2a7c</samp>

Improved shadow system for mobile and desktop devices. Changed `shadowMapResolution` in `RendererState.ts` to adapt to device capabilities.

## References
closes #8545 

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5cc2a7c</samp>

* Improve shadow rendering system for different devices ([link](https://github.com/EtherealEngine/etherealengine/pull/8832/files?diff=unified&w=0#diff-ad74ed813fbcc09b262933b1e7560104a6580074e406f7fadeb7a3a44788fc85L48-R48))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5cc2a7c</samp>

> _New shadow system_
> _`shadowMapResolution`_
> _Changes with device_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
