### PR TITLE
Changes to persist headers across internal service requests

### DIFF
--- a/packages/server-core/src/createApp.ts
+++ b/packages/server-core/src/createApp.ts
@@ -50,6 +50,7 @@ import { Application } from '../declarations'
 import { logger } from './ServerLogger'
 import { ServerMode, ServerState, ServerTypeMode } from './ServerState'
 import { default as appConfig, default as config } from './appconfig'
+import persistHeaders from './hooks/persist-headers'
 import { createDefaultStorageProvider, createIPFSStorageProvider } from './media/storageprovider/storageprovider'
 import mysql from './mysql'
 import sequelize from './sequelize'
@@ -233,6 +234,11 @@ export const createFeathersKoaApp = (
 
   // Set up our services (see `services/index.js`)
   app.configure(services)
+
+  // Store headers across internal service calls
+  app.hooks({
+    around: [persistHeaders]
+  })
 
   pipeLogs(Engine.instance.api)
 

--- a/packages/server-core/src/hooks/persist-headers.ts
+++ b/packages/server-core/src/hooks/persist-headers.ts
@@ -1,0 +1,62 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import { HookContext, NextFunction } from '@feathersjs/feathers'
+
+import { AsyncLocalStorage } from 'async_hooks'
+import { Application } from '../../declarations'
+
+export const asyncLocalStorage = new AsyncLocalStorage<{ headers: any }>()
+
+/**
+ * https://github.com/feathersjs-ecosystem/dataloader/blob/main/docs/guide.md
+ */
+// export default () => {
+//   return async (context: HookContext<Application>) => {
+//     const store = asyncLocalStorage.getStore()
+
+//     if (store && store.headers) {
+//       context.params.headers = store.headers
+//     } else {
+//       const headers = context.params.headers || {}
+//       asyncLocalStorage.enterWith({headers})
+//     }
+
+//     return context
+//   }
+// }
+
+export default async (context: HookContext<Application>, next: NextFunction) => {
+  const store = asyncLocalStorage.getStore()
+
+  if (store && store.headers && !context.params.headers) {
+    context.params.headers = store.headers
+  } else {
+    const headers = context.params.headers || {}
+    asyncLocalStorage.enterWith({ headers })
+  }
+
+  return next()
+}


### PR DESCRIPTION
## Summary
Through this change we can persist headers in params in all internal calls. Reference: https://discord.com/channels/509848480760725514/1155732337343090778

copilot:summary

## References
closes #_insert number here_

## Explanation
copilot:walkthrough
copilot:poem

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
