### PR TITLE
Clean up consumer pause

### DIFF
--- a/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
+++ b/packages/client-core/src/transports/SocketWebRTCClientFunctions.ts
@@ -798,9 +798,6 @@ export async function createCamVideoProducer(network: SocketWebRTCClientNetwork)
           }
         }, 100)
       })
-      if (mediaStreamState.videoPaused.value) await mediaStreamState.camVideoProducer.value!.pause()
-      else if (mediaStreamState.camVideoProducer.value)
-        resumeProducer(network, mediaStreamState.camVideoProducer.value!)
     } catch (err) {
       logger.error(err, 'Error producing video')
     }
@@ -852,10 +849,6 @@ export async function createCamAudioProducer(network: SocketWebRTCClientNetwork)
           }
         }, 100)
       })
-
-      if (mediaStreamState.audioPaused.value) mediaStreamState.camAudioProducer.value!.pause()
-      else if (mediaStreamState.camAudioProducer.value)
-        resumeProducer(network, mediaStreamState.camAudioProducer.value!)
     } catch (err) {
       logger.error(err, 'Error producing video')
     }


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 959ace8</samp>

This pull request improves the media stream state management for WebRTC clients and mediasoup producers. It refactors the code in `SocketWebRTCClientFunctions.ts` and `MediasoupMediaProducerConsumerState.tsx` to avoid unnecessary pauses, resumes, and loops, and to split the `NetworkProducer` component into two smaller components.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 959ace8</samp>

*  Refactor media stream state management to simplify and avoid glitches ([link](https://github.com/EtherealEngine/etherealengine/pull/8903/files?diff=unified&w=0#diff-678165bbc4b3a77cf8ade038c0d197487b513da0ca390dbbd5452e0d18acf520L801-L803), [link](https://github.com/EtherealEngine/etherealengine/pull/8903/files?diff=unified&w=0#diff-678165bbc4b3a77cf8ade038c0d197487b513da0ca390dbbd5452e0d18acf520L855-L858))
* Separate producer and consumer pause logic to improve efficiency and clarity ([link](https://github.com/EtherealEngine/etherealengine/pull/8903/files?diff=unified&w=0#diff-c57c61462cd59a8d4c6f4957801b06a6992ee278fb9f05ccacad74cb0c5a639fL372-R410))
* Remove unused variables from `NetworkProducer` component to clean up code ([link](https://github.com/EtherealEngine/etherealengine/pull/8903/files?diff=unified&w=0#diff-c57c61462cd59a8d4c6f4957801b06a6992ee278fb9f05ccacad74cb0c5a639fL326-R329))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 959ace8</samp>

> _`NetworkProducer`_
> _Refactored and simplified_
> _Spring cleaning for code_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
