### PR TITLE
introduced PortalState

### DIFF
--- a/packages/client-core/src/components/World/EngineHooks.tsx
+++ b/packages/client-core/src/components/World/EngineHooks.tsx
@@ -49,7 +49,11 @@ import { NetworkState, addNetwork } from '@etherealengine/engine/src/networking/
 import { Network, NetworkTopics, createNetwork } from '@etherealengine/engine/src/networking/classes/Network'
 import { NetworkPeerFunctions } from '@etherealengine/engine/src/networking/functions/NetworkPeerFunctions'
 import { spawnLocalAvatarInWorld } from '@etherealengine/engine/src/networking/functions/receiveJoinWorld'
-import { PortalComponent, PortalEffects } from '@etherealengine/engine/src/scene/components/PortalComponent'
+import {
+  PortalComponent,
+  PortalEffects,
+  PortalState
+} from '@etherealengine/engine/src/scene/components/PortalComponent'
 import { UUIDComponent } from '@etherealengine/engine/src/scene/components/UUIDComponent'
 import { setAvatarToLocationTeleportingState } from '@etherealengine/engine/src/scene/functions/loaders/PortalFunctions'
 import { addOutgoingTopicIfNecessary, dispatchAction, getMutableState, getState } from '@etherealengine/hyperflux'
