### PR TITLE
fix selecting non scene entities crashing studio

### DIFF
--- a/packages/editor/src/systems/EditorControlSystem.tsx
+++ b/packages/editor/src/systems/EditorControlSystem.tsx
@@ -652,7 +652,7 @@ const execute = () => {
       if (selectStartPosition.distanceTo(cursorPosition) < SELECT_SENSITIVITY) {
         const result = getIntersectingNodeOnScreen(raycaster, cursorPosition)
         if (result) {
-          if (result.node) {
+          if (result.node && (typeof result.node === 'string' || hasComponent(result.node, SceneObjectComponent))) {
             if (shift) {
               EditorControlFunctions.toggleSelection([result.node])
             } else {


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 66f6beb</samp>

Fixed a bug in the editor that allowed selecting non-scene objects. Modified the `SelectObject` class in `EditorControlSystem.tsx` to filter out nodes that are not strings or scene objects.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 66f6beb</samp>

*  Prevent selecting non-scene objects in the editor by checking the node type ([link](https://github.com/EtherealEngine/etherealengine/pull/8922/files?diff=unified&w=0#diff-5a1b8e4b511f667be5d2dc9dfe22eb80c5373151458f0ca3a77dd3ba688e274bL655-R655))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 66f6beb</samp>

> _`SelectObject` checks_
> _node type before selection_
> _avoiding errors_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
