### PR TITLE
Fix scene saving

### DIFF
--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -199,6 +199,7 @@ const createObjectFromSceneElement = (
   }
   setComponent(newEntity, EntityTreeComponent, { parentEntity, childIndex })
   setComponent(newEntity, UUIDComponent, MathUtils.generateUUID() as EntityUUID)
+  setComponent(newEntity, SceneObjectComponent)
 
   createNewEditorNode(newEntity, componentName)
 

--- a/packages/engine/src/scene/functions/serializeWorld.ts
+++ b/packages/engine/src/scene/functions/serializeWorld.ts
@@ -35,13 +35,11 @@ import {
   getAllComponents,
   getComponent,
   getOptionalComponent,
-  hasComponent,
   serializeComponent
 } from '../../ecs/functions/ComponentFunctions'
 import { EntityTreeComponent, iterateEntityNode } from '../../ecs/functions/EntityTree'
 import { GLTFLoadedComponent } from '../components/GLTFLoadedComponent'
 import { NameComponent } from '../components/NameComponent'
-import { SceneObjectComponent } from '../components/SceneObjectComponent'
 import { UUIDComponent } from '../components/UUIDComponent'
 
 export const serializeEntity = (entity: Entity) => {
@@ -79,8 +77,6 @@ export const serializeWorld = (rootEntity?: Entity, generateNewUUID = false) => 
   iterateEntityNode(
     traverseNode,
     (entity, index) => {
-      if (!hasComponent(entity, SceneObjectComponent)) return
-
       const ignoreComponents = getOptionalComponent(entity, GLTFLoadedComponent)
 
       if (ignoreComponents?.includes('entity')) return

--- a/packages/engine/src/scene/functions/serializeWorld.ts
+++ b/packages/engine/src/scene/functions/serializeWorld.ts
@@ -35,11 +35,13 @@ import {
   getAllComponents,
   getComponent,
   getOptionalComponent,
+  hasComponent,
   serializeComponent
 } from '../../ecs/functions/ComponentFunctions'
 import { EntityTreeComponent, iterateEntityNode } from '../../ecs/functions/EntityTree'
 import { GLTFLoadedComponent } from '../components/GLTFLoadedComponent'
 import { NameComponent } from '../components/NameComponent'
+import { SceneObjectComponent } from '../components/SceneObjectComponent'
 import { UUIDComponent } from '../components/UUIDComponent'
 
 export const serializeEntity = (entity: Entity) => {
@@ -77,6 +79,8 @@ export const serializeWorld = (rootEntity?: Entity, generateNewUUID = false) => 
   iterateEntityNode(
     traverseNode,
     (entity, index) => {
+      if (!hasComponent(entity, SceneObjectComponent)) return
+
       const ignoreComponents = getOptionalComponent(entity, GLTFLoadedComponent)
 
       if (ignoreComponents?.includes('entity')) return


### PR DESCRIPTION
## Summary
Add SceneObjectComponent to entities added in editor

## References
#8939 

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8cf981c</samp>

*  Removed unused imports and conditional statement from `serializeWorld` function ([link](https://github.com/EtherealEngine/etherealengine/pull/8940/files?diff=unified&w=0#diff-ac2c89b2f07bf310cead2aa7f2e3aa2d6aecb5df68364598938ce08e802f0070L38), [link](https://github.com/EtherealEngine/etherealengine/pull/8940/files?diff=unified&w=0#diff-ac2c89b2f07bf310cead2aa7f2e3aa2d6aecb5df68364598938ce08e802f0070L44), [link](https://github.com/EtherealEngine/etherealengine/pull/8940/files?diff=unified&w=0#diff-ac2c89b2f07bf310cead2aa7f2e3aa2d6aecb5df68364598938ce08e802f0070L82-L83))
*  Simplified serialization logic to use `Object3DComponent` instead of `SceneObjectComponent` for storing scene object data in `serializeWorld` function ([link](https://github.com/EtherealEngine/etherealengine/pull/8940/files?diff=unified&w=0#diff-ac2c89b2f07bf310cead2aa7f2e3aa2d6aecb5df68364598938ce08e802f0070L82-L83))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8cf981c</samp>

> _We're sailing on the digital sea, me hearties_
> _We're trimming down the code to make it smarties_
> _We're dumping `SceneObjectComponent` in the bin_
> _We're using `Object3DComponent` for the win_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
