### PR TITLE
Add Priority Queue for Drop Shadows

### DIFF
--- a/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
+++ b/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
@@ -26,12 +26,11 @@ Ethereal Engine. All Rights Reserved.
 import { useEffect } from 'react'
 import { Euler, MathUtils, Mesh, Quaternion, SphereGeometry, Vector3 } from 'three'
 
-import { insertionSort } from '@etherealengine/common/src/utils/insertionSort'
 import { defineState, getMutableState, getState, useHookstate } from '@etherealengine/hyperflux'
 
 import { VRMHumanBoneList } from '@pixiv/three-vrm'
 import { V_010 } from '../../common/constants/MathConstants'
-import { createPriorityQueue } from '../../ecs/PriorityQueue'
+import { createPriorityQueue, createSortAndApplyPriorityQueue } from '../../ecs/PriorityQueue'
 import { Engine } from '../../ecs/classes/Engine'
 import { EngineState } from '../../ecs/classes/EngineState'
 import { Entity } from '../../ecs/classes/Entity'
@@ -40,17 +39,11 @@ import { createEntity, removeEntity } from '../../ecs/functions/EntityFunctions'
 import { defineSystem } from '../../ecs/functions/SystemFunctions'
 import { NetworkObjectComponent } from '../../networking/components/NetworkObjectComponent'
 import { RigidBodyComponent } from '../../physics/components/RigidBodyComponent'
-import { CollisionGroups } from '../../physics/enums/CollisionGroups'
-import { getInteractionGroups } from '../../physics/functions/getInteractionGroups'
 import { RendererState } from '../../renderer/RendererState'
 import { addObjectToGroup } from '../../scene/components/GroupComponent'
 import { NameComponent } from '../../scene/components/NameComponent'
 import { VisibleComponent } from '../../scene/components/VisibleComponent'
-import {
-  DistanceFromCameraComponent,
-  FrustumCullCameraComponent,
-  compareDistanceToCamera
-} from '../../transform/components/DistanceComponents'
+import { compareDistanceToCamera } from '../../transform/components/DistanceComponents'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { isMobileXRHeadset } from '../../xr/XRState'
 import { AnimationComponent } from '.././components/AnimationComponent'
@@ -85,15 +78,6 @@ const avatarComponentQuery = defineQuery([AvatarComponent])
 
 const ikTargetQuery = defineQuery([AvatarIKTargetComponent])
 
-const minimumFrustumCullDistanceSqr = 5 * 5 // 5 units
-
-const filterFrustumCulledEntities = (entity: Entity) =>
-  !(
-    DistanceFromCameraComponent.squaredDistance[entity] > minimumFrustumCullDistanceSqr &&
-    FrustumCullCameraComponent.isCulled[entity]
-  )
-
-let avatarSortAccumulator = 0
 const _quat = new Quaternion()
 const _vector3 = new Vector3()
 const _right = new Vector3()
@@ -126,7 +110,6 @@ const setVisualizers = () => {
     visualizers[i].set(e)
   }
 }
