### PR TITLE
stop behave graph playing studio

### DIFF
--- a/packages/engine/src/behave-graph/systems/BehaveGraphSystem.ts
+++ b/packages/engine/src/behave-graph/systems/BehaveGraphSystem.ts
@@ -25,7 +25,7 @@ Ethereal Engine. All Rights Reserved.
 
 import { Validator, matches } from 'ts-matches'
 
-import { defineAction, defineActionQueue, getMutableState, useHookstate } from '@etherealengine/hyperflux'
+import { defineAction, defineActionQueue, getMutableState, getState, useHookstate } from '@etherealengine/hyperflux'
 
 import { useEffect } from 'react'
 import { EngineState } from '../../ecs/classes/EngineState'
@@ -59,6 +59,8 @@ export const graphQuery = defineQuery([BehaveGraphComponent])
 const executeQueue = defineActionQueue(BehaveGraphActions.execute.matches)
 const stopQueue = defineActionQueue(BehaveGraphActions.stop.matches)
 const execute = () => {
+  if (getState(EngineState).isEditor) return
+
   for (const action of executeQueue()) {
     const entity = action.entity
     if (hasComponent(entity, BehaveGraphComponent)) setComponent(entity, BehaveGraphComponent, { run: true })


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 574abdb</samp>

Improved live editing of behave graph nodes in editor mode. Added an editor mode check in `stopQueue` action of `BehaveGraphSystem.ts`.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 574abdb</samp>

* Imported `getState` function from `@etherealengine/hyperflux` to access global engine state ([link](https://github.com/EtherealEngine/etherealengine/pull/8854/files?diff=unified&w=0#diff-5ddd50c9cfa46916db3f3a0f5b7c2eae5e6e2a303108dd6a930d3b5cdced22fbL28-R28))
* Modified `stopQueue` action to return early if engine is in editor mode ([link](https://github.com/EtherealEngine/etherealengine/pull/8854/files?diff=unified&w=0#diff-5ddd50c9cfa46916db3f3a0f5b7c2eae5e6e2a303108dd6a930d3b5cdced22fbR62-R63))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 574abdb</samp>

> _We're the crew of the behave graph ship, we edit nodes on the fly_
> _We stop the queue when in editor mode, and resume when we're done_
> _Heave away, me hearties, heave away_
> _On the count of three, we'll run the `stopQueue` action_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
