### PR TITLE
Fixed issues with static resource hash generation and ktx2 size fetching

### DIFF
--- a/packages/common/src/utils/CommonKnownContentTypes.ts
+++ b/packages/common/src/utils/CommonKnownContentTypes.ts
@@ -34,6 +34,7 @@ export const CommonKnownContentTypes = {
   glb: 'model/gltf-binary',
   vrm: 'model/vrm',
   png: 'image/png',
+  ktx2: 'image/ktx2',
   jpg: 'image/jpeg',
   jpeg: 'image/jpeg',
   pdf: 'application/pdf',

--- a/packages/instanceserver/src/MediasoupRecordingFunctions.ts
+++ b/packages/instanceserver/src/MediasoupRecordingFunctions.ts
@@ -287,9 +287,13 @@ export const startMediaRecording = async (recordingID: RecordingID, schema: Reco
     const format = recording.format === 'mp3' ? 'audio/opus' : recording.format === 'vp8' ? 'video/webm' : 'video/mp4'
     const ext = recording.format === 'mp3' ? 'mp3' : recording.format === 'vp8' ? 'webm' : 'mp4'
     const key = `recordings/${recordingID}/${recording.peerID}-${recording.mediaType}.${ext}`
-    const hash = createHash('sha3-256').update(key.split('/').pop()!.split('.')[0]).digest('hex')
+    const hash = createHash('sha3-256')
+      .update(stream.readableLength.toString())
+      .update(key.split('/').pop()!)
+      .update(format)
+      .digest('hex')
 
-    const upload = uploadMediaStaticResource({
+    return uploadMediaStaticResource({
       recordingID,
       key,
       body: stream,
@@ -298,8 +302,6 @@ export const startMediaRecording = async (recordingID: RecordingID, schema: Reco
     }).then(() => {
       logger.info('Uploaded media file' + key)
     })
-
-    return upload
   })
 
   logger.info('media recording started')

--- a/packages/instanceserver/src/ServerHostNetworkSystem.tsx
+++ b/packages/instanceserver/src/ServerHostNetworkSystem.tsx
@@ -74,7 +74,7 @@ export const uploadRecordingStaticResource = async (props: {
 
   const provider = getStorageProvider()
   const url = getCachedURL(props.key, provider.cacheDomain)
-  const hash = createStaticResourceHash(props.body, { assetURL: props.key })
+  const hash = createStaticResourceHash(props.body, { mimeType: props.mimeType, assetURL: props.key })
 
   const staticResource = await api.service(staticResourcePath).create(
     {

--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -224,7 +224,7 @@ export class FileBrowserService
       }
     )
 
-    const hash = createStaticResourceHash(data.body, { assetURL: key })
+    const hash = createStaticResourceHash(data.body, { mimeType: data.contentType, assetURL: key })
     const cacheDomain = getCacheDomain(storageProvider, params && params.provider == null)
     const url = getCachedURL(key, cacheDomain)
 

--- a/packages/server-core/src/media/static-resource/static-resource-helper.ts
+++ b/packages/server-core/src/media/static-resource/static-resource-helper.ts
@@ -287,7 +287,8 @@ export const getImageStats = async (
   mimeType: string
 ): Promise<{ width: number; height: number }> => {
   if (mimeType === 'image/ktx2') {
-    if (typeof file === 'string') file = Buffer.from(await (await fetch(file)).arrayBuffer())
+    if (typeof file === 'string')
+      file = Buffer.from(await (await fetch(file, { headers: { range: 'bytes=0-28' } })).arrayBuffer())
     const widthBuffer = file.slice(20, 24)
     const heightBuffer = file.slice(24, 28)
     return {

--- a/packages/server-core/src/media/upload-asset/upload-asset.service.ts
+++ b/packages/server-core/src/media/upload-asset/upload-asset.service.ts
@@ -205,10 +205,14 @@ const uploadAssets = (app: Application) => async (data: AssetUploadType, params:
   }
 }
 
-export const createStaticResourceHash = (file: Buffer | string, props: { name?: string; assetURL?: string }) => {
+export const createStaticResourceHash = (
+  file: Buffer | string,
+  props: { mimeType: string; name?: string; assetURL?: string }
+) => {
   return createHash('sha3-256')
     .update(typeof file === 'string' ? file : file.length.toString())
-    .update(props.name || props.assetURL!.split('/').pop()!.split('.')[0])
+    .update(props.name || props.assetURL!.split('/').pop()!)
+    .update(props.mimeType)
     .digest('hex')
 }
 
@@ -255,7 +259,8 @@ export const addAssetAsStaticResource = async (
 
   const stats = await getStats(file.buffer, file.mimetype)
 
-  const hash = args.hash || createStaticResourceHash(file.buffer, { name: args.name, assetURL: url })
+  const hash =
+    args.hash || createStaticResourceHash(file.buffer, { mimeType: file.mimetype, name: args.name, assetURL: url })
   const body: Partial<StaticResourceType> = {
     hash,
     url,

--- a/packages/server-core/src/media/upload-asset/upload-asset.test.ts
+++ b/packages/server-core/src/media/upload-asset/upload-asset.test.ts
@@ -88,7 +88,7 @@ describe('upload-asset', () => {
         mimetype: 'application/json',
         size: buffer.byteLength
       } as UploadFile
-      const hash = createStaticResourceHash(buffer, { name: 'test.json' })
+      const hash = createStaticResourceHash(buffer, { mimeType: 'application/json', name: 'test.json' })
 
       const args = {
         hash,
@@ -120,7 +120,7 @@ describe('upload-asset', () => {
       // todo - serve this file from a local server
       const assetPath = path.join(appRootPath.path, 'packages/projects/default-project/default.scene.json')
       const name = 'default.scene.json'
-      const hash = createStaticResourceHash(assetPath, { name })
+      const hash = createStaticResourceHash(assetPath, { mimeType: 'application/json', name })
 
       const file = await downloadResourceAndMetadata(assetPath, true)
       const args = {
@@ -150,7 +150,7 @@ describe('upload-asset', () => {
       const storageProvider = getStorageProvider()
       const url = getCachedURL('/projects/default-project/default.scene.json', storageProvider.cacheDomain)
       const name = 'default.scene.json'
-      const hash = createStaticResourceHash(url, { name })
+      const hash = createStaticResourceHash(url, { mimeType: 'application/json', name })
 
       const file = await downloadResourceAndMetadata(url, true)
       const args = {


### PR DESCRIPTION


## Summary
If fetching a ktx2 file for the purposes of getting stats, only fetching the first 28 bytes, as the size is on bytes 20-28. Would have fetched just those bytes, but it's easier to get the preceding bytes as well since if the file passed to getImageStats is a buffer, it doesn't truncate the preceding bytes.

Resolved discrepancies in how file hashes for static resources were being generated. startMediaRecording was only using the file's name, createStaticResourceHash was using the length and name but not mimeType, and getFileMetadata was using all three. All methods are now using length, name, and mimeType to generate hashes.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3997920</samp>

This pull request enhances the recording and uploading of peer media streams and static resources by using a consistent and robust hash function that includes the `mimeType`. It also adds support for the KTX2 texture format by adding its MIME type to the `CommonKnownContentTypes` enum and optimizing the `getImageStats` function.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3997920</samp>

*  Add support for KTX2 texture format by adding 'image/ktx2' MIME type to CommonKnownContentTypes enum ([link](https://github.com/EtherealEngine/etherealengine/pull/8914/files?diff=unified&w=0#diff-283ed94cacd12d811ea0a0af808c5b5c1dc06741e7d22766993344a60528bc85R37))
*  Ensure hash consistency and uniqueness for static resources by adding mimeType to hash calculation in various functions and services ([link](https://github.com/EtherealEngine/etherealengine/pull/8914/files?diff=unified&w=0#diff-1cc284d33e35402ff4d016e80b00af8b2c96a3ff6bc59ec3b151d098ece1ded8L290-R296), [link](https://github.com/EtherealEngine/etherealengine/pull/8914/files?diff=unified&w=0#diff-cdc35f72064ff3b0e0eae03c434f7756645a47922f47084486f640f32adfc652L77-R77), [link](https://github.com/EtherealEngine/etherealengine/pull/8914/files?diff=unified&w=0#diff-51087161442f68c5e789e41eda8110c8d47f29b9b6776133f73607960f40c0faL227-R227), [link](https://github.com/EtherealEngine/etherealengine/pull/8914/files?diff=unified&w=0#diff-f7ddad15aaf9c9b872aa9dddd1864fdafe213cff7d189917cce02247eea4e545L290-R291), [link](https://github.com/EtherealEngine/etherealengine/pull/8914/files?diff=unified&w=0#diff-ef6319c0c74c20f727fd620b049e7944915c7b425b3a480c45425d1c4e7489e9L208-R215), [link](https://github.com/EtherealEngine/etherealengine/pull/8914/files?diff=unified&w=0#diff-ef6319c0c74c20f727fd620b049e7944915c7b425b3a480c45425d1c4e7489e9L258-R263), [link](https://github.com/EtherealEngine/etherealengine/pull/8914/files?diff=unified&w=0#diff-ca3bc009610f1da4632d9e75c69b0f1fe05de92030a47b20dd049d4659a2d836L91-R91), [link](https://github.com/EtherealEngine/etherealengine/pull/8914/files?diff=unified&w=0#diff-ca3bc009610f1da4632d9e75c69b0f1fe05de92030a47b20dd049d4659a2d836L123-R123), [link](https://github.com/EtherealEngine/etherealengine/pull/8914/files?diff=unified&w=0#diff-ca3bc009610f1da4632d9e75c69b0f1fe05de92030a47b20dd049d4659a2d836L153-R153))
*  Optimize image stats function by fetching only the first 29 bytes of the file, which contain the width and height information for KTX2 format ([link](https://github.com/EtherealEngine/etherealengine/pull/8914/files?diff=unified&w=0#diff-f7ddad15aaf9c9b872aa9dddd1864fdafe213cff7d189917cce02247eea4e545L290-R291))
*  Remove unnecessary return statement from startMediaRecording function in `MediasoupRecordingFunctions.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/8914/files?diff=unified&w=0#diff-1cc284d33e35402ff4d016e80b00af8b2c96a3ff6bc59ec3b151d098ece1ded8L301-L302))
*  Test upload-asset service with different MIME types in `upload-asset.test.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/8914/files?diff=unified&w=0#diff-ca3bc009610f1da4632d9e75c69b0f1fe05de92030a47b20dd049d4659a2d836L91-R91), [link](https://github.com/EtherealEngine/etherealengine/pull/8914/files?diff=unified&w=0#diff-ca3bc009610f1da4632d9e75c69b0f1fe05de92030a47b20dd049d4659a2d836L123-R123), [link](https://github.com/EtherealEngine/etherealengine/pull/8914/files?diff=unified&w=0#diff-ca3bc009610f1da4632d9e75c69b0f1fe05de92030a47b20dd049d4659a2d836L153-R153))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3997920</samp>

> _`mimeType` in hash_
> _enhances static resources_
> _autumn of textures_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