-const interactionGroups = getInteractionGroups(CollisionGroups.Avatars, CollisionGroups.Default)
 
 interface targetTransform {
   position: Vector3
@@ -139,6 +122,8 @@ const ikDataByName = {} as Record<string, targetTransform>
 const footRaycastInterval = 0.25
 let footRaycastTimer = 0
 
+const sortAndApplyPriorityQueue = createSortAndApplyPriorityQueue(avatarComponentQuery, compareDistanceToCamera)
+
 const execute = () => {
   const { priorityQueue, sortedTransformEntities, visualizers } = getState(AvatarAnimationState)
   const { elapsedSeconds, deltaSeconds } = getState(EngineState)
@@ -147,43 +132,7 @@ const execute = () => {
   /**
    * 1 - Sort & apply avatar priority queue
    */
-
-  let needsSorting = false
-  avatarSortAccumulator += deltaSeconds
-  if (avatarSortAccumulator > 1) {
-    needsSorting = true
-    avatarSortAccumulator = 0
-  }
-
-  for (const entity of avatarComponentQuery.enter()) {
-    sortedTransformEntities.push(entity)
-    needsSorting = true
-  }
-
-  for (const entity of avatarComponentQuery.exit()) {
-    const idx = sortedTransformEntities.indexOf(entity)
-    idx > -1 && sortedTransformEntities.splice(idx, 1)
-    needsSorting = true
-    priorityQueue.removeEntity(entity)
-  }
-
-  if (needsSorting && sortedTransformEntities.length > 1) {
-    insertionSort(sortedTransformEntities, compareDistanceToCamera)
-  }
-
-  const filteredSortedTransformEntities: Array<Entity> = []
-  for (let i = 0; i < sortedTransformEntities.length; i++) {
-    if (filterFrustumCulledEntities(sortedTransformEntities[i]))
-      filteredSortedTransformEntities.push(sortedTransformEntities[i])
-  }
-
-  for (let i = 0; i < filteredSortedTransformEntities.length; i++) {
-    const entity = filteredSortedTransformEntities[i]
-    const accumulation = Math.min(Math.exp(1 / (i + 1)) / 3, 1)
-    priorityQueue.addPriority(entity, accumulation * accumulation)
-  }
-
-  priorityQueue.update()
+  sortAndApplyPriorityQueue(priorityQueue, sortedTransformEntities, deltaSeconds)
 
   /**
    * 2 - Apply avatar animations

--- a/packages/engine/src/scene/systems/ShadowSystem.tsx
+++ b/packages/engine/src/scene/systems/ShadowSystem.tsx
@@ -32,7 +32,6 @@ import {
   Material,
   Mesh,
   MeshBasicMaterial,
-  Object3D,
   PlaneGeometry,
   Quaternion,
   Raycaster,
@@ -42,12 +41,13 @@ import {
 } from 'three'
 
 import config from '@etherealengine/common/src/config'
-import { getMutableState, getState, hookstate, useHookstate } from '@etherealengine/hyperflux'
+import { defineState, getMutableState, getState, hookstate, useHookstate } from '@etherealengine/hyperflux'
 
 import { AssetLoader } from '../../assets/classes/AssetLoader'
 import { CSM } from '../../assets/csm/CSM'
 import { CameraComponent } from '../../camera/components/CameraComponent'
 import { V_001 } from '../../common/constants/MathConstants'
+import { createPriorityQueue, createSortAndApplyPriorityQueue } from '../../ecs/PriorityQueue'
 import { Engine } from '../../ecs/classes/Engine'
 import { EngineState } from '../../ecs/classes/EngineState'
 import { Entity } from '../../ecs/classes/Entity'
@@ -64,12 +64,13 @@ import {
 } from '../../ecs/functions/ComponentFunctions'
 import { createEntity, removeEntity, useEntityContext } from '../../ecs/functions/EntityFunctions'
 import { createQueryReactor, defineSystem } from '../../ecs/functions/SystemFunctions'
-import { BoundingBoxComponent } from '../../interaction/components/BoundingBoxComponents'
 import { RendererState } from '../../renderer/RendererState'
 import { EngineRenderer, RenderSettingsState } from '../../renderer/WebGLRendererSystem'
 import { getShadowsEnabled, useShadowsEnabled } from '../../renderer/functions/RenderSettingsFunction'
+import { compareDistanceToCamera } from '../../transform/components/DistanceComponents'
 import { TransformComponent } from '../../transform/components/TransformComponent'
 import { XRLightProbeState } from '../../xr/XRLightProbeSystem'
+import { isMobileXRHeadset } from '../../xr/XRState'
 import { DirectionalLightComponent } from '../components/DirectionalLightComponent'
 import { DropShadowComponent } from '../components/DropShadowComponent'
 import { GroupComponent, addObjectToGroup } from '../components/GroupComponent'
@@ -77,6 +78,21 @@ import { NameComponent } from '../components/NameComponent'
 import { ShadowComponent } from '../components/ShadowComponent'
 import { VisibleComponent } from '../components/VisibleComponent'
 import { ObjectLayers } from '../constants/ObjectLayers'
+
+export const ShadowSystemState = defineState({
+  name: 'ee.engine.scene.ShadowSystemState',
+  initial: () => {
+    const accumulationBudget = isMobileXRHeadset ? 4 : 20
+
+    const priorityQueue = createPriorityQueue({
+      accumulationBudget
+    })
+
+    return {
+      priorityQueue
+    }
+  }
+})
 
 export const shadowDirection = new Vector3(0, -1, 0)
 const shadowRotation = new Quaternion()
@@ -201,8 +217,6 @@ const shadowState = hookstate(null as MeshBasicMaterial | null)
 
 const dropShadowComponentQuery = defineQuery([DropShadowComponent, GroupComponent])
 
-let sceneObjects = [] as Object3D<any>[]
-
 const minRadius = 0.15
 const maxRadius = 5
 const sphere = new Sphere()
@@ -213,7 +227,6 @@ const DropShadowReactor = createQueryReactor([ShadowComponent], function DropSha
   const useShadows = useShadowsEnabled()
   const shadowMaterial = useHookstate(shadowState)
   const groupComponent = useOptionalComponent(entity, GroupComponent)
-  const boundingBoxComponent = useOptionalComponent(entity, BoundingBoxComponent)
   const shadow = useComponent(entity, ShadowComponent)
 
   useEffect(() => {
@@ -256,41 +269,53 @@ const DropShadowReactor = createQueryReactor([ShadowComponent], function DropSha
 
 const shadowOffset = new Vector3(0, 0.01, 0)
 
+const sortAndApplyPriorityQueue = createSortAndApplyPriorityQueue(dropShadowComponentQuery, compareDistanceToCamera)
+const sortedEntityTransforms = [] as Entity[]
+
+const updateDropShadowTransforms = () => {
+  const { deltaSeconds } = getState(EngineState)
+  const { priorityQueue } = getState(ShadowSystemState)
+
+  sortAndApplyPriorityQueue(priorityQueue, sortedEntityTransforms, deltaSeconds)
+
+  const sceneObjects = Array.from(Engine.instance.objectLayerList[ObjectLayers.Camera] || [])
+
+  for (const entity of priorityQueue.priorityEntities) {
+    const dropShadow = getComponent(entity, DropShadowComponent)
+    const group = getComponent(entity, GroupComponent)
+    const dropShadowTransform = getComponent(dropShadow.entity, TransformComponent)
+
+    raycasterPosition.copy(group[0].position).add(dropShadow.center)
+    raycaster.set(raycasterPosition, shadowDirection)
+
+    const intersected = raycaster.intersectObjects(sceneObjects)[0]
+    if (!intersected || !intersected.face) {
+      dropShadowTransform.scale.setScalar(0)
+      continue
+    }
+
+    const centerCorrectedDist = Math.max(intersected.distance - dropShadow.center.y, 0.0001)
+
+    //arbitrary bias to make it a bit smaller
+    const sizeBias = 0.3
+    const finalRadius = sizeBias * dropShadow.radius + dropShadow.radius * centerCorrectedDist * 0.5
+
+    const shadowMaterial = (getComponent(dropShadow.entity, GroupComponent)[0] as any).material as Material
+    shadowMaterial.opacity = Math.min(1 / (1 + centerCorrectedDist), 1) * 0.6
+
+    shadowRotation.setFromUnitVectors(intersected.face.normal, V_001)
+    dropShadowTransform.rotation.copy(shadowRotation)
+    dropShadowTransform.scale.setScalar(finalRadius * 2)
+    dropShadowTransform.position.copy(intersected.point.add(shadowOffset))
+  }
+}
+
 const execute = () => {
   const renderState = getState(RendererState)
 
-  sceneObjects = Array.from(Engine.instance.objectLayerList[ObjectLayers.Camera] || [])
-
   const useShadows = getShadowsEnabled()
   if (!useShadows && !getState(EngineState).isEditor) {
-    for (const entity of dropShadowComponentQuery()) {
-      const dropShadow = getComponent(entity, DropShadowComponent)
-      const group = getComponent(entity, GroupComponent)
-      const dropShadowTransform = getComponent(dropShadow.entity, TransformComponent)
-
-      raycasterPosition.copy(group[0].position).add(dropShadow.center)
-      raycaster.set(raycasterPosition, shadowDirection)
-
-      const intersected = raycaster.intersectObjects(sceneObjects)[0]
-      if (!intersected || !intersected.face) {
-        dropShadowTransform.scale.setScalar(0)
-        continue
-      }
-
-      const centerCorrectedDist = Math.max(intersected.distance - dropShadow.center.y, 0.0001)
-
-      //arbitrary bias to make it a bit smaller
-      const sizeBias = 0.3
-      const finalRadius = sizeBias * dropShadow.radius + dropShadow.radius * centerCorrectedDist * 0.5
-
-      const shadowMaterial = (getComponent(dropShadow.entity, GroupComponent)[0] as any).material as Material
-      shadowMaterial.opacity = Math.min(1 / (1 + centerCorrectedDist), 1) * 0.6
-
-      shadowRotation.setFromUnitVectors(intersected.face.normal, V_001)
-      dropShadowTransform.rotation.copy(shadowRotation)
-      dropShadowTransform.scale.setScalar(finalRadius * 2)
-      dropShadowTransform.position.copy(intersected.point.add(shadowOffset))
-    }
+    updateDropShadowTransforms()
     return
   }
 


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a8ba572</samp>

This pull request refactors two systems (`AvatarAnimationSystem` and `ShadowSystem`) to use a new utility function (`createSortAndApplyPriorityQueue`) from the `PriorityQueue` module. This improves the performance and readability of the systems and reduces code duplication. The pull request also refactors the `PriorityQueue` module to export the new utility function.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a8ba572</samp>

*  Refactor the logic of sorting and applying a priority queue into a separate function `createSortAndApplyPriorityQueue` in `PriorityQueue.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/8917/files?diff=unified&w=0#diff-7a339d227425a1416ad55cf2cdb9f48077379ff5b86d72980cd56a2109a1ad89R83-R137))
*  Move the constants and the function that are used by `createSortAndApplyPriorityQueue` from `AvatarAnimationSystem.ts` to `PriorityQueue.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/8917/files?diff=unified&w=0#diff-e0a011e84a40926910be0273bb512c563d8c83d4becd2e1ac35f7075e5a33e20L88-L96), [link](https://github.com/EtherealEngine/etherealengine/pull/8917/files?diff=unified&w=0#diff-7a339d227425a1416ad55cf2cdb9f48077379ff5b86d72980cd56a2109a1ad89L28-R31))
*  Use `createSortAndApplyPriorityQueue` to simplify the `execute` function of `AvatarAnimationSystem.ts` and `ShadowSystem.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/8917/files?diff=unified&w=0#diff-e0a011e84a40926910be0273bb512c563d8c83d4becd2e1ac35f7075e5a33e20R125-R126), [link](https://github.com/EtherealEngine/etherealengine/pull/8917/files?diff=unified&w=0#diff-e0a011e84a40926910be0273bb512c563d8c83d4becd2e1ac35f7075e5a33e20L150-R136), [link](https://github.com/EtherealEngine/etherealengine/pull/8917/files?diff=unified&w=0#diff-393e0b925307f802e0c3a972156e0dee27f34713498bba7c0ba59bfb41de5619L259-R318))
*  Create a new state `ShadowSystemState` to store and update the priority queue for the drop shadows in `ShadowSystem.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/8917/files?diff=unified&w=0#diff-393e0b925307f802e0c3a972156e0dee27f34713498bba7c0ba59bfb41de5619L45-R44), [link](https://github.com/EtherealEngine/etherealengine/pull/8917/files?diff=unified&w=0#diff-393e0b925307f802e0c3a972156e0dee27f34713498bba7c0ba59bfb41de5619R82-R96))
*  Use `isMobileXRHeadset` to determine the accumulation budget for the priority queue in `ShadowSystem.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/8917/files?diff=unified&w=0#diff-393e0b925307f802e0c3a972156e0dee27f34713498bba7c0ba59bfb41de5619L67-R73))
*  Remove unused or dead code from `AvatarAnimationSystem.ts` and `ShadowSystem.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/8917/files?diff=unified&w=0#diff-e0a011e84a40926910be0273bb512c563d8c83d4becd2e1ac35f7075e5a33e20L43-R46), [link](https://github.com/EtherealEngine/etherealengine/pull/8917/files?diff=unified&w=0#diff-e0a011e84a40926910be0273bb512c563d8c83d4becd2e1ac35f7075e5a33e20L129), [link](https://github.com/EtherealEngine/etherealengine/pull/8917/files?diff=unified&w=0#diff-393e0b925307f802e0c3a972156e0dee27f34713498bba7c0ba59bfb41de5619L35), [link](https://github.com/EtherealEngine/etherealengine/pull/8917/files?diff=unified&w=0#diff-393e0b925307f802e0c3a972156e0dee27f34713498bba7c0ba59bfb41de5619L216))
*  Avoid creating a global variable `sceneObjects` and use a local variable instead in `ShadowSystem.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/8917/files?diff=unified&w=0#diff-393e0b925307f802e0c3a972156e0dee27f34713498bba7c0ba59bfb41de5619L204-L205))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a8ba572</samp>

> _To make the animations look fine_
> _We used a new function this time_
> _`createSortAndApplyPriorityQueue`_
> _Is what we now do_
> _And also for shadows, it's sublime_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
