### PR TITLE
Added colors to local dev log categories to better understand

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "clean-node-modules": "npx rimraf node_modules && npx rimraf package-lock.json && npx lerna exec npx rimraf node_modules && npx lerna exec npx rimraf package-lock.json",
     "create-root-package-json": "cross-env ts-node --swc scripts/create-root-package-json",
     "depcheck": "lerna exec --no-bail --stream -- depcheck",
-    "dev": "npm run dev-docker && concurrently -n agones,server,client,taskserver npm:dev-agones-silent npm:dev-server npm:dev-client npm:dev-taskserver",
+    "dev": "npm run dev-docker && concurrently -n agones,server,client,taskserver -c '#CEB793,#FF9800,#7E2D40,#B2B4B2' npm:dev-agones-silent npm:dev-server npm:dev-client npm:dev-taskserver",
     "dev-noclient": "npm run dev-docker && concurrently -n agones,server,taskserver npm:dev-agones-silent npm:dev-server npm:dev-taskserver",
     "dev-agones": "cd scripts && ./start-agones.sh",
     "dev-agones-silent": "npm run dev-agones &> /dev/null",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "check-errors": "tsc --noemit",
-    "dev": "cross-env APP_ENV=development concurrently -n server,instanceserver,mediaserver,files \"ts-node --swc src/index.ts\" \"cd ../instanceserver && npm run dev\" \"cd ../instanceserver && npm run dev-channel\"",
+    "dev": "cross-env APP_ENV=development concurrently -n server,instanceserver,mediaserver,files -c '#FF9800,#A2789C,#00908F,#F93822' \"ts-node --swc src/index.ts\" \"cd ../instanceserver && npm run dev\" \"cd ../instanceserver && npm run dev-channel\"",
     "start": "cross-env APP_ENV=production ts-node --swc src/index.ts",
     "dev-api-server": "ts-node --swc src/index.ts",
     "dev-api-server-nossl": "cross-env NOSSL=true ts-node --swc src/index.ts",


### PR DESCRIPTION
## Summary
Optional: Added color to concurrently headings like shown below, it somewhat help in finding them easily:
![image](https://github.com/EtherealEngine/etherealengine/assets/10975502/b82c6435-3b09-4540-82ea-dab27d567a9b)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e234ac</samp>

This pull request adds color codes to the `concurrently` commands in the `dev` scripts of the root and server `package.json` files. This improves the readability of the logs of the different processes that run in parallel during development of the game engine.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e234ac</samp>

*  Add color codes to the `concurrently` command in the `dev` script of the `package.json` files of the root and the server package ([link](https://github.com/EtherealEngine/etherealengine/pull/8953/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L49-R49), [link](https://github.com/EtherealEngine/etherealengine/pull/8953/files?diff=unified&w=0#diff-92fadee1dfb23b20d6b0f6557a3ea0b8a231a7591db73f9f37772383bd0575d9L34-R34))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0e234ac</samp>

> _`concurrently` adds_
> _colors to dev processes_
> _autumn leaves contrast_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
