### PR TITLE
Add workflow scope to GitHub oauth seed

### DIFF
--- a/packages/server-core/src/setting/authentication-setting/authentication-setting.seed.ts
+++ b/packages/server-core/src/setting/authentication-setting/authentication-setting.seed.ts
@@ -93,7 +93,7 @@ export async function seed(knex: Knex): Promise<void> {
           github: {
             key: process.env.GITHUB_CLIENT_ID,
             secret: process.env.GITHUB_CLIENT_SECRET,
-            scope: ['repo', 'user']
+            scope: ['repo', 'user', 'workflow']
           },
           google: {
             key: process.env.GOOGLE_CLIENT_ID,


### PR DESCRIPTION
## Summary
Pushing projects that have GitHub workflows in them requires the 'workflow' scope. If a repo already has those workflows in a branch, then it's not needed, but pushing a project when a repo is empty throws a 404. This scope was not present in the GitHub auth-setting seed.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb160d7</samp>

Added `workflow` permission to GitHub authentication setting to enable GitHub Actions integration. This allows the Ethereal Engine to run workflows on behalf of the user for tasks such as building, testing and deploying projects.

## References
closes #8887 

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cb160d7</samp>

*  Extend GitHub authentication scope to include `workflow` permission ([link](https://github.com/EtherealEngine/etherealengine/pull/8901/files?diff=unified&w=0#diff-99c069d03dcd0f96cf2afe38d76dd0478c51830a35cb0d0a3336c8dede8201a9L96-R96))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cb160d7</samp>

> _`workflow` permission_
> _Ethereal Engine runs_
> _GitHub Actions. Spring._

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
