### PR TITLE
Load textures inside worker & return decode duration

### DIFF
--- a/packages/engine/src/assets/loaders/gltf/KTX2Loader.d.ts
+++ b/packages/engine/src/assets/loaders/gltf/KTX2Loader.d.ts
@@ -46,7 +46,7 @@ export class KTX2Loader extends CompressedTextureLoader {
      */
     load(
         url: string,
-        onLoad: (texture: CompressedTexture) => void,
+        onLoad: (texture: CompressedTexture, duration?: number) => void,
         onProgress: (requrest: ProgressEvent<EventTarget>) => void | undefined,
         onError: ((event: ErrorEvent) => void) | undefined
     ): CompressedTexture

--- a/packages/engine/src/assets/loaders/gltf/KTX2Loader.d.ts
+++ b/packages/engine/src/assets/loaders/gltf/KTX2Loader.d.ts
@@ -41,6 +41,9 @@ export class KTX2Loader extends CompressedTextureLoader {
         onError?: (event: ErrorEvent) => void,
     ): KTX2Loader;
 
+    /**
+     * onProgress is not supported. If any function is passed, it will be ignored.
+     */
     load(
         url: string,
         onLoad: (texture: CompressedTexture) => void,


### PR DESCRIPTION
## Summary
All loaders load URL in the main thread. This does not scale with the workerCount, since main thread has to fetch the buffer no matter how many workers in the WorkerPool. This PR aims to alleviate this issue, for KTX2Loader.


## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
