### PR TITLE
fix single mode & improve invalid path handling

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -233,7 +233,8 @@
       "info-synchronize": "If true, the media will be synchronized on all the connected clients.",
       "lbl-volume": "Volume",
       "lbl-isMusic": "Is Music",
-      "lbl-size": "Size"
+      "lbl-size": "Size",
+      "seektime": "Start Time"
     },
     "audio": {
       "name": "Positional Audio",

--- a/packages/editor/src/components/properties/MediaNodeEditor.tsx
+++ b/packages/editor/src/components/properties/MediaNodeEditor.tsx
@@ -29,7 +29,11 @@ import { useTranslation } from 'react-i18next'
 import { AllFileTypes } from '@etherealengine/engine/src/assets/constants/fileTypes'
 import { useComponent } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
 import { getEntityErrors } from '@etherealengine/engine/src/scene/components/ErrorComponent'
-import { MediaComponent } from '@etherealengine/engine/src/scene/components/MediaComponent'
+import {
+  MediaComponent,
+  MediaElementComponent,
+  setTime
+} from '@etherealengine/engine/src/scene/components/MediaComponent'
 import { PlayMode } from '@etherealengine/engine/src/scene/constants/PlayMode'
 
 import { SupportedFileTypes } from '../../constants/AssetTypes'
@@ -38,6 +42,7 @@ import BooleanInput from '../inputs/BooleanInput'
 import { PropertiesPanelButton } from '../inputs/Button'
 import CompoundNumericInput from '../inputs/CompoundNumericInput'
 import InputGroup from '../inputs/InputGroup'
+import NumericInputGroup from '../inputs/NumericInputGroup'
 import SelectInput from '../inputs/SelectInput'
 import NodeEditor from './NodeEditor'
 import { EditorComponentType, updateProperty } from './Util'
@@ -65,6 +70,7 @@ export const MediaNodeEditor: EditorComponentType = (props) => {
   const { t } = useTranslation()
 
   const media = useComponent(props.entity, MediaComponent)
+  const element = useComponent(props.entity, MediaElementComponent)
   const errors = getEntityErrors(props.entity, MediaComponent)
 
   const toggle = () => {
@@ -72,7 +78,7 @@ export const MediaNodeEditor: EditorComponentType = (props) => {
   }
 
   const reset = () => {
-    media.seekTime.set(0.001) //safer to set to positive value
+    setTime(element.element, media.seekTime.value)
   }
 
   return (
@@ -97,6 +103,12 @@ export const MediaNodeEditor: EditorComponentType = (props) => {
           onChange={updateProperty(MediaComponent, 'volume')}
         />
       </InputGroup>
+      <NumericInputGroup
+        name="Seek Time"
+        label={t('editor:properties.media.seektime')}
+        value={media.seekTime.value}
+        onChange={updateProperty(MediaComponent, 'seekTime')}
+      />
       <InputGroup name="Is Music" label={t('editor:properties.media.lbl-isMusic')}>
         <BooleanInput value={media.isMusic.value} onChange={updateProperty(MediaComponent, 'isMusic')} />
       </InputGroup>

--- a/packages/engine/src/scene/components/MediaComponent.ts
+++ b/packages/engine/src/scene/components/MediaComponent.ts
@@ -27,7 +27,7 @@ import Hls from 'hls.js'
 import { startTransition, useEffect } from 'react'
 import { DoubleSide, Mesh, MeshBasicMaterial, PlaneGeometry } from 'three'
 
-import { getMutableState, getState, none, useHookstate } from '@etherealengine/hyperflux'
+import { State, getMutableState, getState, none, useHookstate } from '@etherealengine/hyperflux'
 
 import { AssetLoader } from '../../assets/classes/AssetLoader'
 import { AudioState } from '../../audio/AudioState'
@@ -138,7 +138,7 @@ export const MediaComponent = defineComponent({
       // runtime props
       paused: true,
       ended: true,
-      seekTime: -1,
+      seekTime: 0,
       waiting: false,
       track: 0,
       trackDurations: [] as number[],
@@ -297,12 +297,9 @@ export function MediaReactor() {
 
   useEffect(
     function updateSeekTime() {
-      console.log('DEBUG Triggred seek')
-      if (!mediaElement || media.seekTime.value < 0 || mediaElement.element.value.currentTime === media.seekTime.value)
-        return
-      mediaElement.element.currentTime.set(media.seekTime.value) // set time and stop playing
-      if (!media.paused.value) mediaElement.element.value.play()
-      media.seekTime.set(-1)
+      if (!mediaElement) return
+      setTime(mediaElement.element, media.seekTime.value)
+      if (!mediaElement.element.paused.value) mediaElement.element.value.play() // if not paused, start play again
     },
     [media.seekTime, mediaElement]
   )
@@ -532,6 +529,11 @@ export const setupHLS = (entity: Entity, url: string): Hls => {
   })
 
   return hls
+}
+
+export function setTime(element: State<HTMLMediaElement>, time: number) {
+  if (!element.value || time < 0 || element.value.currentTime === time) return
+  element.currentTime.set(time)
 }
 
 export function getNextTrack(currentTrack: number, trackCount: number, currentMode: PlayMode) {


### PR DESCRIPTION
## Summary
Fixes single play mode. And handles invalid paths cleanly

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c8f1fac</samp>

*  Added `getNextTrack` function to determine the next track to play based on the media resources, the current track, and the play mode ([link](https://github.com/EtherealEngine/etherealengine/pull/8926/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cR538-R539), [link](https://github.com/EtherealEngine/etherealengine/pull/8926/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cL542-L543))
*  Modified `updateMediaElement` function to use `getNextTrack` function and handle different play modes consistently ([link](https://github.com/EtherealEngine/etherealengine/pull/8926/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cL354-R362), [link](https://github.com/EtherealEngine/etherealengine/pull/8926/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cL413-L416))
*  Modified `updateMediaElement` function to set the `media.ended` and `media.track` values before loading the media element ([link](https://github.com/EtherealEngine/etherealengine/pull/8926/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cR377-R379))
*  Modified `updateMediaElement` function to set the `media.ended` and `media.waiting` values in case of an error while loading the media element ([link](https://github.com/EtherealEngine/etherealengine/pull/8926/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cL402-R408))
*  Modified `MediaReactor` function to update the media element whenever the `media.playMode` value changes ([link](https://github.com/EtherealEngine/etherealengine/pull/8926/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cL448-R449))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c8f1fac</samp>

> _`updateMediaElement` with the power of sound_
> _`getNextTrack` from the resources we found_
> _Choose your play mode, single, loop, or shuffle_
> _Control your destiny, don't let them muffle_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
