### PR TITLE
Fix avatar animation system errors

### DIFF
--- a/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
+++ b/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
@@ -257,7 +257,8 @@ const execute = () => {
 
       //calculate hips to head
       rig.hips.node.position.applyMatrix4(transform.matrixInverse)
-      _hipVector.subVectors(rig.hips.node.position, ikDataByName[ikTargets.head].position)
+      if (ikDataByName[ikTargets.head])
+        _hipVector.subVectors(rig.hips.node.position, ikDataByName[ikTargets.head].position)
 
       if (rigComponent.ikOverride == 'mocap')
         rig.hips.node.quaternion


### PR DESCRIPTION
## Summary
One liner fix to check if there is an ik target for the head before attempting to access it

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3048c08</samp>

*  Add null check for head target in avatar animation system ([link](https://github.com/EtherealEngine/etherealengine/pull/8947/files?diff=unified&w=0#diff-e0a011e84a40926910be0273bb512c563d8c83d4becd2e1ac35f7075e5a33e20L260-R261))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3048c08</samp>

> _`ikDataByName`_
> _Check for null before use - kya!_
> _Avatar dances_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
