### PR TITLE
Fixed issue with spaces in scene names

### DIFF
--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -415,7 +415,9 @@ export class S3Provider implements StorageProviderInterface {
         CallerReference: Date.now().toString(),
         Paths: {
           Quantity: invalidationItems.length,
-          Items: invalidationItems.map((item) => (item[0] !== '/' ? `/${item}` : item))
+          Items: invalidationItems.map((item) =>
+            item[0] !== '/' ? `/${item.replaceAll(' ', '%20')}` : item.replaceAll(' ', '%20')
+          )
         }
       }
     }

--- a/packages/server-core/src/projects/scene/scene.class.ts
+++ b/packages/server-core/src/projects/scene/scene.class.ts
@@ -73,7 +73,7 @@ export const getSceneData = async (
 
   const scenePath = `projects/${projectName}/${sceneName}.scene.json`
 
-  const sceneResult = await storageProvider.getCachedObject(scenePath)
+  const sceneResult = await storageProvider.getObject(scenePath)
   const sceneData: SceneData = {
     name: sceneName,
     project: projectName,


### PR DESCRIPTION
## Summary
Cloudfront invalidation paths need spaces to be encoded.

Changed getSceneData to use storageProvider.getObject instead of getCachedObject to avoid retrieving an old version of a file.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea79498</samp>

This pull request fixes a bug with CloudFront invalidation for S3 files with spaces in their names, and improves scene data consistency by using `getObject` instead of `getCachedObject` when fetching scenes from S3.

## References
closes #8892

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ea79498</samp>

* Fix invalidation errors for S3 files with spaces in names ([link](https://github.com/EtherealEngine/etherealengine/pull/8897/files?diff=unified&w=0#diff-8355cc6812ded09068b1c27fb6c745d20017ce5fe28ee5235d676e5399fea10eL418-R420))
* Use `getObject` instead of `getCachedObject` for fetching scene data from S3 ([link](https://github.com/EtherealEngine/etherealengine/pull/8897/files?diff=unified&w=0#diff-d24560b170b8c7dd4d5e56f3e1441c1b13a3ad7481c5bd81e83c2a4275672f28L76-R76))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ea79498</samp>

> _`CloudFront` and `S3`_
> _Fixing bugs with spaces, cache_
> _Winter of errors_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
