### PR TITLE
Fix docs action for clearing commit history before pushing docs changes

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [dev]
   push:
-    branches: [fix/docs-build-clear-commit-history]
+    branches: [dev]
 
 jobs:
   secrets-gate:
@@ -78,7 +78,7 @@ jobs:
           git checkout gh-pages
           git checkout --orphan temp-gh-pages
           git add -A
-          git commit -m "Update docs to latest commit only"
+          git commit -m "Update docs to latest commit only in gh-pages"
           git checkout gh-pages
           git reset --hard temp-gh-pages
           git push origin gh-pages --force

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [dev]
   push:
-    branches: [dev]
+    branches: [fix/docs-build-clear-commit-history]
 
 jobs:
   secrets-gate:
@@ -75,10 +75,11 @@ jobs:
           git clone git@github.com:etherealengine/etherealengine-docs.git docs
           echo "Starting to remove commit history for gh-pages branch"
           cd docs
+          latestMasterCommit=$(git rev-parse HEAD)
           git checkout gh-pages
           git checkout --orphan temp-gh-pages
           git add -A
-          git commit -m "Commit history on gh-pages is removed and gh-pages points to latest master"
+          git commit -m "Deploy website - based on" $latestMasterCommit
           git checkout gh-pages
           git reset --hard temp-gh-pages
           git push origin gh-pages --force

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [dev]
   push:
-    branches: [dev]
+    branches: [fix/docs-build-clear-commit-history]
 
 jobs:
   secrets-gate:
@@ -72,7 +72,7 @@ jobs:
           git config --global user.email "actions@github.com"
           git config --global user.name "gh-actions"
           npm install --legacy-peer-deps
-          git clone https://github.com/etherealengine/etherealengine-docs.git docs
+          git clone git@github.com:etherealengine/etherealengine-docs.git docs
           echo "Starting to remove commit history for gh-pages branch"
           cd docs
           git checkout gh-pages
@@ -84,6 +84,7 @@ jobs:
           git push origin gh-pages --force
           git branch -D temp-gh-pages
           echo "gh-pages commit history has been cleared"
+          git checkout master
           cp .env.local.default .env.local
           npm install --legacy-peer-deps
           npm run deploy

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -78,7 +78,7 @@ jobs:
           git checkout gh-pages
           git checkout --orphan temp-gh-pages
           git add -A
-          git commit -m "Update docs to latest commit only in gh-pages"
+          git commit -m "Commit history on gh-pages is removed and gh-pages points to latest master"
           git checkout gh-pages
           git reset --hard temp-gh-pages
           git push origin gh-pages --force

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [dev]
   push:
-    branches: [fix/docs-build-clear-commit-history]
+    branches: [dev]
 
 jobs:
   secrets-gate:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -79,7 +79,7 @@ jobs:
           git checkout gh-pages
           git checkout --orphan temp-gh-pages
           git add -A
-          git commit -m "Deploy website - based on" $latestMasterCommit
+          git commit -m "Deploy website - based on ${latestMasterCommit}"
           git checkout gh-pages
           git reset --hard temp-gh-pages
           git push origin gh-pages --force


### PR DESCRIPTION
## Summary
Fix the documentation workflow that was failing because it was pushing the

## QA Steps
The docs workflow should pass now.

## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
