### PR TITLE
fix ios audio

### DIFF
--- a/packages/engine/src/scene/components/MediaComponent.ts
+++ b/packages/engine/src/scene/components/MediaComponent.ts
@@ -240,10 +240,13 @@ export function MediaReactor() {
     // This must be outside of the normal ECS flow by necessity, since we have to respond to user-input synchronously
     // in order to ensure media will play programmatically
     const handleAutoplay = () => {
+      const mediaComponent = getComponent(entity, MediaElementComponent)
       // handle when we dont have autoplay enabled but have programatically started playback
-      if (!media.autoplay.value && !media.paused.value) getComponent(entity, MediaElementComponent)?.element.play()
+      if (!media.autoplay.value && !media.paused.value) mediaComponent?.element.play()
       // handle when we have autoplay enabled but have paused playback
       if (media.autoplay.value && media.paused.value) media.paused.set(false)
+      // handle when we have autoplay and mediaComponent is paused
+      if (media.autoplay.value && !media.paused.value && mediaComponent?.element.paused) mediaComponent.element.play()
       window.removeEventListener('pointerdown', handleAutoplay)
       window.removeEventListener('keypress', handleAutoplay)
       window.removeEventListener('touchstart', handleAutoplay)


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 99d13b6</samp>

Fix autoplay bug and refactor code for media components. The change ensures that media elements play automatically when required and avoids unnecessary calls to `getComponent` in `MediaComponent.ts`.

## References
#8866 

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 99d13b6</samp>

* Fix media autoplay bug and refactor code ([link](https://github.com/EtherealEngine/etherealengine/pull/8867/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cL243-R249))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 99d13b6</samp>

> _`media` resumes_
> _when autoplay is enabled_
> _a bug fix for fall_

## QA Steps
Open on IOS and hear sounds of apartment city

## Checklist

- [x] If this PR is still a WIP, convert to a draft
- [x] When this PR is ready, mark it as "Ready for review"
- [ ] [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- [x] Changes have been manually QA'd 
- [ ] Changes reviewed by at least 2 approved reviewers
