### PR TITLE
fix skybox

### DIFF
--- a/packages/engine/src/scene/components/EnvmapComponent.tsx
+++ b/packages/engine/src/scene/components/EnvmapComponent.tsx
@@ -26,6 +26,7 @@ Ethereal Engine. All Rights Reserved.
 import React, { useEffect } from 'react'
 import {
   Color,
+  CubeReflectionMapping,
   CubeTexture,
   DataTexture,
   EquirectangularReflectionMapping,
@@ -50,7 +51,7 @@ import { defineComponent, useComponent } from '../../ecs/functions/ComponentFunc
 import { useEntityContext } from '../../ecs/functions/EntityFunctions'
 import { RendererState } from '../../renderer/RendererState'
 import { EnvMapSourceType, EnvMapTextureType } from '../constants/EnvMapEnum'
-import { getPmremGenerator, getRGBArray, loadCubeMapTexture } from '../constants/Util'
+import { getRGBArray, loadCubeMapTexture } from '../constants/Util'
 import { addError, removeError } from '../functions/ErrorFunctions'
 import { applyBoxProjection, EnvMapBakeComponent } from './EnvMapBakeComponent'
 import { GroupComponent } from './GroupComponent'
@@ -119,8 +120,9 @@ export const EnvmapComponent = defineComponent({
       const texture = new DataTexture(getRGBArray(col), resolution, resolution, RGBAFormat)
       texture.needsUpdate = true
       texture.colorSpace = SRGBColorSpace
+      texture.mapping = EquirectangularReflectionMapping
 
-      updateEnvMap(group.value, getPmremGenerator().fromEquirectangular(texture).texture)
+      updateEnvMap(group.value, texture)
     }, [component.type, group])
 
     useEffect(() => {
@@ -132,7 +134,8 @@ export const EnvmapComponent = defineComponent({
             component.envMapSourceURL.value,
             (texture: CubeTexture | undefined) => {
               if (texture) {
-                const EnvMap = getPmremGenerator().fromCubemap(texture).texture
+                texture.mapping = CubeReflectionMapping
+                const EnvMap = texture
                 EnvMap.colorSpace = SRGBColorSpace
                 if (group?.value) updateEnvMap(group.value, texture)
                 removeError(entity, EnvmapComponent, 'MISSING_FILE')

--- a/packages/engine/src/scene/components/SkyboxComponent.ts
+++ b/packages/engine/src/scene/components/SkyboxComponent.ts
@@ -24,7 +24,14 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { useEffect } from 'react'
-import { Color, CubeTexture, SRGBColorSpace, Texture } from 'three'
+import {
+  Color,
+  CubeReflectionMapping,
+  CubeTexture,
+  EquirectangularReflectionMapping,
+  SRGBColorSpace,
+  Texture
+} from 'three'
 
 import { config } from '@etherealengine/common/src/config'
 import { getMutableState, getState, useHookstate } from '@etherealengine/hyperflux'
@@ -38,7 +45,7 @@ import { RendererState } from '../../renderer/RendererState'
 import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { Sky } from '../classes/Sky'
 import { SkyTypeEnum } from '../constants/SkyTypeEnum'
-import { getPmremGenerator, loadCubeMapTexture } from '../constants/Util'
+import { loadCubeMapTexture } from '../constants/Util'
 import { addError, removeError } from '../functions/ErrorFunctions'
 
 export const SkyboxComponent = defineComponent({
@@ -100,7 +107,8 @@ export const SkyboxComponent = defineComponent({
       if (skyboxState.backgroundType.value !== SkyTypeEnum.cubemap) return
       const onLoad = (texture: CubeTexture) => {
         texture.colorSpace = SRGBColorSpace
-        background.set(getPmremGenerator().fromCubemap(texture).texture)
+        texture.mapping = CubeReflectionMapping
+        background.set(texture)
         removeError(entity, SkyboxComponent, 'FILE_ERROR')
       }
       const loadArgs: [
@@ -124,7 +132,8 @@ export const SkyboxComponent = defineComponent({
         {},
         (texture: Texture) => {
           texture.colorSpace = SRGBColorSpace
-          background.set(getPmremGenerator().fromEquirectangular(texture).texture)
+          texture.mapping = EquirectangularReflectionMapping
+          background.set(texture)
           removeError(entity, SkyboxComponent, 'FILE_ERROR')
         },
         undefined,
@@ -156,9 +165,9 @@ export const SkyboxComponent = defineComponent({
       sky.luminance = skyboxState.skyboxProps.value.luminance
 
       getState(RendererState).csm?.lightDirection.copy(sky.sunPosition).multiplyScalar(-1)
-      background.set(
-        getPmremGenerator().fromCubemap(sky.generateSkyboxTextureCube(EngineRenderer.instance.renderer)).texture
-      )
+      const texture = sky.generateSkyboxTextureCube(EngineRenderer.instance.renderer)
+      texture.mapping = CubeReflectionMapping
+      background.set(texture)
     }, [skyboxState.backgroundType, skyboxState.skyboxProps])
 
     return null

--- a/packages/engine/src/scene/constants/Util.ts
+++ b/packages/engine/src/scene/constants/Util.ts
@@ -23,19 +23,11 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { Color, CompressedTexture, CubeTexture, CubeTextureLoader, PMREMGenerator, TextureLoader } from 'three'
+import { Color, CompressedTexture, CubeTexture, CubeTextureLoader, TextureLoader } from 'three'
 
 import { DDSLoader } from '../../assets/loaders/dds/DDSLoader'
-import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 
 export const textureLoader = new TextureLoader()
-
-let pmremGenerator: PMREMGenerator
-
-export const getPmremGenerator = (): PMREMGenerator => {
-  if (!pmremGenerator) pmremGenerator = new PMREMGenerator(EngineRenderer.instance.renderer)
-  return pmremGenerator
-}
 
 export const getRGBArray = (color: Color): Uint8Array => {
   const resolution = 64 // Min value required


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 961ab31</samp>

This pull request simplifies the texture handling for environment maps and skyboxes in the engine by using the updated features from `three`. It removes the redundant `getPmremGenerator` function and its references from `EnvmapComponent`, `SkyboxComponent`, and `Util`.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 961ab31</samp>

*  Removed `getPmremGenerator` function and import from `Util.ts`, `EnvmapComponent.tsx`, and `SkyboxComponent.ts` as it is no longer needed for texture filtering ([link](https://github.com/EtherealEngine/etherealengine/pull/8884/files?diff=unified&w=0#diff-8b618dbde5a987eebd270e11bbcff42adefdccecbd207ad45401d6d98171cd1bL26-R31), [link](https://github.com/EtherealEngine/etherealengine/pull/8884/files?diff=unified&w=0#diff-c3b5fd77b5cfb8085e215c2bafd90a2727de2d03ad82fe74db17b47605762c7eL53-R54), [link](https://github.com/EtherealEngine/etherealengine/pull/8884/files?diff=unified&w=0#diff-1c322620579d0d7a0760399d4e36f0b5da1a607f07dbd28f25fc30b9627a58c0L41-R48))
*  Set texture mapping mode for cube maps to `CubeReflectionMapping` and updated environment map and background with original textures in `EnvmapComponent.tsx` and `SkyboxComponent.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/8884/files?diff=unified&w=0#diff-c3b5fd77b5cfb8085e215c2bafd90a2727de2d03ad82fe74db17b47605762c7eR29), [link](https://github.com/EtherealEngine/etherealengine/pull/8884/files?diff=unified&w=0#diff-c3b5fd77b5cfb8085e215c2bafd90a2727de2d03ad82fe74db17b47605762c7eL135-R138), [link](https://github.com/EtherealEngine/etherealengine/pull/8884/files?diff=unified&w=0#diff-1c322620579d0d7a0760399d4e36f0b5da1a607f07dbd28f25fc30b9627a58c0L27-R34), [link](https://github.com/EtherealEngine/etherealengine/pull/8884/files?diff=unified&w=0#diff-1c322620579d0d7a0760399d4e36f0b5da1a607f07dbd28f25fc30b9627a58c0L103-R111), [link](https://github.com/EtherealEngine/etherealengine/pull/8884/files?diff=unified&w=0#diff-1c322620579d0d7a0760399d4e36f0b5da1a607f07dbd28f25fc30b9627a58c0L159-R170))
*  Set texture mapping mode for equirectangular maps to `EquirectangularReflectionMapping` and updated environment map and background with original textures in `EnvmapComponent.tsx` and `SkyboxComponent.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/8884/files?diff=unified&w=0#diff-c3b5fd77b5cfb8085e215c2bafd90a2727de2d03ad82fe74db17b47605762c7eL122-R125), [link](https://github.com/EtherealEngine/etherealengine/pull/8884/files?diff=unified&w=0#diff-1c322620579d0d7a0760399d4e36f0b5da1a607f07dbd28f25fc30b9627a58c0L27-R34), [link](https://github.com/EtherealEngine/etherealengine/pull/8884/files?diff=unified&w=0#diff-1c322620579d0d7a0760399d4e36f0b5da1a607f07dbd28f25fc30b9627a58c0L127-R136))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 961ab31</samp>

> _We don't need `getPmremGenerator` anymore_
> _We've got a better way to map the textures_
> _So haul away the old code and the clutter_
> _And let the skybox shine with `three`'s features_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._
