### PR TITLE
fix head decap not working for invalid avatars

### DIFF
--- a/packages/engine/src/avatar/components/AvatarIKComponents.ts
+++ b/packages/engine/src/avatar/components/AvatarIKComponents.ts
@@ -47,11 +47,12 @@ export const AvatarHeadDecapComponent = defineComponent({
     const rig = useOptionalComponent(entity, AvatarRigComponent)
 
     useEffect(() => {
-      if (rig?.value) {
-        if (headDecap?.value) rig.value.vrm.humanoid.rawHumanBones.head.node.scale.setScalar(EPSILON)
-        return () => {
-          rig.value.vrm.humanoid.rawHumanBones.head.node.scale.setScalar(1)
-        }
+      if (!rig?.value?.vrm?.humanoid?.rawHumanBones?.head?.node || !headDecap?.value) return
+
+      rig.value.vrm.humanoid.rawHumanBones.head.node.scale.setScalar(EPSILON)
+
+      return () => {
+        rig.value.vrm.humanoid.rawHumanBones.head.node.scale.setScalar(1)
       }
     }, [headDecap, rig])
 


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00ade88</samp>

Refactored the `useEffect` hook in `AvatarHeadDecapComponent` to prevent errors and improve readability. Added checks for the head node and the headDecap value before scaling the head node.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 00ade88</samp>

*  Refactored the `useEffect` hook in the `AvatarHeadDecapComponent` to prevent errors or side effects when the head node or the headDecap value is missing ([link](https://github.com/EtherealEngine/etherealengine/pull/8886/files?diff=unified&w=0#diff-c06c9050522d630a61e2be22bdb16e8d296021b982308c9bd95ae8ba9c27204aL50-R55))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 00ade88</samp>

> _`useEffect` hook_
> _refines head decap logic_
> _snowflakes fall gently_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