@@ -172,7 +176,7 @@ export const usePortalTeleport = () => {
   useEffect(() => {
     if (engineState.isTeleporting.value) {
       logger.info('Resetting connection for portal teleport.')
-      const activePortalEntity = Engine.instance.activePortalEntity
+      const activePortalEntity = getState(PortalState).activePortalEntity
 
       if (!activePortalEntity) return
 
@@ -185,7 +189,7 @@ export const usePortalTeleport = () => {
           activePortal.remoteSpawnPosition
           // activePortal.remoteSpawnRotation
         )
-        Engine.instance.activePortalEntity = UndefinedEntity
+        getState(PortalState).activePortalEntity = UndefinedEntity
         dispatchAction(EngineActions.setTeleporting({ isTeleporting: false, $time: Date.now() + 500 }))
         return
       }

--- a/packages/engine/src/ecs/classes/Engine.ts
+++ b/packages/engine/src/ecs/classes/Engine.ts
@@ -141,9 +141,6 @@ export class Engine {
   #entityQuery = defineQuery([Not(EntityRemovedComponent)])
   entityQuery = () => this.#entityQuery() as Entity[]
 
-  // @todo move to EngineState
-  activePortalEntity = UndefinedEntity
-
   systemGroups = {} as {
     input: SystemUUID
     simulation: SystemUUID

--- a/packages/engine/src/scene/components/PortalComponent.ts
+++ b/packages/engine/src/scene/components/PortalComponent.ts
@@ -38,12 +38,13 @@ import {
   Vector3
 } from 'three'
 
-import { getMutableState, none, useHookstate } from '@etherealengine/hyperflux'
+import { defineState, getMutableState, none, useHookstate } from '@etherealengine/hyperflux'
 
 import { AssetLoader } from '../../assets/classes/AssetLoader'
 import { matches } from '../../common/functions/MatchesUtils'
 import { isClient } from '../../common/functions/getEnvironment'
 import { Engine } from '../../ecs/classes/Engine'
+import { UndefinedEntity } from '../../ecs/classes/Entity'
 import {
   ComponentType,
   defineComponent,
@@ -84,6 +85,13 @@ export const portalColliderValues = {
   target: '',
   onEnter: 'teleport'
 }
+
+export const PortalState = defineState({
+  name: 'PortalState',
+  initial: {
+    activePortalEntity: UndefinedEntity
+  }
+})
 
 export const PortalComponent = defineComponent({
   name: 'PortalComponent',

--- a/packages/engine/src/scene/systems/HyperspacePortalSystem.ts
+++ b/packages/engine/src/scene/systems/HyperspacePortalSystem.ts
@@ -46,7 +46,7 @@ import { TransformComponent } from '../../transform/components/TransformComponen
 import { createTransitionState } from '../../xrui/functions/createTransitionState'
 import { PortalEffect } from '../classes/PortalEffect'
 import { HyperspaceTagComponent } from '../components/HyperspaceTagComponent'
-import { PortalComponent, PortalEffects } from '../components/PortalComponent'
+import { PortalComponent, PortalEffects, PortalState } from '../components/PortalComponent'
 import { SceneAssetPendingTagComponent } from '../components/SceneAssetPendingTagComponent'
 import { ObjectLayers } from '../constants/ObjectLayers'
 import { setObjectLayers } from '../functions/setObjectLayers'
@@ -119,7 +119,7 @@ const execute = () => {
         /**
          * hide scene, render just the hyperspace effect and avatar
          */
-        const activePortal = getComponent(Engine.instance.activePortalEntity, PortalComponent)
+        const activePortal = getComponent(getState(PortalState).activePortalEntity, PortalComponent)
         teleportAvatar(Engine.instance.localClientEntity, activePortal!.remoteSpawnPosition, true)
         camera.layers.disable(ObjectLayers.Scene)
         sceneVisible = false


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8bfe89c</samp>

This pull request refactors the portal system to use the Hyperflux library and the PortalState component, instead of the Engine instance, to manage the active portal entity. This improves the integration, consistency, and performance of the portal system across different modules and components. It affects the files `EngineHooks.tsx`, `PortalComponent.ts`, `PortalFunctions.ts`, `HyperspacePortalSystem.ts`, and `Engine.ts`.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8bfe89c</samp>

*  Define and use `PortalState` to store and access the active portal entity instead of `Engine.instance.activePortalEntity` ([link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-4eb5fff26e4a39c8028a97e510c932816f052eff3473dc5b4bfafcfbc4d018d5L52-R56), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-4eb5fff26e4a39c8028a97e510c932816f052eff3473dc5b4bfafcfbc4d018d5L175-R179), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-4eb5fff26e4a39c8028a97e510c932816f052eff3473dc5b4bfafcfbc4d018d5L188-R192), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-f5058824fc8b2d07de7b40700a45b4be45ed166e119171595f90bede67eca1c0L144-L146), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-c4b2169777135ed957545287ff3c210ade9fff878d78ca870e371fc016f21bb2L41-R41), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-c4b2169777135ed957545287ff3c210ade9fff878d78ca870e371fc016f21bb2R47), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-c4b2169777135ed957545287ff3c210ade9fff878d78ca870e371fc016f21bb2R89-R95), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-8f0003ed8efe9c7f950c6e8736def825546c8e9b507da561388e9158edb3940cL26-R26), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-8f0003ed8efe9c7f950c6e8736def825546c8e9b507da561388e9158edb3940cL37-R37), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-8f0003ed8efe9c7f950c6e8736def825546c8e9b507da561388e9158edb3940cL54-R54), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-8f0003ed8efe9c7f950c6e8736def825546c8e9b507da561388e9158edb3940cL63-R63), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-8f0003ed8efe9c7f950c6e8736def825546c8e9b507da561388e9158edb3940cL70-R70), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-085a39f96e4cfd5ad07ca86307dc8d71d197ba172735d93afd731b6422aa7f8eL49-R49), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-085a39f96e4cfd5ad07ca86307dc8d71d197ba172735d93afd731b6422aa7f8eL122-R122))
* Import `UndefinedEntity` from `Entity` module and use it as the initial value of the active portal entity in `PortalState` ([link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-c4b2169777135ed957545287ff3c210ade9fff878d78ca870e371fc016f21bb2R47), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-8f0003ed8efe9c7f950c6e8736def825546c8e9b507da561388e9158edb3940cL63-R63))
* Import `defineState` and `getMutableState` functions from `Hyperflux` library and use them to create and update `PortalState` ([link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-c4b2169777135ed957545287ff3c210ade9fff878d78ca870e371fc016f21bb2L41-R41), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-8f0003ed8efe9c7f950c6e8736def825546c8e9b507da561388e9158edb3940cL26-R26), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-c4b2169777135ed957545287ff3c210ade9fff878d78ca870e371fc016f21bb2R89-R95), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-8f0003ed8efe9c7f950c6e8736def825546c8e9b507da561388e9158edb3940cL63-R63), [link](https://github.com/EtherealEngine/etherealengine/pull/8881/files?diff=unified&w=0#diff-8f0003ed8efe9c7f950c6e8736def825546c8e9b507da561388e9158edb3940cL70-R70))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8bfe89c</samp>

> _`PortalState` shines_
> _Replacing `Engine`'s role_
> _Portal system blooms_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
