### PR TITLE
fix file panel css by making file-browser-panel cover all vertical area 

### DIFF
--- a/packages/editor/src/components/assets/FileBrowserContentPanel.tsx
+++ b/packages/editor/src/components/assets/FileBrowserContentPanel.tsx
@@ -510,7 +510,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
           variant="body2"
         />
       )}
-      <div id="file-browser-panel" style={{ overflowY: 'auto' }}>
+      <div id="file-browser-panel" style={{ overflowY: 'auto', height: '100%' }}>
         <DndWrapper id="file-browser-panel">
           <DropArea />
         </DndWrapper>


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 482ee69</samp>

Fixed layout and UI bugs in the editor. Changed the style of `file-browser-panel` to make it fill the available space.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 482ee69</samp>

*  Fixed file browser panel height bug by adding `height: 100%` to the `file-browser-panel` div style ([link](https://github.com/EtherealEngine/etherealengine/pull/8890/files?diff=unified&w=0#diff-5ef17280c22d3bd2b41075f135ca0374d375555609a4360a37de3f942363ed8cL513-R513))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 482ee69</samp>

> _`file-browser-panel`_
> _height fills the editor space_
> _a bug fixed in fall_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
