### PR TITLE
Fixed bugs in updateBuilder()

### DIFF
--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -152,42 +152,36 @@ export const updateBuilder = async (
         builderLabelSelector
       )
 
-      if (builderJob && builderJob.body.items.length > 0) {
-        const jobName = builderJob.body.items[0].metadata!.name
-        if (helmSettings && helmSettings.builder && helmSettings.builder.length > 0)
-          await execAsync(
-            `kubectl delete job --ignore-not-found=true ${jobName} && helm repo update && helm upgrade --reuse-values --version ${helmSettings.builder} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
-          )
-        else {
-          const { stdout } = await execAsync(`helm history ${builderDeploymentName} | grep deployed`)
-          const builderChartVersion = BUILDER_CHART_REGEX.exec(stdout)
-          if (builderChartVersion)
-            await execAsync(
-              `kubectl delete job --ignore-not-found=true ${jobName} && helm repo update && helm upgrade --reuse-values --version ${builderChartVersion} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
-            )
-        }
-      } else {
-        const builderDeployments = await k8sAppsClient.listNamespacedDeployment(
-          'default',
-          undefined,
-          false,
-          undefined,
-          undefined,
-          builderLabelSelector
+      const builderDeployments = await k8sAppsClient.listNamespacedDeployment(
+        'default',
+        undefined,
+        false,
+        undefined,
+        undefined,
+        builderLabelSelector
+      )
+
+      const isJob = builderJob && builderJob.body.items.length > 0
+      const isDeployment = builderDeployments && builderDeployments.body.items.length > 0
+
+      if (isJob)
+        await execAsync(`kubectl delete job --ignore-not-found=true ${builderJob.body.items[0].metadata!.name}`)
+      else if (isDeployment)
+        await execAsync(
+          `kubectl delete deployment --ignore-not-found=true ${builderDeployments.body.items[0].metadata!.name}`
         )
-        const deploymentName = builderDeployments.body.items[0].metadata!.name
-        if (helmSettings && helmSettings.builder && helmSettings.builder.length > 0)
+
+      if (helmSettings && helmSettings.builder && helmSettings.builder.length > 0)
+        await execAsync(
+          `helm repo update && helm upgrade --reuse-values --version ${helmSettings.builder} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
+        )
+      else {
+        const { stdout } = await execAsync(`helm history ${builderDeploymentName} | grep deployed`)
+        const builderChartVersion = BUILDER_CHART_REGEX.exec(stdout)![1]
+        if (builderChartVersion)
           await execAsync(
-            `kubectl delete deployment --ignore-not-found=true ${deploymentName} && helm repo update && helm upgrade --reuse-values --version ${helmSettings.builder} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
+            `helm repo update && helm upgrade --reuse-values --version ${builderChartVersion} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
           )
-        else {
-          const { stdout } = await execAsync(`helm history ${builderDeploymentName} | grep deployed`)
-          const builderChartVersion = BUILDER_CHART_REGEX.exec(stdout)
-          if (builderChartVersion)
-            await execAsync(
-              `kubectl delete deployment --ignore-not-found=true ${deploymentName} && helm repo update && helm upgrade --reuse-values --version ${builderChartVersion} --set builder.image.tag=${tag} ${builderDeploymentName} etherealengine/etherealengine-builder`
-            )
-        }
       }
     } catch (err) {
       logger.error(err)


### PR DESCRIPTION
## Summary
Updating builder when Helm version was not set was bugged. It was using the raw call of BUIDLER_CHART_REGEX.exec(stdout), when it should have been using item 1 from the result, which is the actual capture group value, i.e. the version itself.

The above was introducing a buggy state when it failed. The builder job had been deleted, but the upgrade had not succeeded and created a new job. On subsequent calls, since there was no job, it was assuming that the builder was a deployment, and then failing to delete and upgrade the nonexistent deployment. To fix, the deletion of the job/deployment is its own step, and then it performs a common helm upgrade depending on whether or not the version is set in helmSettings.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 91a9e86</samp>

*  Refactored `updateBuilder` function to simplify logic and avoid repetition ([link](https://github.com/EtherealEngine/etherealengine/pull/8879/files?diff=unified&w=0#diff-e3b26c02b27ede7deb0ddbcacfe426dc9775fe1c5d10ca23beb184fe844de111L155-R184))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 91a9e86</samp>

> _`updateBuilder` cleans_
> _deletes and upgrades wisely_
> _autumn leaves no trace_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
