### PR TITLE
Added some checks for resolvers after removes

### DIFF
--- a/packages/server-core/src/bot/bot/bot.resolvers.ts
+++ b/packages/server-core/src/bot/bot/bot.resolvers.ts
@@ -44,27 +44,21 @@ export const botResolver = resolve<BotType, HookContext>({})
 
 export const botExternalResolver = resolve<BotType, HookContext>({
   location: virtual(async (bot, context) => {
-    if (bot.locationId) {
-      const location = await context.app.service(locationPath)._get(bot.locationId)
-      return location
-    }
+    if (context.event !== 'removed' && bot.locationId)
+      return await context.app.service(locationPath)._get(bot.locationId)
   }),
   instance: virtual(async (bot, context) => {
-    if (bot.instanceId) {
-      const instance = (await context.app.service(instancePath)._get(bot.instanceId)) as any as InstanceType
-      return instance
-    }
+    if (context.event !== 'removed' && bot.instanceId)
+      return (await context.app.service(instancePath)._get(bot.instanceId)) as any as InstanceType
   }),
   botCommands: virtual(async (bot, context) => {
-    if (bot.id) {
-      const botCommands = (await context.app.service(botCommandPath).find({
+    if (context.event !== 'removed' && bot.id)
+      return (await context.app.service(botCommandPath).find({
         query: {
           botId: bot.id
         },
         paginate: false
       })) as BotCommandType[]
-      return botCommands
-    }
   }),
   createdAt: virtual(async (bot) => fromDateTimeSql(bot.createdAt)),
   updatedAt: virtual(async (bot) => fromDateTimeSql(bot.updatedAt))

--- a/packages/server-core/src/networking/instance/instance.resolvers.ts
+++ b/packages/server-core/src/networking/instance/instance.resolvers.ts
@@ -35,10 +35,8 @@ import { fromDateTimeSql, getDateTimeSql } from '../../util/datetime-sql'
 
 export const instanceResolver = resolve<InstanceType, HookContext>({
   location: virtual(async (instance, context) => {
-    if (instance.locationId) {
-      const location = await context.app.service(locationPath)._get(instance.locationId)
-      return location
-    }
+    if (context.event !== 'removed' && instance.locationId)
+      return await context.app.service(locationPath)._get(instance.locationId)
   }),
   assignedAt: virtual(async (location) => (location.assignedAt ? fromDateTimeSql(location.assignedAt) : '')),
   createdAt: virtual(async (location) => fromDateTimeSql(location.createdAt)),

--- a/packages/server-core/src/projects/project-permission/project-permission.resolvers.ts
+++ b/packages/server-core/src/projects/project-permission/project-permission.resolvers.ts
@@ -38,10 +38,7 @@ import { fromDateTimeSql, getDateTimeSql } from '../../util/datetime-sql'
 
 export const projectPermissionResolver = resolve<ProjectPermissionType, HookContext>({
   user: virtual(async (projectPermission, context) => {
-    if (projectPermission.userId) {
-      const user = await context.app.service(userPath)._get(projectPermission.userId)
-      return user
-    }
+    if (projectPermission.userId) return await context.app.service(userPath)._get(projectPermission.userId)
   }),
   createdAt: virtual(async (projectPermission) => fromDateTimeSql(projectPermission.createdAt)),
   updatedAt: virtual(async (projectPermission) => fromDateTimeSql(projectPermission.updatedAt))

--- a/packages/server-core/src/projects/project/project.resolvers.ts
+++ b/packages/server-core/src/projects/project/project.resolvers.ts
@@ -63,17 +63,14 @@ export const projectDbToSchema = (rawData: ProjectDatabaseType): ProjectType => 
 export const projectResolver = resolve<ProjectType, HookContext>(
   {
     projectPermissions: virtual(async (project, context) => {
-      if (context.params?.query?.allowed) {
-        const projectPermissions = (await context.app.service(projectPermissionPath).find({
+      if (context.params?.query?.allowed)
+        return (await context.app.service(projectPermissionPath).find({
           query: {
             projectId: project.id
           },
           user: context.params?.user,
           paginate: false
         })) as ProjectPermissionType[]
-
-        return projectPermissions
-      }
     }),
 
     commitDate: virtual(async (project) => {

--- a/packages/server-core/src/recording/recording-resource/recording-resource.resolvers.ts
+++ b/packages/server-core/src/recording/recording-resource/recording-resource.resolvers.ts
@@ -38,8 +38,8 @@ import { fromDateTimeSql, getDateTimeSql } from '../../util/datetime-sql'
 
 export const recordingResourceResolver = resolve<RecordingResourceType, HookContext>({
   staticResource: virtual(async (recordingResource, context) => {
-    const staticResource = await context.app.service(staticResourcePath).get(recordingResource.staticResourceId)
-    return staticResource
+    if (context.event !== 'removed')
+      return context.app.service(staticResourcePath).get(recordingResource.staticResourceId)
   }),
   createdAt: virtual(async (recordingResource) => fromDateTimeSql(recordingResource.createdAt)),
   updatedAt: virtual(async (recordingResource) => fromDateTimeSql(recordingResource.updatedAt))

--- a/packages/server-core/src/recording/recording/recording.resolvers.ts
+++ b/packages/server-core/src/recording/recording/recording.resolvers.ts
@@ -64,9 +64,7 @@ export const recordingResolver = resolve<RecordingType, HookContext>({
       paginate: false
     })
 
-    const recordingResource = recordingResources.map((resource) => resource.staticResource)
-
-    return recordingResource
+    return recordingResources.map((resource) => resource.staticResource)
   }),
   userName: virtual(async (recording, context) => {
     const user = await context.app.service(userPath)._get(recording.userId)

--- a/packages/server-core/src/scope/scope/scope.resolvers.ts
+++ b/packages/server-core/src/scope/scope/scope.resolvers.ts
@@ -38,8 +38,7 @@ export const scopeResolver = resolve<ScopeType, HookContext>({})
 export const scopeExternalResolver = resolve<ScopeType, HookContext>({
   user: virtual(async (scope, context) => {
     if (scope.userId) {
-      const user = await context.app.service(userPath)._get(scope.userId)
-      return user
+      return await context.app.service(userPath)._get(scope.userId)
     }
   }),
   createdAt: virtual(async (scope) => fromDateTimeSql(scope.createdAt)),

--- a/packages/server-core/src/social/channel-user/channel-user.resolvers.ts
+++ b/packages/server-core/src/social/channel-user/channel-user.resolvers.ts
@@ -34,10 +34,7 @@ import { fromDateTimeSql, getDateTimeSql } from '../../util/datetime-sql'
 
 export const channelUserResolver = resolve<ChannelUserType, HookContext>({
   user: virtual(async (channelUser, context) => {
-    if (channelUser.userId) {
-      const user = await context.app.service(userPath)._get(channelUser.userId)
-      return user
-    }
+    if (channelUser.userId) return await context.app.service(userPath)._get(channelUser.userId)
   }),
   createdAt: virtual(async (channel) => fromDateTimeSql(channel.createdAt)),
   updatedAt: virtual(async (channel) => fromDateTimeSql(channel.updatedAt))

--- a/packages/server-core/src/social/invite-code-lookup/invite-code-lookup.resolvers.ts
+++ b/packages/server-core/src/social/invite-code-lookup/invite-code-lookup.resolvers.ts
@@ -38,16 +38,14 @@ import type { HookContext } from '@etherealengine/server-core/declarations'
 
 export const inviteCodeLookupResolver = resolve<InviteCodeLookupType, HookContext>({
   instanceAttendance: virtual(async (inviteCodeLookup, context) => {
-    if (context.params.user?.id === context.arguments[0]) {
-      const instanceAttendance = (await context.app.service(instanceAttendancePath).find({
+    if (context.params.user?.id === context.arguments[0])
+      return (await context.app.service(instanceAttendancePath).find({
         query: {
           userId: inviteCodeLookup.id,
           ended: false
         },
         paginate: false
       })) as InstanceAttendanceType[]
-      return instanceAttendance
-    }
 
     return []
   })

--- a/packages/server-core/src/social/invite/invite.resolvers.ts
+++ b/packages/server-core/src/social/invite/invite.resolvers.ts
@@ -63,17 +63,11 @@ export const inviteResolver = resolve<InviteType, HookContext>({
 export const inviteExternalResolver = resolve<InviteType, HookContext>(
   {
     user: virtual(async (invite, context) => {
-      if (invite.userId) {
-        const user = await context.app.service(userPath)._get(invite.userId)
-        return user
-      }
+      if (invite.userId) return await context.app.service(userPath)._get(invite.userId)
     }),
 
     invitee: virtual(async (invite, context) => {
-      if (invite.inviteeId) {
-        const user = await context.app.service(userPath)._get(invite.inviteeId)
-        return user
-      }
+      if (invite.inviteeId) return await context.app.service(userPath)._get(invite.inviteeId)
     }),
     channelName: virtual(async (invite, context) => {
       if (invite.inviteType === 'channel' && invite.targetObjectId) {

--- a/packages/server-core/src/social/location/location.resolvers.ts
+++ b/packages/server-core/src/social/location/location.resolvers.ts
@@ -73,22 +73,20 @@ export const locationResolver = resolve<LocationType, HookContext>({
     return undefined
   }),
   locationAuthorizedUsers: virtual(async (location, context) => {
-    const locationAuthorizedUser = (await context.app.service('location-authorized-user').find({
+    return (await context.app.service('location-authorized-user').find({
       query: {
         locationId: location.id
       },
       paginate: false
     })) as LocationAuthorizedUserType[]
-    return locationAuthorizedUser
   }),
   locationBans: virtual(async (location, context) => {
-    const locationBan = (await context.app.service(locationBanPath).find({
+    return (await context.app.service(locationBanPath).find({
       query: {
         locationId: location.id
       },
       paginate: false
     })) as LocationBanType[]
-    return locationBan
   }),
   createdAt: virtual(async (location) => fromDateTimeSql(location.createdAt)),
   updatedAt: virtual(async (location) => fromDateTimeSql(location.updatedAt))

--- a/packages/server-core/src/social/message/message.resolvers.ts
+++ b/packages/server-core/src/social/message/message.resolvers.ts
@@ -36,8 +36,7 @@ import { fromDateTimeSql, getDateTimeSql } from '../../util/datetime-sql'
 export const messageResolver = resolve<MessageType, HookContext>({
   sender: virtual(async (message, context) => {
     if (message.senderId) {
-      const sender = await context.app.service(userPath)._get(message.senderId)
-      return sender
+      return await context.app.service(userPath)._get(message.senderId)
     }
   }),
   createdAt: virtual(async (message) => fromDateTimeSql(message.createdAt)),

--- a/packages/server-core/src/user/avatar/avatar.resolvers.ts
+++ b/packages/server-core/src/user/avatar/avatar.resolvers.ts
@@ -35,16 +35,12 @@ import { fromDateTimeSql, getDateTimeSql } from '../../util/datetime-sql'
 
 export const avatarResolver = resolve<AvatarType, HookContext>({
   modelResource: virtual(async (avatar, context) => {
-    if (avatar.modelResourceId) {
-      const modelStaticResource = await context.app.service(staticResourcePath).get(avatar.modelResourceId)
-      return modelStaticResource
-    }
+    if (context.event !== 'removed' && avatar.modelResourceId)
+      return context.app.service(staticResourcePath).get(avatar.modelResourceId)
   }),
   thumbnailResource: virtual(async (avatar, context) => {
-    if (avatar.thumbnailResourceId) {
-      const thumbnailStaticResource = await context.app.service(staticResourcePath).get(avatar.thumbnailResourceId)
-      return thumbnailStaticResource
-    }
+    if (context.event !== 'removed' && avatar.thumbnailResourceId)
+      return context.app.service(staticResourcePath).get(avatar.thumbnailResourceId)
   }),
   createdAt: virtual(async (avatar) => fromDateTimeSql(avatar.createdAt)),
   updatedAt: virtual(async (avatar) => fromDateTimeSql(avatar.updatedAt))

--- a/packages/server-core/src/user/user-relationship/user-relationship.resolvers.ts
+++ b/packages/server-core/src/user/user-relationship/user-relationship.resolvers.ts
@@ -38,16 +38,10 @@ import { fromDateTimeSql, getDateTimeSql } from '../../util/datetime-sql'
 
 export const userRelationshipResolver = resolve<UserRelationshipType, HookContext>({
   user: virtual(async (userRelationship, context) => {
-    if (userRelationship.userId) {
-      const user = await context.app.service('user')._get(userRelationship.userId)
-      return user
-    }
+    if (userRelationship.userId) return await context.app.service('user')._get(userRelationship.userId)
   }),
   relatedUser: virtual(async (userRelationship, context) => {
-    if (userRelationship.relatedUserId) {
-      const relatedUser = await context.app.service('user')._get(userRelationship.relatedUserId)
-      return relatedUser
-    }
+    if (userRelationship.relatedUserId) return await context.app.service('user')._get(userRelationship.relatedUserId)
   }),
   createdAt: virtual(async (userRelationship) => fromDateTimeSql(userRelationship.createdAt)),
   updatedAt: virtual(async (userRelationship) => fromDateTimeSql(userRelationship.updatedAt))

--- a/packages/server-core/src/user/user/user.resolvers.ts
+++ b/packages/server-core/src/user/user/user.resolvers.ts
@@ -48,10 +48,7 @@ import { fromDateTimeSql, getDateTimeSql } from '../../util/datetime-sql'
 
 export const userResolver = resolve<UserType, HookContext>({
   avatar: virtual(async (user, context) => {
-    if (user.avatarId) {
-      const avatar = await context.app.service(avatarPath).get(user.avatarId)
-      return avatar
-    }
+    if (context.event !== 'removed' && user.avatarId) return await context.app.service(avatarPath).get(user.avatarId)
   }),
   userSetting: virtual(async (user, context) => {
     const userSetting = (await context.app.service(userSettingPath).find({
@@ -74,53 +71,46 @@ export const userResolver = resolve<UserType, HookContext>({
     return apiKey.length > 0 ? apiKey[0] : undefined
   }),
   identityProviders: virtual(async (user, context) => {
-    const identityProviders = (await context.app.service(identityProviderPath).find({
+    return (await context.app.service(identityProviderPath).find({
       query: {
         userId: user.id
       },
       paginate: false
     })) as IdentityProviderType[]
-
-    return identityProviders
   }),
   locationAdmins: virtual(async (user, context) => {
-    const locationAdmins = (await context.app.service(locationAdminPath).find({
+    return (await context.app.service(locationAdminPath).find({
       query: {
         userId: user.id
       },
       paginate: false
     })) as LocationAdminType[]
-    return locationAdmins
   }),
   locationBans: virtual(async (user, context) => {
-    const locationBans = (await context.app.service(locationBanPath).find({
+    return (await context.app.service(locationBanPath).find({
       query: {
         userId: user.id
       },
       paginate: false
     })) as LocationBanType[]
-    return locationBans
   }),
   scopes: virtual(async (user, context) => {
-    const scopes = (await context.app.service(scopePath).find({
+    return (await context.app.service(scopePath).find({
       query: {
         userId: user.id
       },
       paginate: false
     })) as ScopeType[]
-    return scopes
   }),
   instanceAttendance: virtual(async (user, context) => {
-    if (context.params.user?.id === context.arguments[0]) {
-      const instanceAttendance = (await context.app.service(instanceAttendancePath).find({
+    if (context.params.user?.id === context.arguments[0])
+      return (await context.app.service(instanceAttendancePath).find({
         query: {
           userId: user.id,
           ended: false
         },
         paginate: false
       })) as InstanceAttendanceType[]
-      return instanceAttendance
-    }
 
     return []
   }),


### PR DESCRIPTION
## Summary
Avatar removal was returning errors. This was caused by the avatarResolver fetching model and thumbnail static-resources, but on avatar deletion, these have been removed, which makes the .get's error. Made this not trigger when context.event is 'removed', and applied this to other resolvers that fetch static-resources.

Cleaned up some redundant function calls that are assigned to variables before just returning the variable.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 94fcdac</samp>

This pull request refactors and optimizes various virtual fields in the resolvers of different entities in `packages/server-core/src`. It removes unnecessary conditions, variables, and return statements, and avoids database queries for deleted entities. The purpose is to improve the performance, readability, and error handling of the resolvers.

## References
closes #8930 

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 94fcdac</samp>

*  Avoid unnecessary database queries and errors when bots, instances, avatars, or users are deleted by checking the context.event ([link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-e16e50aa9d8f6dcb1582140fecfaac38cb8e192e997ac1bf2d3bd40d12687929L47-R56), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-a0015697452807384a5e06e7ae54856b89412947110c5de19cef1f98ac93cf83L38-R39), F12L36L36, [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-ae5e320d761134086ef0fb3a57124ad983c9c89985de39838ad1f4ab9259e765L51-R51))
* Simplify virtual fields for various entities by removing if conditions, intermediate variables, and redundant return statements and returning the query results directly ([link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-e16e50aa9d8f6dcb1582140fecfaac38cb8e192e997ac1bf2d3bd40d12687929L66-L67), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-e3aa923f528e384c97bdf3a164b822f6d782b28760d167e4238de6fe17065ce1L41-R41), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-7d23bc64e8570e75e70887d7b748e21ad264046c2a3d82aeb5d71fb17cd3ce52L66-R67), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-7d23bc64e8570e75e70887d7b748e21ad264046c2a3d82aeb5d71fb17cd3ce52L74-L76), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-e3860bf1b3c6fc45a5cb61d956d79c63f09225c3182c8581ec011917af5f56a1L41-R42), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-107ca8929dca85436e959add04dac6fcbd64a29cca99af12abb409eaa3e61bc1L67-R67), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-b9e5d34d763effea6c64e39c79830082836e062114a790302f1137c9ef6bbb06L41-R41), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-db003d37ebd7e0a6c86238d1f6390a9b0b61471361ad9f8291d92fa22b8accd4L37-R37), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-73242032c6d82a224a0cfd5535dc75c06e5c6c60de511ca2ec705fdf9cd0e3c8L41-R42), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-73242032c6d82a224a0cfd5535dc75c06e5c6c60de511ca2ec705fdf9cd0e3c8L49-L50), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-de735f7002a8f55233d4b5642d05d4492a3c86d3146ac9a86c8a092162615d25L66-R70), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-3198d7d3c7aa7ed7b9056f38fe1922e5c82edfc717f53220da5a0e6b9c65a9caL76-R76), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-3198d7d3c7aa7ed7b9056f38fe1922e5c82edfc717f53220da5a0e6b9c65a9caL82-R84), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-3198d7d3c7aa7ed7b9056f38fe1922e5c82edfc717f53220da5a0e6b9c65a9caL91), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-46d136801a9c79aa99f4546df6564e9f34b98aff268c2bbfa3e3a06e79c5f549L39-R39), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-e2ec0d8d5623b30a438ebb8a911c62a1a8b43369abd56fcd599bc01ff63a0371L41-R44), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-ae5e320d761134086ef0fb3a57124ad983c9c89985de39838ad1f4ab9259e765L77-R74), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-ae5e320d761134086ef0fb3a57124ad983c9c89985de39838ad1f4ab9259e765L83-R82), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-ae5e320d761134086ef0fb3a57124ad983c9c89985de39838ad1f4ab9259e765L93-R90), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-ae5e320d761134086ef0fb3a57124ad983c9c89985de39838ad1f4ab9259e765L102-R98), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-ae5e320d761134086ef0fb3a57124ad983c9c89985de39838ad1f4ab9259e765L111-R107), [link](https://github.com/EtherealEngine/etherealengine/pull/8936/files?diff=unified&w=0#diff-ae5e320d761134086ef0fb3a57124ad983c9c89985de39838ad1f4ab9259e765L122-L123))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 94fcdac</samp>

> _We are the masters of the code_
> _We slash the queries and the load_
> _We make the fields concise and clear_
> _We crush the errors and the fear_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
