### PR TITLE
Avatar envmaps hotfix

### DIFF
--- a/packages/engine/src/avatar/functions/avatarFunctions.ts
+++ b/packages/engine/src/avatar/functions/avatarFunctions.ts
@@ -174,18 +174,14 @@ export const setupAvatarForUser = (entity: Entity, model: VRM) => {
   setupAvatarEnvmaps(entity, model.scene)
   avatar.model = model.scene
 }
-
+const envmapBakeQuery = defineQuery([EnvMapBakeComponent])
 const setupAvatarEnvmaps = (entity: Entity, model: Object3D) => {
   //query all envmap bake components and get the url from the first one
-  const envmapBakes = defineQuery([EnvMapBakeComponent])
-  const envmapBake = getComponent(envmapBakes()[0], EnvMapBakeComponent)
-  console.log(envmapBake)
-  AssetLoader.loadAsync(envmapBake.envMapOrigin, {}).then((texture) => {
-    if (texture) {
-      console.log(texture)
-      texture.mapping = EquirectangularReflectionMapping
-      console.log(getComponent(entity, GroupComponent))
+  const envmapBake = getComponent(envmapBakeQuery()[0], EnvMapBakeComponent)
 
+  AssetLoader.loadAsync(envmapBake.envMapOrigin).then((texture) => {
+    if (texture) {
+      texture.mapping = EquirectangularReflectionMapping
       updateEnvMap(getComponent(entity, GroupComponent), texture)
     }
   })

--- a/packages/engine/src/scene/components/EnvmapComponent.tsx
+++ b/packages/engine/src/scene/components/EnvmapComponent.tsx
@@ -194,7 +194,7 @@ const EnvBakeComponentReactor = (props: { envmapEntity: Entity; bakeEntity: Enti
   return null
 }
 
-function updateEnvMap(obj3ds: Object3D[], envmap: Texture | null) {
+export function updateEnvMap(obj3ds: Object3D[], envmap: Texture | null) {
   if (!obj3ds?.length) return
 
   for (const obj of obj3ds) {


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9c5981</samp>

This pull request adds a new feature to the engine that allows avatars to have environment maps applied to them. It also refactors some code to reuse existing functions and improve readability.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e9c5981</samp>

*  Add a function to set up environment maps for avatar models ([link](https://github.com/EtherealEngine/etherealengine/pull/8908/files?diff=unified&w=0#diff-ae0c696fdcb759ddeda5f76ab4b6722ad7279c8c65438f5008fd6fadfb9535a9L169-R193))
  - Import constants, components, and functions from `three` and `@xrengine/engine` packages ([link](https://github.com/EtherealEngine/etherealengine/pull/8908/files?diff=unified&w=0#diff-ae0c696fdcb759ddeda5f76ab4b6722ad7279c8c65438f5008fd6fadfb9535a9R33), [link](https://github.com/EtherealEngine/etherealengine/pull/8908/files?diff=unified&w=0#diff-ae0c696fdcb759ddeda5f76ab4b6722ad7279c8c65438f5008fd6fadfb9535a9R51), [link](https://github.com/EtherealEngine/etherealengine/pull/8908/files?diff=unified&w=0#diff-ae0c696fdcb759ddeda5f76ab4b6722ad7279c8c65438f5008fd6fadfb9535a9L57-R59), [link](https://github.com/EtherealEngine/etherealengine/pull/8908/files?diff=unified&w=0#diff-ae0c696fdcb759ddeda5f76ab4b6722ad7279c8c65438f5008fd6fadfb9535a9R69-R70))
  - Query for the entity with the `EnvMapBakeComponent` and load the texture from the URL ([link](https://github.com/EtherealEngine/etherealengine/pull/8908/files?diff=unified&w=0#diff-ae0c696fdcb759ddeda5f76ab4b6722ad7279c8c65438f5008fd6fadfb9535a9L169-R193))
  - Set the mapping type of the texture to `EquirectangularReflectionMapping` ([link](https://github.com/EtherealEngine/etherealengine/pull/8908/files?diff=unified&w=0#diff-ae0c696fdcb759ddeda5f76ab4b6722ad7279c8c65438f5008fd6fadfb9535a9L169-R193))
  - Call the `updateEnvMap` function with the avatar entity's `GroupComponent` and the texture ([link](https://github.com/EtherealEngine/etherealengine/pull/8908/files?diff=unified&w=0#diff-ae0c696fdcb759ddeda5f76ab4b6722ad7279c8c65438f5008fd6fadfb9535a9L169-R193))
  - Call the `setupAvatarEnvmaps` function from the `setupAvatarForUser` function ([link](https://github.com/EtherealEngine/etherealengine/pull/8908/files?diff=unified&w=0#diff-ae0c696fdcb759ddeda5f76ab4b6722ad7279c8c65438f5008fd6fadfb9535a9L169-R193))
* Export the `updateEnvMap` function from the `EnvmapComponent.tsx` file ([link](https://github.com/EtherealEngine/etherealengine/pull/8908/files?diff=unified&w=0#diff-c3b5fd77b5cfb8085e215c2bafd90a2727de2d03ad82fe74db17b47605762c7eL197-R197))
  - Allow the function to be imported and used in the `avatarFunctions.ts` file ([link](https://github.com/EtherealEngine/etherealengine/pull/8908/files?diff=unified&w=0#diff-ae0c696fdcb759ddeda5f76ab4b6722ad7279c8c65438f5008fd6fadfb9535a9R69-R70))
* Remove an empty line of code from the `avatarFunctions.ts` file ([link](https://github.com/EtherealEngine/etherealengine/pull/8908/files?diff=unified&w=0#diff-ae0c696fdcb759ddeda5f76ab4b6722ad7279c8c65438f5008fd6fadfb9535a9R164))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e9c5981</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A wondrous map of the environs for the avatar,_
> _The shining image of the self, and made it shine_
> _With textures fetched from distant URLs, the work of `updateEnvMap`._

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
