### PR TITLE
Added .bin files as base64-encoded for GH push purposes

### DIFF
--- a/packages/engine/src/assets/constants/fileTypes.tsx
+++ b/packages/engine/src/assets/constants/fileTypes.tsx
@@ -45,6 +45,7 @@ export const ModelFileTypes = ['.glb', '.gltf', 'model/gltf-binary', 'model/gltf
 export const VolumetricFileTypes = ['.manifest']
 //array containing custom script type.
 export const CustomScriptFileTypes = ['.tsx', '.ts', '.js', '.jsx']
+export const BinaryFileTypes = ['.bin']
 //array contains arrays of all files types.
 export const AllFileTypes = [
   ...AudioFileTypes,
@@ -52,7 +53,8 @@ export const AllFileTypes = [
   ...ImageFileTypes,
   ...ModelFileTypes,
   ...VolumetricFileTypes,
-  ...CustomScriptFileTypes
+  ...CustomScriptFileTypes,
+  ...BinaryFileTypes
 ]
 
 //creating comma separated string contains all file types

--- a/packages/server-core/src/projects/project/github-helper.ts
+++ b/packages/server-core/src/projects/project/github-helper.ts
@@ -33,6 +33,7 @@ import path from 'path'
 import { GITHUB_PER_PAGE, GITHUB_URL_REGEX } from '@etherealengine/common/src/constants/GitHubConstants'
 import {
   AudioFileTypes,
+  BinaryFileTypes,
   ImageFileTypes,
   ModelFileTypes,
   VideoFileTypes,
@@ -604,6 +605,7 @@ const isBase64Encoded = (filePath: string) => {
     AudioFileTypes.indexOf(extension) > -1 ||
     VolumetricFileTypes.indexOf(extension) > -1 ||
     VideoFileTypes.indexOf(extension) > -1 ||
-    ModelFileTypes.indexOf(extension) > -1
+    ModelFileTypes.indexOf(extension) > -1 ||
+    BinaryFileTypes.indexOf(extension) > -1
   )
 }


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 07d7ecf</samp>

This pull request adds support for binary files to the engine and the server-core projects. It defines a new constant `BinaryFileTypes` in `fileTypes.tsx` and uses it to encode or decode binary files in the GitHub integration of `github-helper.ts`.

## References
closes https://github.com/EtherealEngine/etherealengine/issues/8942

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 07d7ecf</samp>

*  Add support for uploading and downloading binary files from GitHub repositories ([link](https://github.com/EtherealEngine/etherealengine/pull/8941/files?diff=unified&w=0#diff-d5f163ee75026c22a5eb1dc8c8783cf6f3d606b49b74f01988af0f1776d5431fR48), [link](https://github.com/EtherealEngine/etherealengine/pull/8941/files?diff=unified&w=0#diff-d5f163ee75026c22a5eb1dc8c8783cf6f3d606b49b74f01988af0f1776d5431fL55-R57), [link](https://github.com/EtherealEngine/etherealengine/pull/8941/files?diff=unified&w=0#diff-b651502d77caa5c46c93b5c78a2493b55970a88d67453d4d6136be8ba64f5ddfR36), [link](https://github.com/EtherealEngine/etherealengine/pull/8941/files?diff=unified&w=0#diff-b651502d77caa5c46c93b5c78a2493b55970a88d67453d4d6136be8ba64f5ddfL607-R609))
  * Define a new constant array `BinaryFileTypes` that contains the file extension `.bin` for binary files in `fileTypes.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/8941/files?diff=unified&w=0#diff-d5f163ee75026c22a5eb1dc8c8783cf6f3d606b49b74f01988af0f1776d5431fR48))
  * Append `BinaryFileTypes` to the existing `AllFileTypes` array that contains all the supported file types for the project in `fileTypes.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/8941/files?diff=unified&w=0#diff-d5f163ee75026c22a5eb1dc8c8783cf6f3d606b49b74f01988af0f1776d5431fL55-R57))
  * Import `BinaryFileTypes` from `fileTypes.tsx` to `github-helper.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/8941/files?diff=unified&w=0#diff-b651502d77caa5c46c93b5c78a2493b55970a88d67453d4d6136be8ba64f5ddfR36))
  * Add a condition to the `isBase64Encoded` function in `github-helper.ts` that checks if the file extension is in `BinaryFileTypes` ([link](https://github.com/EtherealEngine/etherealengine/pull/8941/files?diff=unified&w=0#diff-b651502d77caa5c46c93b5c78a2493b55970a88d67453d4d6136be8ba64f5ddfL607-R609))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 07d7ecf</samp>

> _We face the doom of binary files_
> _We encode and decode with base64_
> _We use the `BinaryFileTypes` to resist_
> _We integrate with GitHub and persist_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
