### PR TITLE
reset functionality for media

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -224,6 +224,7 @@
       "playmode": "Play Mode",
       "playtitle": "Play",
       "pausetitle": "Pause",
+      "resettitle": "Reset",
       "lbl-controls": "controls",
       "info-controls": "Toggle the visibility of the media controls.",
       "lbl-autoplay": "Autoplay",

--- a/packages/editor/src/components/inputs/ArrayInputGroup.tsx
+++ b/packages/editor/src/components/inputs/ArrayInputGroup.tsx
@@ -78,9 +78,6 @@ const ArrayInputGroup = ({
 }: ArrayInputGroupProp) => {
   let count = 0
   if (values && values.length) count = values.length
-
-  console.log('debug1 styles', styles, 'and', styles.sizeLabel)
-
   return (
     <InputGroup name="label" label={label} labelClasses={styles.sizeLabel}>
       <div className={styles.arrayInputGroupContent}>

--- a/packages/editor/src/components/properties/MediaNodeEditor.tsx
+++ b/packages/editor/src/components/properties/MediaNodeEditor.tsx
@@ -35,7 +35,7 @@ import { PlayMode } from '@etherealengine/engine/src/scene/constants/PlayMode'
 import { SupportedFileTypes } from '../../constants/AssetTypes'
 import ArrayInputGroup from '../inputs/ArrayInputGroup'
 import BooleanInput from '../inputs/BooleanInput'
-import { Button } from '../inputs/Button'
+import { PropertiesPanelButton } from '../inputs/Button'
 import CompoundNumericInput from '../inputs/CompoundNumericInput'
 import InputGroup from '../inputs/InputGroup'
 import SelectInput from '../inputs/SelectInput'
@@ -69,6 +69,10 @@ export const MediaNodeEditor: EditorComponentType = (props) => {
 
   const toggle = () => {
     media.paused.set(!media.paused.value)
+  }
+
+  const reset = () => {
+    media.seekTime.set(0.001) //safer to set to positive value
   }
 
   return (
@@ -133,12 +137,17 @@ export const MediaNodeEditor: EditorComponentType = (props) => {
           value={media.playMode.value}
           onChange={updateProperty(MediaComponent, 'playMode')}
         />
-        {media.resources.length > 0 && (
-          <Button style={{ marginLeft: '5px', width: '60px' }} type="submit" onClick={toggle}>
-            {media.paused.value ? t('editor:properties.media.playtitle') : t('editor:properties.media.pausetitle')}
-          </Button>
-        )}
       </InputGroup>
+      {media.resources.length > 0 && (
+        <PropertiesPanelButton type="submit" onClick={toggle}>
+          {media.paused.value ? t('editor:properties.media.playtitle') : t('editor:properties.media.pausetitle')}
+        </PropertiesPanelButton>
+      )}
+      {media.resources.length > 0 && (
+        <PropertiesPanelButton type="submit" onClick={reset}>
+          {t('editor:properties.media.resettitle')}
+        </PropertiesPanelButton>
+      )}
     </NodeEditor>
   )
 }

--- a/packages/engine/src/behave-graph/nodes/Profiles/Engine/Values/CustomNodes.ts
+++ b/packages/engine/src/behave-graph/nodes/Profiles/Engine/Values/CustomNodes.ts
@@ -135,6 +135,7 @@ export const playAudio = makeFlowNodeDefinition({
     isMusic: 'boolean',
     volume: 'float',
     paused: 'boolean',
+    seekTime: 'float',
     playMode: (_, graphApi) => {
       const choices = Object.keys(PlayMode).map((key) => ({
         text: key,
@@ -163,11 +164,13 @@ export const playAudio = makeFlowNodeDefinition({
     volume = MathUtils.clamp(read('volume') ?? volume, 0, 1)
     const playMode = read<PlayMode>('playMode')
     const paused = read<boolean>('paused')
+    const seekTime = read<number>('seekTime')
     setComponent(entity, MediaComponent, {
       autoplay: autoplay,
       resources: resources,
       volume: volume,
-      playMode: playMode!
+      playMode: playMode!,
+      seekTime: seekTime
     }) // play
     const component = getMutableComponent(entity, MediaComponent)
     component.paused.set(paused)

--- a/packages/engine/src/scene/components/MediaComponent.ts
+++ b/packages/engine/src/scene/components/MediaComponent.ts
@@ -300,7 +300,7 @@ export function MediaReactor() {
       console.log('DEBUG Triggred seek')
       if (!mediaElement || media.seekTime.value < 0 || mediaElement.element.value.currentTime === media.seekTime.value)
         return
-      mediaElement.element.value.currentTime = media.seekTime.value // set time and stop playing
+      mediaElement.element.currentTime.set(media.seekTime.value) // set time and stop playing
       media.paused.value ? media.paused.set(false) : mediaElement.element.value.play() // start play again
       media.seekTime.set(-1)
     },

--- a/packages/engine/src/scene/components/MediaComponent.ts
+++ b/packages/engine/src/scene/components/MediaComponent.ts
@@ -138,6 +138,7 @@ export const MediaComponent = defineComponent({
       paths: [] as string[],
       // runtime props
       paused: true,
+      seekTime: -1,
       waiting: false,
       track: 0,
       trackDurations: [] as number[],
@@ -165,7 +166,8 @@ export const MediaComponent = defineComponent({
       volume: component.volume.value,
       synchronize: component.synchronize.value,
       playMode: component.playMode.value,
-      isMusic: component.isMusic.value
+      isMusic: component.isMusic.value,
+      seekTime: component.seekTime.value // we can start media from a specific point if needed
     }
   },
 
@@ -218,6 +220,8 @@ export const MediaComponent = defineComponent({
 
       // @ts-ignore deprecated autoplay field
       if (typeof json.paused === 'boolean') component.autoplay.set(!json.paused)
+      if (typeof json.seekTime === 'number') component.seekTime.set(json.seekTime)
+
       if (typeof json.autoplay === 'boolean') component.autoplay.set(json.autoplay)
     })
   },
@@ -289,6 +293,18 @@ export function MediaReactor() {
       }
     },
     [media.paused, mediaElement]
+  )
+
+  useEffect(
+    function updateSeekTime() {
+      console.log('DEBUG Triggred seek')
+      if (!mediaElement || media.seekTime.value < 0 || mediaElement.element.value.currentTime === media.seekTime.value)
+        return
+      mediaElement.element.value.currentTime = media.seekTime.value // set time and stop playing
+      media.paused.value ? media.paused.set(false) : mediaElement.element.value.play() // start play again
+      media.seekTime.set(-1)
+    },
+    [media.seekTime, mediaElement]
   )
 
   useEffect(
@@ -407,7 +423,7 @@ export function MediaReactor() {
 
       mediaElementState.hls.value?.destroy()
       mediaElementState.hls.set(undefined)
-
+      mediaElementState.element.value.crossOrigin = 'anonymous'
       if (isHLS(path)) {
         mediaElementState.hls.set(setupHLS(entity, path))
         mediaElementState.hls.value!.attachMedia(mediaElementState.element.value)
@@ -510,6 +526,7 @@ export function getNextTrack(media: ComponentType<typeof MediaComponent>) {
 
   if (media.playMode == PlayMode.random) {
     // todo: smart random, i.e., lower probability of recently played tracks
+    // Rahul : use LRU cache?
     nextTrack = Math.floor(Math.random() * numTracks)
   } else if (media.playMode == PlayMode.single) {
     nextTrack = (currentTrack + 1) % numTracks


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db68810</samp>

This pull request improves the media node editing feature in the editor by adding a reset function, enabling cross-origin streaming, and enhancing the layout and functionality of the media node editor component. It also removes a debug statement and adds a translation key. The affected files are `MediaNodeEditor.tsx`, `MediaComponent.ts`, `editor.json`, and `ArrayInputGroup.tsx`.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at db68810</samp>

*  Add a reset button and functionality to the media node editor ([link](https://github.com/EtherealEngine/etherealengine/pull/8913/files?diff=unified&w=0#diff-827e8c4336f8ab1c715c553a8028695e3cfe0fa1b3af6432139850e34eb078fdR227), [link](https://github.com/EtherealEngine/etherealengine/pull/8913/files?diff=unified&w=0#diff-6d528b60b54cd3ab3d8886b704bec0ec0c595aba136d13c5f4892488e2d8f1a6R74-R77), [link](https://github.com/EtherealEngine/etherealengine/pull/8913/files?diff=unified&w=0#diff-6d528b60b54cd3ab3d8886b704bec0ec0c595aba136d13c5f4892488e2d8f1a6L136-R150), [link](https://github.com/EtherealEngine/etherealengine/pull/8913/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cR141), [link](https://github.com/EtherealEngine/etherealengine/pull/8913/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cR296-R305))
*  Rename the Button import to PropertiesPanelButton in `MediaNodeEditor.tsx` to avoid confusion and follow convention ([link](https://github.com/EtherealEngine/etherealengine/pull/8913/files?diff=unified&w=0#diff-6d528b60b54cd3ab3d8886b704bec0ec0c595aba136d13c5f4892488e2d8f1a6L38-R38))
*  Remove a console log statement from `ArrayInputGroup.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/8913/files?diff=unified&w=0#diff-fdb7806cad35dcd73b0792dd29f970cb5e4b744fba7c1549320019927e32e245L81-L83))
*  Set the crossOrigin attribute of the media element to 'anonymous' in `MediaComponent.ts` to enable HLS streaming from different origins ([link](https://github.com/EtherealEngine/etherealengine/pull/8913/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cL410-R421))
*  Add a comment to suggest using a LRU cache for the media component in `MediaComponent.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/8913/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cR524))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at db68810</samp>

> _The media node editor got a boost_
> _With a reset button and a name reduced_
> _The layout is neat_
> _The array input complete_
> _And the media reactor can stream HLS to boot_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
