### PR TITLE
refactor(app service): remove action receptors

### DIFF
--- a/packages/client-core/src/common/services/AppService.ts
+++ b/packages/client-core/src/common/services/AppService.ts
@@ -23,8 +23,7 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { matches } from '@etherealengine/engine/src/common/functions/MatchesUtils'
-import { defineAction, defineState, getMutableState, syncStateWithLocalStorage } from '@etherealengine/hyperflux'
+import { defineState, syncStateWithLocalStorage } from '@etherealengine/hyperflux'
 
 export const AppState = defineState({
   name: 'AppState',
@@ -37,32 +36,3 @@ export const AppState = defineState({
     syncStateWithLocalStorage(AppState, ['showTopShelf', 'showBottomShelf'])
   }
 })
-
-export const AppServiceReceptor = (action) => {
-  const s = getMutableState(AppState)
-  matches(action)
-    .when(AppAction.showTopShelf.matches, (action) => {
-      return s.showTopShelf.set(action.show)
-    })
-    .when(AppAction.showBottomShelf.matches, (action) => {
-      return s.showBottomShelf.set(action.show)
-    })
-    .when(AppAction.showTouchPad.matches, (action) => {
-      return s.showTouchPad.set(action.show)
-    })
-}
-
-export class AppAction {
-  static showTopShelf = defineAction({
-    type: 'ee.client.App.SHOW_TOP_SHELF' as const,
-    show: matches.boolean
-  })
-  static showBottomShelf = defineAction({
-    type: 'ee.client.App.SHOW_BOTTOM_SHELF' as const,
-    show: matches.boolean
-  })
-  static showTouchPad = defineAction({
-    type: 'ee.client.App.SHOW_TOUCH_PAD' as const,
-    show: matches.boolean
-  })
-}

--- a/packages/client-core/src/components/ARPlacement/index.tsx
+++ b/packages/client-core/src/components/ARPlacement/index.tsx
@@ -29,10 +29,10 @@ import { useTranslation } from 'react-i18next'
 import { AudioEffectPlayer } from '@etherealengine/engine/src/audio/systems/MediaSystem'
 import { EngineState } from '@etherealengine/engine/src/ecs/classes/EngineState'
 import { XRState } from '@etherealengine/engine/src/xr/XRState'
-import { dispatchAction, getMutableState, useHookstate } from '@etherealengine/hyperflux'
+import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
 import Icon from '@etherealengine/ui/src/primitives/mui/Icon'
 
-import { AppAction } from '../../common/services/AppService'
+import { AppState } from '../../common/services/AppService'
 import { useShelfStyles } from '../Shelves/useShelfStyles'
 import styles from './index.module.scss'
 
@@ -49,8 +49,7 @@ export const ARPlacement = () => {
 
   const place = () => {
     xrState.scenePlacementMode.set(xrState.scenePlacementMode.value === 'placing' ? 'placed' : 'placing')
-    dispatchAction(AppAction.showTopShelf({ show: false }))
-    dispatchAction(AppAction.showBottomShelf({ show: false }))
+    getMutableState(AppState).merge({ showTopShelf: false, showBottomShelf: false })
   }
 
   return (

--- a/packages/client-core/src/components/InstanceChat/index.tsx
+++ b/packages/client-core/src/components/InstanceChat/index.tsx
@@ -46,7 +46,7 @@ import { Close as CloseIcon, Message as MessageIcon } from '@mui/icons-material'
 import Fab from '@mui/material/Fab'
 
 import { messagePath } from '@etherealengine/engine/src/schemas/social/message.schema'
-import { AppAction } from '../../common/services/AppService'
+import { AppState } from '../../common/services/AppService'
 import { AvatarUIActions, AvatarUIState } from '../../systems/state/AvatarUIState'
 import { useUserAvatarThumbnail } from '../../user/functions/useUserAvatarThumbnail'
 import { useShelfStyles } from '../Shelves/useShelfStyles'
@@ -265,9 +265,11 @@ export const InstanceChat = ({
   }, [chatState.messageCreated.value])
 
   const hideOtherMenus = () => {
-    dispatchAction(AppAction.showTopShelf({ show: false }))
-    dispatchAction(AppAction.showBottomShelf({ show: false }))
-    dispatchAction(AppAction.showTouchPad({ show: false }))
+    getMutableState(AppState).merge({
+      showTopShelf: false,
+      showBottomShelf: false,
+      showTouchPad: false
+    })
   }
 
   const toggleChatWindow = () => {
@@ -344,7 +346,7 @@ export const InstanceChat = ({
         onClick={() => {
           chatWindowOpen.set(false)
           unreadMessages.set(false)
-          dispatchAction(AppAction.showTouchPad({ show: true }))
+          getMutableState(AppState).showTouchPad.set(true)
         }}
         className={styles.backdrop + ' ' + (!chatWindowOpen.value ? styles.hideBackDrop : '')}
       ></div>
@@ -432,7 +434,7 @@ export const InstanceChat = ({
                 ) : (
                   <CloseButton
                     onClick={() => {
-                      dispatchAction(AppAction.showTouchPad({ show: true }))
+                      getMutableState(AppState).showTouchPad.set(true)
                     }}
                   />
                 )}

--- a/packages/client-core/src/components/Shelves/index.tsx
+++ b/packages/client-core/src/components/Shelves/index.tsx
@@ -23,21 +23,15 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import React, { useEffect } from 'react'
+import React from 'react'
 
 import { AudioEffectPlayer } from '@etherealengine/engine/src/audio/systems/MediaSystem'
-import {
-  addActionReceptor,
-  dispatchAction,
-  getMutableState,
-  removeActionReceptor,
-  useHookstate
-} from '@etherealengine/hyperflux'
+import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
 import Icon from '@etherealengine/ui/src/primitives/mui/Icon'
 
 import IconButtonWithTooltip from '@etherealengine/ui/src/primitives/mui/IconButtonWithTooltip'
 import { useTranslation } from 'react-i18next'
-import { AppAction, AppServiceReceptor, AppState } from '../../common/services/AppService'
+import { AppState } from '../../common/services/AppService'
 import styles from './index.module.scss'
 
 export const Shelves = () => {
@@ -47,19 +41,12 @@ export const Shelves = () => {
   const showTopShelf = appState.showTopShelf.value
   const showBottomShelf = appState.showBottomShelf.value
 
-  useEffect(() => {
-    addActionReceptor(AppServiceReceptor)
-    return () => {
-      removeActionReceptor(AppServiceReceptor)
-    }
-  }, [])
-
   const handleShowMediaIcons = () => {
-    dispatchAction(AppAction.showTopShelf({ show: !appState.showTopShelf.value }))
+    appState.showTopShelf.set((prevValue) => !prevValue)
   }
 
   const handleShowBottomIcons = () => {
-    dispatchAction(AppAction.showBottomShelf({ show: !appState.showBottomShelf.value }))
+    appState.showBottomShelf.set((prevValue) => !prevValue)
   }
 
   return (


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2657655</samp>

Refactored the state management of several components in the client-core package to use the new `AppService` and `getMutableState` functions instead of `hyperflux` and `dispatchAction`. This simplified the code and eliminated some unnecessary abstractions and imports.

## References
incorporates #8305 

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2657655</samp>

*  Removed unused imports and functions related to the old `AppAction` and `AppServiceReceptor` definitions ([link](https://github.com/EtherealEngine/etherealengine/pull/8857/files?diff=unified&w=0#diff-b6eb8d9b59217dd506fd2e65445760cebd639dd907b9d72d9c551bc35aa89cd1L26-R26), [link](https://github.com/EtherealEngine/etherealengine/pull/8857/files?diff=unified&w=0#diff-b6eb8d9b59217dd506fd2e65445760cebd639dd907b9d72d9c551bc35aa89cd1L40-L68))
*  Replaced `dispatchAction` calls with `getMutableState(AppState).merge` or `getMutableState(AppState).showTouchPad.set` to hide or show the UI elements using the new state management approach ([link](https://github.com/EtherealEngine/etherealengine/pull/8857/files?diff=unified&w=0#diff-64fd26724451e3347ccd9a8e724a02b7f4a1ef2a8fcab8b220a594e4d90638e7L32-R35), [link](https://github.com/EtherealEngine/etherealengine/pull/8857/files?diff=unified&w=0#diff-64fd26724451e3347ccd9a8e724a02b7f4a1ef2a8fcab8b220a594e4d90638e7L52-R52), [link](https://github.com/EtherealEngine/etherealengine/pull/8857/files?diff=unified&w=0#diff-77a6024af510f69a657d6d2e27fdba47b7854be220fcf304a0342b6ff988cb3eL49-R49), [link](https://github.com/EtherealEngine/etherealengine/pull/8857/files?diff=unified&w=0#diff-77a6024af510f69a657d6d2e27fdba47b7854be220fcf304a0342b6ff988cb3eL268-R272), [link](https://github.com/EtherealEngine/etherealengine/pull/8857/files?diff=unified&w=0#diff-77a6024af510f69a657d6d2e27fdba47b7854be220fcf304a0342b6ff988cb3eL347-R349), [link](https://github.com/EtherealEngine/etherealengine/pull/8857/files?diff=unified&w=0#diff-77a6024af510f69a657d6d2e27fdba47b7854be220fcf304a0342b6ff988cb3eL435-R437), [link](https://github.com/EtherealEngine/etherealengine/pull/8857/files?diff=unified&w=0#diff-6a6d49e269b486354018e4e1cef551b639428c3ec556791dcf6a6dd9e629eee7L50-R49))
*  Removed the `useEffect` hook that added and removed the `AppServiceReceptor` in `Shelves` component, as it was no longer needed ([link](https://github.com/EtherealEngine/etherealengine/pull/8857/files?diff=unified&w=0#diff-6a6d49e269b486354018e4e1cef551b639428c3ec556791dcf6a6dd9e629eee7L26-R34), [link](https://github.com/EtherealEngine/etherealengine/pull/8857/files?diff=unified&w=0#diff-6a6d49e269b486354018e4e1cef551b639428c3ec556791dcf6a6dd9e629eee7L50-R49))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2657655</samp>

> _We're cleaning up the code, me hearties, yo ho ho_
> _We're dropping `hyperflux` and `AppAction`, yo ho ho_
> _We're using `AppService` and `getMutableState`, yo ho ho_
> _We're heaving on the ropes on the count of three, yo ho ho_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
