### PR TITLE
hot-fix(ci): fix type error in input group

### DIFF
--- a/packages/editor/src/components/inputs/InputGroup.tsx
+++ b/packages/editor/src/components/inputs/InputGroup.tsx
@@ -58,7 +58,7 @@ export const InputGroupContainer = ({ disabled = false, children, ...rest }) => 
 /**
  * Used to provide styles for InputGroupContent div.
  */
-export const InputGroupContent = ({ extraClasses, children }) => (
+export const InputGroupContent = ({ extraClasses = '', children }) => (
   <div className={`input-group-content ${extraClasses}`}>{children}</div>
 )
 


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 87af41e</samp>

Fixed a bug in the `InputGroupContent` component that caused invalid class names. Added a default value for the `extraClasses` prop in `InputGroup.tsx`.

## References

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 87af41e</samp>

*  Added a default value for the `extraClasses` prop of the `InputGroupContent` component to prevent rendering `undefined` as a class name ([link](https://github.com/EtherealEngine/etherealengine/pull/8841/files?diff=unified&w=0#diff-08cb803bdf51ebb9608c62265dfea61a9617e56f6b6224b4bc34fe0931af504aL61-R61))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 87af41e</samp>

> _`extraClasses` prop_
> _avoids undefined class name_
> _cleaner in winter_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
