### PR TITLE
8873 Fix saving scene with ktx2 image

### DIFF
--- a/packages/common/src/utils/CommonKnownContentTypes.ts
+++ b/packages/common/src/utils/CommonKnownContentTypes.ts
@@ -45,7 +45,8 @@ export const CommonKnownContentTypes = {
   tsx: 'application/octet-stream',
   ts: 'application/octet-stream',
   js: 'application/octet-stream',
-  json: 'application/json'
+  json: 'application/json',
+  ktx2: 'image/ktx2'
 }
 
 export const MimeTypeToExtension = {

--- a/packages/common/src/utils/CommonKnownContentTypes.ts
+++ b/packages/common/src/utils/CommonKnownContentTypes.ts
@@ -45,8 +45,7 @@ export const CommonKnownContentTypes = {
   tsx: 'application/octet-stream',
   ts: 'application/octet-stream',
   js: 'application/octet-stream',
-  json: 'application/json',
-  ktx2: 'image/ktx2'
+  json: 'application/json'
 }
 
 export const MimeTypeToExtension = {

--- a/packages/engine/src/assets/loaders/gltf/KTX2Loader.js
+++ b/packages/engine/src/assets/loaders/gltf/KTX2Loader.js
@@ -60,6 +60,8 @@ import {
 } from 'three'
 import { WorkerPool } from './WorkerPool'
 
+import { isClient } from '@etherealengine/engine/src/common/functions/getEnvironment'
+
 const KTX2TransferSRGB = 2
 const KTX2_ALPHA_PREMULTIPLIED = 1
 const _taskCache = new WeakMap()
@@ -189,7 +191,7 @@ class KTX2Loader extends Loader {
   }
 
   load(url, onLoad, onProgress, onError) {
-    if (this.workerConfig === null) {
+    if (isClient && this.workerConfig === null) {
       throw new Error('THREE.KTX2Loader: Missing initialization with `.detectSupport( renderer )`.')
     }
 

--- a/packages/engine/src/assets/loaders/gltf/KTX2Loader.js
+++ b/packages/engine/src/assets/loaders/gltf/KTX2Loader.js
@@ -60,6 +60,8 @@ import {
 } from 'three'
 import { WorkerPool } from './WorkerPool'
 
+import WebWorker from 'web-worker'
+
 import { isClient } from '@etherealengine/engine/src/common/functions/getEnvironment'
 
 const KTX2TransferSRGB = 2
@@ -153,7 +155,7 @@ class KTX2Loader extends Loader {
         this.transcoderBinary = binaryContent
 
         this.workerPool.setWorkerCreator(() => {
-          const worker = new Worker(this.workerSourceURL)
+          const worker = isClient ? new Worker(this.workerSourceURL) : new WebWorker(`data:image/ktx2;base64,${Buffer.from(body, 'utf-8').toString('base64')}`)
           const transcoderBinary = this.transcoderBinary.slice(0)
 
           worker.postMessage({ type: 'init', config: this.workerConfig, transcoderBinary }, [transcoderBinary])

--- a/packages/engine/src/assets/loaders/gltf/KTX2Loader.js
+++ b/packages/engine/src/assets/loaders/gltf/KTX2Loader.js
@@ -175,6 +175,19 @@ class KTX2Loader extends Loader {
     return this.transcoderPending
   }
 
+  parse(buffer, onLoad, onError) {
+    const texture = new CompressedTexture()
+    this._createTexture(buffer)
+      .then(function (_texture) {
+        texture.copy(_texture)
+        texture.needsUpdate = true
+
+        if (onLoad) onLoad(texture)
+      })
+      .catch(onError)
+    return texture
+  }
+
   load(url, onLoad, onProgress, onError) {
     if (this.workerConfig === null) {
       throw new Error('THREE.KTX2Loader: Missing initialization with `.detectSupport( renderer )`.')

--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -239,9 +239,13 @@ export class FileBrowserService
 
     if (existingResource.data.length > 0) {
       const resource = existingResource.data[0]
-      await this.app.service(staticResourcePath).patch(resource.id, {
-        url
-      })
+      await this.app.service(staticResourcePath).patch(
+        resource.id,
+        {
+          url
+        },
+        { isInternal: true }
+      )
       await storageProvider.createInvalidation([key])
     } else {
       await this.app.service(staticResourcePath).create(

--- a/packages/server-core/src/media/static-resource/static-resource-helper.ts
+++ b/packages/server-core/src/media/static-resource/static-resource-helper.ts
@@ -113,13 +113,20 @@ const absoluteProjectPath = path.join(appRootPath.path, '/packages/projects/proj
 export const isAssetFromProject = (url: string, project: string) => {
   const storageProvider = getStorageProvider()
   const storageProviderPath = path.join(storageProvider.cacheDomain, 'projects/', project)
-  return url.includes(storageProviderPath) || url.includes(path.join(absoluteProjectPath, project))
+  const originPath = path.join(storageProvider.originURLs[0], 'projects/', project)
+  return (
+    url.includes(storageProviderPath) ||
+    url.includes(originPath) ||
+    url.includes(path.join(absoluteProjectPath, project))
+  )
 }
 
 export const getKeyForAsset = (url: string, project: string, isFromProject: boolean) => {
   const storageProvider = getStorageProvider()
   const storageProviderPath = 'https://' + path.join(storageProvider.cacheDomain, 'projects/', project)
+  const originPath = 'https://' + path.join(storageProvider.originURLs[0], 'projects/', project)
   const projectPath = url
+    .replace(originPath, '')
     .replace(storageProviderPath, '')
     .replace(path.join(absoluteProjectPath, project), '')
     .split('/')
@@ -282,6 +289,7 @@ export const getImageStats = async (
 ): Promise<{ width: number; height: number }> => {
   if (mimeType === 'image/ktx2') {
     const loader = new KTX2Loader()
+    loader.setTranscoderPath(config.client.dist + '/loader_decoders/basis/')
     return new Promise<{ width: number; height: number }>((resolve, reject) => {
       if (typeof file === 'string') {
         loader.load(

--- a/packages/server-core/src/media/static-resource/static-resource-helper.ts
+++ b/packages/server-core/src/media/static-resource/static-resource-helper.ts
@@ -78,8 +78,8 @@ export const downloadResourceAndMetadata = async (
         buffer: Buffer.from(await file.arrayBuffer()),
         originalname: url.split('/').pop()!,
         mimetype:
-          file.headers.get('content-type') ||
-          file.headers.get('Content-Type') ||
+          file.headers.get('content-type') ??
+          file.headers.get('Content-Type') ??
           CommonKnownContentTypes[url.split('.').pop()!],
         size: parseInt(file.headers.get('content-length') || file.headers.get('Content-Length') || '0')
       }
@@ -90,8 +90,8 @@ export const downloadResourceAndMetadata = async (
         buffer: url,
         originalname: url.split('/').pop()!,
         mimetype:
-          file.headers.get('content-type') ||
-          file.headers.get('Content-Type') ||
+          file.headers.get('content-type') ??
+          file.headers.get('Content-Type') ??
           CommonKnownContentTypes[url.split('.').pop()!],
         size: parseInt(file.headers.get('content-length') || file.headers.get('Content-Length') || '0')
       }

--- a/packages/server-core/src/media/static-resource/static-resource-helper.ts
+++ b/packages/server-core/src/media/static-resource/static-resource-helper.ts
@@ -78,8 +78,8 @@ export const downloadResourceAndMetadata = async (
         buffer: Buffer.from(await file.arrayBuffer()),
         originalname: url.split('/').pop()!,
         mimetype:
-          file.headers.get('content-type') ??
-          file.headers.get('Content-Type') ??
+          file.headers.get('content-type') ||
+          file.headers.get('Content-Type') ||
           CommonKnownContentTypes[url.split('.').pop()!],
         size: parseInt(file.headers.get('content-length') || file.headers.get('Content-Length') || '0')
       }
@@ -90,8 +90,8 @@ export const downloadResourceAndMetadata = async (
         buffer: url,
         originalname: url.split('/').pop()!,
         mimetype:
-          file.headers.get('content-type') ??
-          file.headers.get('Content-Type') ??
+          file.headers.get('content-type') ||
+          file.headers.get('Content-Type') ||
           CommonKnownContentTypes[url.split('.').pop()!],
         size: parseInt(file.headers.get('content-length') || file.headers.get('Content-Length') || '0')
       }

--- a/packages/server-core/src/media/static-resource/static-resource-helper.ts
+++ b/packages/server-core/src/media/static-resource/static-resource-helper.ts
@@ -287,49 +287,13 @@ export const getImageStats = async (
   mimeType: string
 ): Promise<{ width: number; height: number }> => {
   if (mimeType === 'image/ktx2') {
+    if (typeof file === 'string') file = Buffer.from(await (await fetch(file)).arrayBuffer())
+    const widthBuffer = file.slice(20, 24)
+    const heightBuffer = file.slice(24, 28)
     return {
-      height: 0,
-      width: 0
+      height: heightBuffer.readUInt32LE(),
+      width: widthBuffer.readUInt32LE()
     }
-    // FIXME Once the KTX2Loader works properly on the backend, uncomment this and remove the above return
-    // const loader = new KTX2Loader()
-    // loader.setTranscoderPath(config.client.dist + '/loader_decoders/basis/')
-    // return new Promise<{ width: number; height: number }>((resolve, reject) => {
-    //   if (typeof file === 'string') {
-    //     loader.load(
-    //       file,
-    //       (texture) => {
-    //         const { width, height } = texture.source.data
-    //         resolve({
-    //           width,
-    //           height
-    //         })
-    //       },
-    //       () => {},
-    //       (err) => {
-    //         logger.error('error parsing ktx2')
-    //         logger.error(err)
-    //         reject(err)
-    //       }
-    //     )
-    //   } else {
-    //     loader.parse(
-    //       file,
-    //       (texture) => {
-    //         const { width, height } = texture.source.data
-    //         resolve({
-    //           width,
-    //           height
-    //         })
-    //       },
-    //       (err) => {
-    //         logger.error('error parsing ktx2')
-    //         logger.error(err)
-    //         reject(err)
-    //       }
-    //     )
-    //   }
-    // })
   } else {
     if (typeof file === 'string') file = Buffer.from(await (await fetch(file)).arrayBuffer())
     const stream = new Readable()

--- a/packages/server-core/src/media/static-resource/static-resource-helper.ts
+++ b/packages/server-core/src/media/static-resource/static-resource-helper.ts
@@ -34,7 +34,6 @@ import { Readable } from 'stream'
 
 import { UploadFile } from '@etherealengine/common/src/interfaces/UploadAssetInterface'
 import { CommonKnownContentTypes } from '@etherealengine/common/src/utils/CommonKnownContentTypes'
-import { KTX2Loader } from '@etherealengine/engine/src/assets/loaders/gltf/KTX2Loader'
 import multiLogger from '@etherealengine/engine/src/common/functions/logger'
 
 import { StaticResourceType, staticResourcePath } from '@etherealengine/engine/src/schemas/media/static-resource.schema'
@@ -288,44 +287,49 @@ export const getImageStats = async (
   mimeType: string
 ): Promise<{ width: number; height: number }> => {
   if (mimeType === 'image/ktx2') {
-    const loader = new KTX2Loader()
-    loader.setTranscoderPath(config.client.dist + '/loader_decoders/basis/')
-    return new Promise<{ width: number; height: number }>((resolve, reject) => {
-      if (typeof file === 'string') {
-        loader.load(
-          file,
-          (texture) => {
-            const { width, height } = texture.source.data
-            resolve({
-              width,
-              height
-            })
-          },
-          () => {},
-          (err) => {
-            logger.error('error parsing ktx2')
-            logger.error(err)
-            reject(err)
-          }
-        )
-      } else {
-        loader.parse(
-          file,
-          (texture) => {
-            const { width, height } = texture.source.data
-            resolve({
-              width,
-              height
-            })
-          },
-          (err) => {
-            logger.error('error parsing ktx2')
-            logger.error(err)
-            reject(err)
-          }
-        )
-      }
-    })
+    return {
+      height: 0,
+      width: 0
+    }
+    // FIXME Once the KTX2Loader works properly on the backend, uncomment this and remove the above return
+    // const loader = new KTX2Loader()
+    // loader.setTranscoderPath(config.client.dist + '/loader_decoders/basis/')
+    // return new Promise<{ width: number; height: number }>((resolve, reject) => {
+    //   if (typeof file === 'string') {
+    //     loader.load(
+    //       file,
+    //       (texture) => {
+    //         const { width, height } = texture.source.data
+    //         resolve({
+    //           width,
+    //           height
+    //         })
+    //       },
+    //       () => {},
+    //       (err) => {
+    //         logger.error('error parsing ktx2')
+    //         logger.error(err)
+    //         reject(err)
+    //       }
+    //     )
+    //   } else {
+    //     loader.parse(
+    //       file,
+    //       (texture) => {
+    //         const { width, height } = texture.source.data
+    //         resolve({
+    //           width,
+    //           height
+    //         })
+    //       },
+    //       (err) => {
+    //         logger.error('error parsing ktx2')
+    //         logger.error(err)
+    //         reject(err)
+    //       }
+    //     )
+    //   }
+    // })
   } else {
     if (typeof file === 'string') file = Buffer.from(await (await fetch(file)).arrayBuffer())
     const stream = new Readable()


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1443331</samp>

Added a `parse` method to `KTX2Loader` to load KTX2 compressed textures asynchronously and return a `CompressedTexture` object. This fixes the linked bug as the parse method didn't exist beforehand.

## References
#8873 

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1443331</samp>

* Add a `parse` method to the `KTX2Loader` class to load KTX2 files asynchronously and return a `CompressedTexture` object ([link](https://github.com/EtherealEngine/etherealengine/pull/8902/files?diff=unified&w=0#diff-790914f78b2f1626ec09fc2c7e131853e8d270ac7f1f2a08c3ee535c01d1734dR178-R190))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1443331</samp>

> _`KTX2Loader` adds_
> _`parse` method for textures_
> _Autumn of compression_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
