### PR TITLE
reintegrate tracking space scaling

### DIFF
--- a/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
+++ b/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
@@ -416,14 +416,13 @@ const execute = () => {
 const reactor = () => {
   const heightDifference = useHookstate(getMutableState(XRState).userAvatarHeightDifference)
   const xrState = getMutableState(XRState)
-  const mode = useHookstate(xrState.sessionMode)
   const pose = useHookstate(xrState.viewerPose)
   useEffect(() => {
     if (heightDifference.value) xrState.sceneScale.set(Math.max(heightDifference.value, 0.5))
     xrState.avatarCameraMode.set('attached')
   }, [heightDifference])
   useEffect(() => {
-    if (mode.value == 'immersive-vr' && !heightDifference.value) setTrackingSpace()
+    if (xrState.sessionMode.value == 'immersive-vr' && !heightDifference.value) setTrackingSpace()
   }, [pose])
   const renderState = useHookstate(getMutableState(RendererState))
   useEffect(() => {

--- a/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
+++ b/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
@@ -52,7 +52,7 @@ import {
   compareDistanceToCamera
 } from '../../transform/components/DistanceComponents'
 import { TransformComponent } from '../../transform/components/TransformComponent'
-import { isMobileXRHeadset } from '../../xr/XRState'
+import { XRState, isMobileXRHeadset } from '../../xr/XRState'
 import { AnimationComponent } from '.././components/AnimationComponent'
 import { AvatarAnimationComponent, AvatarRigComponent } from '.././components/AvatarAnimationComponent'
 import { AvatarIKTargetComponent } from '.././components/AvatarIKComponents'
@@ -411,6 +411,12 @@ const execute = () => {
 }
 
 const reactor = () => {
+  const localAvatarScale = useHookstate(getMutableState(XRState).userAvatarHeightDifference)
+  useEffect(() => {
+    const xrState = getMutableState(XRState)
+    xrState.sceneScale.set(Math.max(localAvatarScale.value, 0.5))
+    xrState.avatarCameraMode.set('attached')
+  }, [localAvatarScale])
   const renderState = useHookstate(getMutableState(RendererState))
   useEffect(() => {
     setVisualizers()

--- a/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
+++ b/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
@@ -52,6 +52,7 @@ import {
   compareDistanceToCamera
 } from '../../transform/components/DistanceComponents'
 import { TransformComponent } from '../../transform/components/TransformComponent'
+import { setTrackingSpace } from '../../xr/XRScaleAdjustmentFunctions'
 import { XRState, isMobileXRHeadset } from '../../xr/XRState'
 import { AnimationComponent } from '.././components/AnimationComponent'
 import { AvatarAnimationComponent, AvatarRigComponent } from '.././components/AvatarAnimationComponent'
@@ -412,11 +413,15 @@ const execute = () => {
 
 const reactor = () => {
   const localAvatarScale = useHookstate(getMutableState(XRState).userAvatarHeightDifference)
+  const mode = useHookstate(getMutableState(XRState).sessionMode)
   useEffect(() => {
     const xrState = getMutableState(XRState)
     xrState.sceneScale.set(Math.max(localAvatarScale.value, 0.5))
     xrState.avatarCameraMode.set('attached')
   }, [localAvatarScale])
+  useEffect(() => {
+    if (mode.value == 'immersive-vr') setTrackingSpace()
+  }, [mode])
   const renderState = useHookstate(getMutableState(RendererState))
   useEffect(() => {
     setVisualizers()

--- a/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
+++ b/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
@@ -205,6 +205,8 @@ const execute = () => {
   footRaycastTimer += deltaSeconds
   updateAnimationGraph(avatarAnimationEntities)
 
+  console.log(getState(XRState).viewerPose)
+
   for (const entity of avatarAnimationEntities) {
     const rigComponent = getComponent(entity, AvatarRigComponent)
     const avatarAnimationComponent = getComponent(entity, AvatarAnimationComponent)
@@ -412,16 +414,17 @@ const execute = () => {
 }
 
 const reactor = () => {
-  const localAvatarScale = useHookstate(getMutableState(XRState).userAvatarHeightDifference)
-  const mode = useHookstate(getMutableState(XRState).sessionMode)
+  const heightDifference = useHookstate(getMutableState(XRState).userAvatarHeightDifference)
+  const xrState = getMutableState(XRState)
+  const mode = useHookstate(xrState.sessionMode)
+  const pose = useHookstate(xrState.viewerPose)
   useEffect(() => {
-    const xrState = getMutableState(XRState)
-    xrState.sceneScale.set(Math.max(localAvatarScale.value, 0.5))
+    if (heightDifference.value) xrState.sceneScale.set(Math.max(heightDifference.value, 0.5))
     xrState.avatarCameraMode.set('attached')
-  }, [localAvatarScale])
+  }, [heightDifference])
   useEffect(() => {
-    if (mode.value == 'immersive-vr') setTrackingSpace()
-  }, [mode])
+    if (mode.value == 'immersive-vr' && !heightDifference.value) setTrackingSpace()
+  }, [pose])
   const renderState = useHookstate(getMutableState(RendererState))
   useEffect(() => {
     setVisualizers()

--- a/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
+++ b/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
@@ -205,8 +205,6 @@ const execute = () => {
   footRaycastTimer += deltaSeconds
   updateAnimationGraph(avatarAnimationEntities)
 
-  console.log(getState(XRState).viewerPose)
-
   for (const entity of avatarAnimationEntities) {
     const rigComponent = getComponent(entity, AvatarRigComponent)
     const avatarAnimationComponent = getComponent(entity, AvatarAnimationComponent)

--- a/packages/engine/src/avatar/systems/AvatarIKTargetSystem.ts
+++ b/packages/engine/src/avatar/systems/AvatarIKTargetSystem.ts
@@ -41,7 +41,6 @@ import { VisibleComponent } from '../../scene/components/VisibleComponent'
 import { ObjectLayers } from '../../scene/constants/ObjectLayers'
 import { setObjectLayers } from '../../scene/functions/setObjectLayers'
 import { TransformComponent } from '../../transform/components/TransformComponent'
-import { setTrackingSpace } from '../../xr/XRScaleAdjustmentFunctions'
 import { XRAction, XRState, getCameraMode } from '../../xr/XRState'
 import { ikTargets } from '../animation/Util'
 import { AvatarRigComponent } from '../components/AvatarAnimationComponent'
@@ -96,8 +95,6 @@ const execute = () => {
     setObjectLayers(helper, ObjectLayers.Gizmos)
     addObjectToGroup(entity, helper)
     setComponent(entity, VisibleComponent)
-
-    setTrackingSpace()
   }
 
   // todo - remove ik targets when session ends

--- a/packages/engine/src/xr/XRScaleAdjustmentFunctions.ts
+++ b/packages/engine/src/xr/XRScaleAdjustmentFunctions.ts
@@ -38,5 +38,5 @@ export const getTrackingSpaceOffset = (height: number) => {
 export const setTrackingSpace = () => {
   const xrState = getMutableState(XRState)
   const offset = xrState.viewerPose.value ? getTrackingSpaceOffset(xrState.viewerPose.value.transform.position.y) : 1
-  xrState.localAvatarScale.set(offset)
+  xrState.userAvatarHeightDifference.set(offset)
 }

--- a/packages/engine/src/xr/XRSessionFunctions.ts
+++ b/packages/engine/src/xr/XRSessionFunctions.ts
@@ -38,6 +38,7 @@ import { computeAndUpdateWorldOrigin, updateEyeHeight } from '../transform/updat
 import { Engine } from './../ecs/classes/Engine'
 import { addComponent, getComponent, hasComponent } from './../ecs/functions/ComponentFunctions'
 import { EngineRenderer } from './../renderer/WebGLRendererSystem'
+import { setTrackingSpace } from './XRScaleAdjustmentFunctions'
 import { ReferenceSpace, XRAction, XRState, getCameraMode } from './XRState'
 
 const quat180y = new Quaternion().setFromAxisAngle(new Vector3(0, 1, 0), Math.PI)
@@ -102,6 +103,8 @@ export const setupXRSession = async (requestedMode?: 'inline' | 'immersive-ar' |
       : xrState.supportedSessionModes['immersive-vr'].value
       ? 'immersive-vr'
       : 'inline')
+
+  if (mode == 'immersive-vr') setTrackingSpace()
 
   xrState.requestingSession.set(true)
 

--- a/packages/engine/src/xr/XRSessionFunctions.ts
+++ b/packages/engine/src/xr/XRSessionFunctions.ts
@@ -38,7 +38,6 @@ import { computeAndUpdateWorldOrigin, updateEyeHeight } from '../transform/updat
 import { Engine } from './../ecs/classes/Engine'
 import { addComponent, getComponent, hasComponent } from './../ecs/functions/ComponentFunctions'
 import { EngineRenderer } from './../renderer/WebGLRendererSystem'
-import { setTrackingSpace } from './XRScaleAdjustmentFunctions'
 import { ReferenceSpace, XRAction, XRState, getCameraMode } from './XRState'
 
 const quat180y = new Quaternion().setFromAxisAngle(new Vector3(0, 1, 0), Math.PI)
@@ -103,8 +102,6 @@ export const setupXRSession = async (requestedMode?: 'inline' | 'immersive-ar' |
       : xrState.supportedSessionModes['immersive-vr'].value
       ? 'immersive-vr'
       : 'inline')
-
-  if (mode == 'immersive-vr') setTrackingSpace()
 
   xrState.requestingSession.set(true)
 

--- a/packages/engine/src/xr/XRSessionFunctions.ts
+++ b/packages/engine/src/xr/XRSessionFunctions.ts
@@ -65,6 +65,7 @@ export const onSessionEnd = () => {
 
   dispatchAction(XRAction.sessionChanged({ active: false }))
 
+  xrState.userAvatarHeightDifference.set(null)
   xrState.session.set(null)
 }
 

--- a/packages/engine/src/xr/XRState.ts
+++ b/packages/engine/src/xr/XRState.ts
@@ -55,7 +55,7 @@ export const XRState = defineState({
       session: null as XRSession | null,
       sessionMode: 'none' as 'inline' | 'immersive-ar' | 'immersive-vr' | 'none',
       avatarCameraMode: 'auto' as 'auto' | 'attached' | 'detached',
-      localAvatarScale: 1,
+      userAvatarHeightDifference: 1,
       /** Stores the depth map data - will exist if depth map is supported */
       depthDataTexture: null as DepthDataTexture | null,
       is8thWallActive: false,

--- a/packages/engine/src/xr/XRState.ts
+++ b/packages/engine/src/xr/XRState.ts
@@ -55,7 +55,7 @@ export const XRState = defineState({
       session: null as XRSession | null,
       sessionMode: 'none' as 'inline' | 'immersive-ar' | 'immersive-vr' | 'none',
       avatarCameraMode: 'auto' as 'auto' | 'attached' | 'detached',
-      userAvatarHeightDifference: 1,
+      userAvatarHeightDifference: null as number | null,
       /** Stores the depth map data - will exist if depth map is supported */
       depthDataTexture: null as DepthDataTexture | null,
       is8thWallActive: false,


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e587730</samp>

The pull request adds a feature to adjust the avatar height and scene scale in VR mode using the `userAvatarHeightDifference` and `sceneScale` state variables. It also refactors some XR functions and modules to improve the avatar animation and positioning in immersive VR mode.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e587730</samp>

*  Renamed `localAvatarScale` to `userAvatarHeightDifference` in state variables and hooks to avoid confusion with `sceneScale` and clarify meaning ([link](https://github.com/EtherealEngine/etherealengine/pull/8921/files?diff=unified&w=0#diff-41b884e9f85ee750ba8098befd2248095dac2308711c5e76dd335881c3035750L41-R41), [link](https://github.com/EtherealEngine/etherealengine/pull/8921/files?diff=unified&w=0#diff-7c2cb31b78634868ae12c850427282896a8e7f30dc785e16da9fe4a193c59d5cL58-R58), [link](https://github.com/EtherealEngine/etherealengine/pull/8921/files?diff=unified&w=0#diff-e0a011e84a40926910be0273bb512c563d8c83d4becd2e1ac35f7075e5a33e20R414-R419))
*  Moved `setTrackingSpace` function from `AvatarIKTargetSystem.ts` to `XRScaleAdjustmentFunctions.ts` to centralize scaling logic for XR tracking space ([link](https://github.com/EtherealEngine/etherealengine/pull/8921/files?diff=unified&w=0#diff-f5502b213a611190e3eb8480261be1b5ab00e0818450adddd4dadbbf451c8b3cL44), [link](https://github.com/EtherealEngine/etherealengine/pull/8921/files?diff=unified&w=0#diff-e6322f4d505cddcf9d5b85deb21835c4e19acd87d6ae80343b98b63ad35b132eR41))
*  Called `setTrackingSpace` function in `XRSessionFunctions.ts` when XR session mode is `immersive-vr` to scale tracking space based on user avatar height difference when entering VR mode ([link](https://github.com/EtherealEngine/etherealengine/pull/8921/files?diff=unified&w=0#diff-f5502b213a611190e3eb8480261be1b5ab00e0818450adddd4dadbbf451c8b3cL99-L100), [link](https://github.com/EtherealEngine/etherealengine/pull/8921/files?diff=unified&w=0#diff-e6322f4d505cddcf9d5b85deb21835c4e19acd87d6ae80343b98b63ad35b132eR107-R108))
*  Imported `XRState` module in `AvatarAnimationSystem.ts` to access XR state variables related to scaling and camera mode ([link](https://github.com/EtherealEngine/etherealengine/pull/8921/files?diff=unified&w=0#diff-e0a011e84a40926910be0273bb512c563d8c83d4becd2e1ac35f7075e5a33e20L55-R55))
*  Created `localAvatarScale` hook in `AvatarAnimationSystem.ts` to track ratio between user avatar height and default avatar height and update `sceneScale` and `avatarCameraMode` state variables accordingly ([link](https://github.com/EtherealEngine/etherealengine/pull/8921/files?diff=unified&w=0#diff-e0a011e84a40926910be0273bb512c563d8c83d4becd2e1ac35f7075e5a33e20R414-R419))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e587730</samp>

> _To make VR more immersive and fun_
> _We added a feature to scale everyone_
> _The `localAvatarScale` hook_
> _And the `XRState` nook_
> _Adjust the `trackingSpace` and the `sceneScale` when done_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
