### PR TITLE
Mocap fixes

### DIFF
--- a/packages/engine/src/mocap/MotionCaptureSystem.ts
+++ b/packages/engine/src/mocap/MotionCaptureSystem.ts
@@ -39,11 +39,7 @@ import { NetworkObjectComponent } from '../networking/components/NetworkObjectCo
 
 import { NormalizedLandmarkList } from '@mediapipe/pose'
 
-import {
-  DataChannelRegistryState,
-  addDataChannelHandler,
-  removeDataChannelHandler
-} from '../networking/systems/DataChannelRegistry'
+import { addDataChannelHandler, removeDataChannelHandler } from '../networking/systems/DataChannelRegistry'
 
 import { getState } from '@etherealengine/hyperflux'
 import { VRMHumanBoneList } from '@pixiv/three-vrm'
@@ -82,7 +78,6 @@ export const sendResults = (results: MotionCaptureResults) => {
 }
 
 export const receiveResults = (buff: ArrayBuffer) => {
-  console.log(buff)
   return decode(new Uint8Array(buff)) as {
     timestamp: number
     results: MotionCaptureResults
@@ -102,12 +97,10 @@ const handleMocapData = (
   fromPeerID: PeerID,
   message: ArrayBufferLike
 ) => {
-  console.log('handling mocap data')
   if (network.isHosting) {
     network.transport.bufferToAll(dataChannel, fromPeerID, message)
   }
   const results = MotionCaptureFunctions.receiveResults(message as ArrayBuffer)
-  console.log(results)
   if (!timeSeriesMocapData.has(fromPeerID)) {
     timeSeriesMocapData.set(fromPeerID, new RingBuffer(10))
   }
@@ -135,10 +128,8 @@ const execute = () => {
       timeSeriesMocapLastSeen.delete(peerID)
     }
   }
-  console.log(motionCaptureQuery().length)
   for (const [peerID, mocapData] of timeSeriesMocapData) {
     const data = mocapData.popLast()
-    console.log(data)
     const userID = network.peers[peerID]!.userId
     const entity = NetworkObjectComponent.getUserAvatarEntity(userID)
 
@@ -245,7 +236,6 @@ helperGroup.add(positionLineSegment)
 const reactor = () => {
   useEffect(() => {
     addDataChannelHandler(mocapDataChannelType, handleMocapData)
-    console.log(getState(DataChannelRegistryState)[mocapDataChannelType])
     return () => {
       removeDataChannelHandler(mocapDataChannelType, handleMocapData)
     }

--- a/packages/engine/src/networking/systems/IncomingNetworkSystem.ts
+++ b/packages/engine/src/networking/systems/IncomingNetworkSystem.ts
@@ -64,6 +64,7 @@ const handleNetworkdata = (
   message: ArrayBufferLike
 ) => {
   const { incomingMessageQueueUnreliable, incomingMessageQueueUnreliableIDs } = getState(IncomingNetworkState)
+  console.log('handling network data')
   if (network.isHosting) {
     incomingMessageQueueUnreliable.add(toArrayBuffer(message))
     incomingMessageQueueUnreliableIDs.add(fromPeerID)

--- a/packages/engine/src/networking/systems/IncomingNetworkSystem.ts
+++ b/packages/engine/src/networking/systems/IncomingNetworkSystem.ts
@@ -64,7 +64,6 @@ const handleNetworkdata = (
   message: ArrayBufferLike
 ) => {
   const { incomingMessageQueueUnreliable, incomingMessageQueueUnreliableIDs } = getState(IncomingNetworkState)
-  console.log('handling network data')
   if (network.isHosting) {
     incomingMessageQueueUnreliable.add(toArrayBuffer(message))
     incomingMessageQueueUnreliableIDs.add(fromPeerID)

--- a/packages/engine/src/networking/systems/MediasoupMediaProducerConsumerState.tsx
+++ b/packages/engine/src/networking/systems/MediasoupMediaProducerConsumerState.tsx
@@ -372,16 +372,12 @@ export const NetworkProducer = (props: { networkID: InstanceID; producerID: stri
     const consumer = Object.entries(getState(MediasoupMediaProducerConsumerState)[networkID].consumers).find(
       ([_, consumer]) => consumer.producerID === producerID
     )
-    console.log(consumer)
     if (!producer || !consumer) return
 
     if (producer.closed || producer._closed) return
 
     if (producerState.paused.value && producer.pause) producer.pause()
     if (!producerState.paused.value && producer.resume) producer.resume()
-
-    console.log(getState(MediasoupMediaProducerConsumerState)[networkID].consumers)
-    console.log(getState(MediasoupMediaProducerConsumerState)[networkID].producers)
 
     if (!consumer) return console.warn('No consumer found for paused producer', producerID)
 

--- a/packages/engine/src/networking/systems/MediasoupMediaProducerConsumerState.tsx
+++ b/packages/engine/src/networking/systems/MediasoupMediaProducerConsumerState.tsx
@@ -322,10 +322,13 @@ export const NetworkProducer = (props: { networkID: InstanceID; producerID: stri
   const producerState = useHookstate(
     getMutableState(MediasoupMediaProducerConsumerState)[networkID].producers[producerID]
   )
+
   const networkState = useHookstate(getMutableState(NetworkState).networks[networkID])
   const producerObjectState = useHookstate(
     getMutableState(MediasoupMediaProducersConsumersObjectsState).producers[producerID]
   )
+
+  const mediaState = useHookstate(getMutableState(MediasoupMediaProducersConsumersObjectsState).consumers)
 
   useEffect(() => {
     const peerID = producerState.peerID.value
@@ -366,16 +369,19 @@ export const NetworkProducer = (props: { networkID: InstanceID; producerID: stri
 
   useEffect(() => {
     const producer = producerObjectState.value as any
-    if (!producer) return
+    const consumer = Object.entries(getState(MediasoupMediaProducerConsumerState)[networkID].consumers).find(
+      ([_, consumer]) => consumer.producerID === producerID
+    )
+    console.log(consumer)
+    if (!producer || !consumer) return
 
     if (producer.closed || producer._closed) return
 
     if (producerState.paused.value && producer.pause) producer.pause()
     if (!producerState.paused.value && producer.resume) producer.resume()
 
-    const consumer = Object.entries(getState(MediasoupMediaProducerConsumerState)[networkID].consumers).find(
-      ([_, consumer]) => consumer.producerID === producerID
-    )
+    console.log(getState(MediasoupMediaProducerConsumerState)[networkID].consumers)
+    console.log(getState(MediasoupMediaProducerConsumerState)[networkID].producers)
 
     if (!consumer) return console.warn('No consumer found for paused producer', producerID)
 
@@ -386,7 +392,7 @@ export const NetworkProducer = (props: { networkID: InstanceID; producerID: stri
         $topic: networkState.topic.value
       })
     )
-  }, [producerState.paused, producerObjectState])
+  }, [producerState.paused, producerObjectState, networkState, mediaState])
 
   return null
 }

--- a/packages/instanceserver/src/ServerHostNetworkSystem.tsx
+++ b/packages/instanceserver/src/ServerHostNetworkSystem.tsx
@@ -43,7 +43,7 @@ import { SocketWebRTCServerNetwork } from './SocketWebRTCServerFunctions'
 export async function validateNetworkObjects(network: SocketWebRTCServerNetwork): Promise<void> {
   for (const [peerID, client] of Object.entries(network.peers)) {
     if (client.userId === Engine.instance.userID) continue
-    if (Date.now() - client.lastSeenTs > 5000) {
+    if (Date.now() - client.lastSeenTs > 10000) {
       NetworkPeerFunctions.destroyPeer(network, peerID as PeerID)
       updatePeers(network)
     }

--- a/packages/ui/src/pages/Capture/index.tsx
+++ b/packages/ui/src/pages/Capture/index.tsx
@@ -125,7 +125,7 @@ export const stopPlayback = () => {
 const sendResults = (results: MotionCaptureResults) => {
   const network = Engine.instance.worldNetwork as SocketWebRTCClientNetwork
   if (!network?.ready) return
-  // console.log('sending results', results)
+  console.log('sending results', results)
   const data = MotionCaptureFunctions.sendResults(results)
   network.transport.bufferToAll(mocapDataChannelType, Engine.instance.peerID, data)
 }

--- a/packages/ui/src/pages/Capture/index.tsx
+++ b/packages/ui/src/pages/Capture/index.tsx
@@ -125,7 +125,6 @@ export const stopPlayback = () => {
 const sendResults = (results: MotionCaptureResults) => {
   const network = Engine.instance.worldNetwork as SocketWebRTCClientNetwork
   if (!network?.ready) return
-  console.log('sending results', results)
   const data = MotionCaptureFunctions.sendResults(results)
   network.transport.bufferToAll(mocapDataChannelType, Engine.instance.peerID, data)
 }


### PR DESCRIPTION
## Summary

Critical fixes for mocap consistency. Adds a new state variable for media consumers, increases the timeout threshold for peer connections.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 646dd88</samp>

*  Updated `handleMocapData` function to use generic `dataChannel` for WebRTC communication ([link](https://github.com/EtherealEngine/etherealengine/pull/8900/files?diff=unified&w=0#diff-0dd013982d900b7dee40b698fa162bdc4c6543934bd215cd869403e0364c670bL101-R101))
*  Added `mediaState` variable to track media consumers state in `NetworkProducer` component ([link](https://github.com/EtherealEngine/etherealengine/pull/8900/files?diff=unified&w=0#diff-c57c61462cd59a8d4c6f4957801b06a6992ee278fb9f05ccacad74cb0c5a639fR331-R332))
*  Added check for consumer existence and removed redundant declaration in `NetworkProducer` component ([link](https://github.com/EtherealEngine/etherealengine/pull/8900/files?diff=unified&w=0#diff-c57c61462cd59a8d4c6f4957801b06a6992ee278fb9f05ccacad74cb0c5a639fL369-R375), [link](https://github.com/EtherealEngine/etherealengine/pull/8900/files?diff=unified&w=0#diff-c57c61462cd59a8d4c6f4957801b06a6992ee278fb9f05ccacad74cb0c5a639fL376-L379))
*  Added `networkState` and `mediaState` to `useEffect` dependency array in `NetworkProducer` component ([link](https://github.com/EtherealEngine/etherealengine/pull/8900/files?diff=unified&w=0#diff-c57c61462cd59a8d4c6f4957801b06a6992ee278fb9f05ccacad74cb0c5a639fL389-R391))
*  Increased timeout threshold for destroying peer connection in `validateNetworkObjects` function in `ServerHostNetworkSystem.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/8900/files?diff=unified&w=0#diff-cdc35f72064ff3b0e0eae03c434f7756645a47922f47084486f640f32adfc652L46-R46))
*  Removed empty or commented-out lines of code in `MotionCaptureSystem.ts` and `MediasoupMediaProducerConsumerState.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/8900/files?diff=unified&w=0#diff-0dd013982d900b7dee40b698fa162bdc4c6543934bd215cd869403e0364c670bL131), [link](https://github.com/EtherealEngine/etherealengine/pull/8900/files?diff=unified&w=0#diff-c57c61462cd59a8d4c6f4957801b06a6992ee278fb9f05ccacad74cb0c5a639fR325), [link](https://github.com/EtherealEngine/etherealengine/pull/8900/files?diff=unified&w=0#diff-60259fb73fe4b06cbefd932110e73a0207e64eb37479a27da78b38f17a8a382eL128))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 646dd88</samp>

> _We are the masters of motion capture_
> _We send our data through the WebRTC_
> _We fix the bugs and optimize the code_
> _We are the network producers of doom_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
