### PR TITLE
unify playlist implementation

### DIFF
--- a/packages/engine/src/scene/components/VolumetricComponent.ts
+++ b/packages/engine/src/scene/components/VolumetricComponent.ts
@@ -37,7 +37,6 @@ import { AudioState } from '../../audio/AudioState'
 import { isClient } from '../../common/functions/getEnvironment'
 import { Entity } from '../../ecs/classes/Entity'
 import {
-  ComponentType,
   defineComponent,
   getComponent,
   getMutableComponent,
@@ -52,7 +51,7 @@ import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { addObjectToGroup } from '../components/GroupComponent'
 import { PlayMode } from '../constants/PlayMode'
-import { AudioNodeGroups, MediaElementComponent, createAudioNodeGroup } from './MediaComponent'
+import { AudioNodeGroups, MediaElementComponent, createAudioNodeGroup, getNextTrack } from './MediaComponent'
 import { ShadowComponent } from './ShadowComponent'
 
 export const VolumetricComponent = defineComponent({
@@ -157,7 +156,9 @@ export function VolumetricReactor() {
               renderer: EngineRenderer.instance.renderer,
               onTrackEnd: () => {
                 volumetric.hasTrackStopped.set(true)
-                volumetric.track.set(getNextTrack(volumetric.value))
+                volumetric.track.set(
+                  getNextTrack(volumetric.track.value, volumetric.paths.length, volumetric.playMode.value)
+                )
               },
               video: element as HTMLVideoElement,
               V1Args: {
@@ -255,26 +256,6 @@ export function VolumetricReactor() {
   }, [volumetric.paused, volumetric.player])
 
   return null
-}
-
-export function getNextTrack(volumetric: ComponentType<typeof VolumetricComponent>) {
-  const currentTrack = volumetric.track
-  const numTracks = volumetric.paths.length
-  let nextTrack = 0
-
-  if (volumetric.playMode == PlayMode.random) {
-    // todo: smart random, i.e., lower probability of recently played tracks
-    nextTrack = Math.floor(Math.random() * numTracks)
-  } else if (volumetric.playMode == PlayMode.single) {
-    nextTrack = (currentTrack + 1) % numTracks
-  } else if (volumetric.playMode == PlayMode.singleloop) {
-    nextTrack = currentTrack
-  } else {
-    //PlayMode.Loop
-    nextTrack = (currentTrack + 1) % numTracks
-  }
-
-  return nextTrack
 }
 
 export const endLoadingEffect = (entity, object) => {


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed9da6f</samp>

This pull request improves the code reuse and readability of the `MediaComponent` and `VolumetricComponent` classes by extracting a common `getNextTrack` function for playing media tracks. It also cleans up some unused imports and updates the function calls accordingly.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ed9da6f</samp>

*  Refactored `getNextTrack` function to take current track, track count, and play mode as parameters instead of media component ([link](https://github.com/EtherealEngine/etherealengine/pull/8904/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cL506-R518), [link](https://github.com/EtherealEngine/etherealengine/pull/8904/files?diff=unified&w=0#diff-488521cee868606ef11e398a540128d8c0f8c7d535547d76e49778e16e2b029bL260-L279))
*  Updated `getNextTrack` function calls to use the new parameters in `MediaComponent.ts` and `VolumetricComponent.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/8904/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cL38), [link](https://github.com/EtherealEngine/etherealengine/pull/8904/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cL380-R380), [link](https://github.com/EtherealEngine/etherealengine/pull/8904/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cL390-R390), [link](https://github.com/EtherealEngine/etherealengine/pull/8904/files?diff=unified&w=0#diff-488521cee868606ef11e398a540128d8c0f8c7d535547d76e49778e16e2b029bL160-R161))
*  Moved `getNextTrack` function from `VolumetricComponent.ts` to `MediaComponent.ts` and imported it in the former ([link](https://github.com/EtherealEngine/etherealengine/pull/8904/files?diff=unified&w=0#diff-488521cee868606ef11e398a540128d8c0f8c7d535547d76e49778e16e2b029bL55-R54))
*  Removed unused `ComponentType` import from `MediaComponent.ts` and `VolumetricComponent.ts` ( [link](https://github.com/EtherealEngine/etherealengine/pull/8904/files?diff=unified&w=0#diff-488521cee868606ef11e398a540128d8c0f8c7d535547d76e49778e16e2b029bL40))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ed9da6f</samp>

> _To play media of any kind_
> _They refactored `getNextTrack` in mind_
> _They removed some imports_
> _And updated the args_
> _To make the code more streamlined and aligned_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
