### PR TITLE
Optimize portal data fetching to speed up scene loading

### DIFF
--- a/packages/common/src/interfaces/PortalInterface.ts
+++ b/packages/common/src/interfaces/PortalInterface.ts
@@ -23,7 +23,7 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import type { Euler, Vector3 } from 'three'
+import type { Quaternion, Vector3 } from 'three'
 
 export type PortalDetail = {
   sceneName: string
@@ -31,5 +31,5 @@ export type PortalDetail = {
   portalEntityName: string
   previewImageURL: string
   spawnPosition: Vector3
-  spawnRotation: Euler
+  spawnRotation: Quaternion
 }

--- a/packages/engine/src/scene/components/PortalComponent.ts
+++ b/packages/engine/src/scene/components/PortalComponent.ts
@@ -233,7 +233,6 @@ export const PortalComponent = defineComponent({
       if (linkedPortalExists) {
         /** Portal is in the scene already */
         const portalDetails = getComponent(linkedPortalExists, PortalComponent)
-        // console.log({portalDetails})
         if (portalDetails) applyPortalDetails(portalDetails)
       } else {
         /** Portal is not in the scene yet */

--- a/packages/engine/src/scene/components/PortalComponent.ts
+++ b/packages/engine/src/scene/components/PortalComponent.ts
@@ -47,6 +47,7 @@ import { Engine } from '../../ecs/classes/Engine'
 import {
   ComponentType,
   defineComponent,
+  getComponent,
   hasComponent,
   setComponent,
   useComponent
@@ -61,6 +62,7 @@ import { disposeMaterial } from '../systems/SceneObjectSystem'
 import { setCallback } from './CallbackComponent'
 import { ColliderComponent } from './ColliderComponent'
 import { addObjectToGroup, removeObjectFromGroup } from './GroupComponent'
+import { UUIDComponent } from './UUIDComponent'
 
 export const PortalPreviewTypeSimple = 'Simple' as const
 export const PortalPreviewTypeSpherical = 'Spherical' as const
@@ -202,36 +204,50 @@ export const PortalComponent = defineComponent({
 
     useEffect(() => {
       if (!isClient) return
-      Engine.instance.api
-        .service('portal')
-        .get(portalComponent.linkedPortalId.value)
-        .then((data) => {
-          const portalDetails = data.data!
-          if (portalDetails) {
-            portalComponent.remoteSpawnPosition.value.copy(portalDetails.spawnPosition)
-            portalComponent.remoteSpawnRotation.value.setFromEuler(
-              new Euler(
-                portalDetails.spawnRotation.x,
-                portalDetails.spawnRotation.y,
-                portalDetails.spawnRotation.z,
-                portalDetails.spawnRotation.order
-              )
-            )
-            if (
-              typeof portalComponent.previewImageURL.value !== 'undefined' &&
-              portalComponent.previewImageURL.value !== ''
-            ) {
-              const mesh = portalComponent.mesh.value
-              if (mesh) {
-                AssetLoader.loadAsync(portalDetails.previewImageURL).then((texture: Texture) => {
-                  if (!mesh || !entityExists(entity)) return
-                  mesh.material.map = texture
-                  texture.needsUpdate = true
-                })
-              }
-            }
+      if (!portalComponent.mesh.value) return
+
+      const linkedPortalExists = UUIDComponent.entitiesByUUID[portalComponent.linkedPortalId.value]
+
+      const applyPortalDetails = (portalDetails: {
+        spawnPosition: Vector3
+        spawnRotation: Quaternion
+        previewImageURL: string
+      }) => {
+        portalComponent.remoteSpawnPosition.value.copy(portalDetails.spawnPosition)
+        portalComponent.remoteSpawnRotation.value.copy(portalDetails.spawnRotation)
+        if (
+          typeof portalComponent.previewImageURL.value !== 'undefined' &&
+          portalComponent.previewImageURL.value !== ''
+        ) {
+          const mesh = portalComponent.mesh.value
+          if (mesh) {
+            AssetLoader.loadAsync(portalDetails.previewImageURL).then((texture: Texture) => {
+              if (!mesh || !entityExists(entity)) return
+              mesh.material.map = texture
+              texture.needsUpdate = true
+            })
           }
-        })
+        }
+      }
+
+      if (linkedPortalExists) {
+        /** Portal is in the scene already */
+        const portalDetails = getComponent(linkedPortalExists, PortalComponent)
+        // console.log({portalDetails})
+        if (portalDetails) applyPortalDetails(portalDetails)
+      } else {
+        /** Portal is not in the scene yet */
+        Engine.instance.api
+          .service('portal')
+          .get(portalComponent.linkedPortalId.value, { query: { locationName: portalComponent.location.value } })
+          .then((data) => {
+            const portalDetails = data.data!
+            if (portalDetails) applyPortalDetails(portalDetails)
+          })
+          .catch((e) => {
+            console.error('Error getting portal', e)
+          })
+      }
     }, [portalComponent.previewImageURL, portalComponent.mesh])
 
     return null


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f095a0</samp>

The pull request implements quaternion-based portal rotation and location-aware portal linking for the engine and server packages. It modifies the `PortalInterface` and `PortalComponent` types and the `portal` service to support these features. It also improves type safety and code clarity in `scene-helper.ts`.

## References
closes #8865

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0f095a0</samp>

*  Replace `Euler` with `Quaternion` for portal rotation in `PortalInterface.ts` and `PortalComponent.ts` to simplify logic and avoid errors ([link](https://github.com/EtherealEngine/etherealengine/pull/8870/files?diff=unified&w=0#diff-70b5bcef2844fea1816c76527be5e6552df521a2a690b14b75e0c41f9f4fe48fL26-R26), [link](https://github.com/EtherealEngine/etherealengine/pull/8870/files?diff=unified&w=0#diff-70b5bcef2844fea1816c76527be5e6552df521a2a690b14b75e0c41f9f4fe48fL34-R34), [link](https://github.com/EtherealEngine/etherealengine/pull/8870/files?diff=unified&w=0#diff-c4b2169777135ed957545287ff3c210ade9fff878d78ca870e371fc016f21bb2L205-R250))
*  Import `getComponent` and `UUIDComponent` in `PortalComponent.ts` to access linked portal entity in scene ([link](https://github.com/EtherealEngine/etherealengine/pull/8870/files?diff=unified&w=0#diff-c4b2169777135ed957545287ff3c210ade9fff878d78ca870e371fc016f21bb2R50), [link](https://github.com/EtherealEngine/etherealengine/pull/8870/files?diff=unified&w=0#diff-c4b2169777135ed957545287ff3c210ade9fff878d78ca870e371fc016f21bb2R65))
*  Refactor `useEffect` hook in `PortalComponent.ts` to handle cases when linked portal entity is in scene or not, and fetch portal details from server using `portal` service ([link](https://github.com/EtherealEngine/etherealengine/pull/8870/files?diff=unified&w=0#diff-c4b2169777135ed957545287ff3c210ade9fff878d78ca870e371fc016f21bb2L205-R250))
*  Add location name as query parameter for `portal` service in `scene-helper.ts` and use it to find location and scene data ([link](https://github.com/EtherealEngine/etherealengine/pull/8870/files?diff=unified&w=0#diff-2e0eeeecf852ed2c0b8330b9591ac43fadd33e641f25c0d7671888e1aeec1d6aL37-R42), [link](https://github.com/EtherealEngine/etherealengine/pull/8870/files?diff=unified&w=0#diff-2e0eeeecf852ed2c0b8330b9591ac43fadd33e641f25c0d7671888e1aeec1d6aL52-R70))
*  Import `Application` type in `scene-helper.ts` to replace `any` type for `app` parameter in `getEnvMapBake` function ([link](https://github.com/EtherealEngine/etherealengine/pull/8870/files?diff=unified&w=0#diff-2e0eeeecf852ed2c0b8330b9591ac43fadd33e641f25c0d7671888e1aeec1d6aL63-R77))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0f095a0</samp>

> _Sing, O Muse, of the cunning code review_
> _That changed the portals' shape and motion true_
> _From `Euler` angles, prone to error and strife_
> _To `Quaternion` circles, smooth and full of life_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
