### PR TITLE
Fix audio component

### DIFF
--- a/packages/editor/src/components/properties/MediaNodeEditor.tsx
+++ b/packages/editor/src/components/properties/MediaNodeEditor.tsx
@@ -27,7 +27,7 @@ import React from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { AllFileTypes } from '@etherealengine/engine/src/assets/constants/fileTypes'
-import { useComponent } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
+import { useComponent, useOptionalComponent } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
 import { getEntityErrors } from '@etherealengine/engine/src/scene/components/ErrorComponent'
 import {
   MediaComponent,
@@ -70,7 +70,7 @@ export const MediaNodeEditor: EditorComponentType = (props) => {
   const { t } = useTranslation()
 
   const media = useComponent(props.entity, MediaComponent)
-  const element = useComponent(props.entity, MediaElementComponent)
+  const element = useOptionalComponent(props.entity, MediaElementComponent)
   const errors = getEntityErrors(props.entity, MediaComponent)
 
   const toggle = () => {
@@ -78,7 +78,9 @@ export const MediaNodeEditor: EditorComponentType = (props) => {
   }
 
   const reset = () => {
-    setTime(element.element, media.seekTime.value)
+    if (element) {
+      setTime(element.element, media.seekTime.value)
+    }
   }
 
   return (

--- a/packages/editor/src/components/properties/MediaNodeEditor.tsx
+++ b/packages/editor/src/components/properties/MediaNodeEditor.tsx
@@ -153,14 +153,14 @@ export const MediaNodeEditor: EditorComponentType = (props) => {
         />
       </InputGroup>
       {media.resources.length > 0 && (
-        <PropertiesPanelButton type="submit" onClick={toggle}>
-          {media.paused.value ? t('editor:properties.media.playtitle') : t('editor:properties.media.pausetitle')}
-        </PropertiesPanelButton>
-      )}
-      {media.resources.length > 0 && (
-        <PropertiesPanelButton type="submit" onClick={reset}>
-          {t('editor:properties.media.resettitle')}
-        </PropertiesPanelButton>
+        <InputGroup name="media-controls" label="media-controls">
+          <PropertiesPanelButton type="submit" onClick={toggle}>
+            {media.paused.value ? t('editor:properties.media.playtitle') : t('editor:properties.media.pausetitle')}
+          </PropertiesPanelButton>
+          <PropertiesPanelButton type="submit" onClick={reset}>
+            {t('editor:properties.media.resettitle')}
+          </PropertiesPanelButton>
+        </InputGroup>
       )}
     </NodeEditor>
   )

--- a/packages/engine/src/scene/components/MediaComponent.ts
+++ b/packages/engine/src/scene/components/MediaComponent.ts
@@ -443,7 +443,7 @@ export function MediaReactor() {
         mediaElementState.value.element.play()
       }
     },
-    [media.resources, media.track, media.ended, media.playMode]
+    [media.resources, media.ended, media.playMode]
   )
 
   useEffect(


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f9d41d0</samp>

Improved media node editing and playback performance. Fixed a bug that caused media elements to re-render when changing tracks, and added more error handling for the media node editor component.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f9d41d0</samp>

* Import `useOptionalComponent` function to access optional `MediaElementComponent` on media entities ([link](https://github.com/EtherealEngine/etherealengine/pull/8956/files?diff=unified&w=0#diff-6d528b60b54cd3ab3d8886b704bec0ec0c595aba136d13c5f4892488e2d8f1a6L30-R30))
* Use `useOptionalComponent` instead of `useComponent` to assign `element` variable and avoid errors ([link](https://github.com/EtherealEngine/etherealengine/pull/8956/files?diff=unified&w=0#diff-6d528b60b54cd3ab3d8886b704bec0ec0c595aba136d13c5f4892488e2d8f1a6L73-R73))
* Check if `element` is defined before calling `setTime` on it in `reset` function ([link](https://github.com/EtherealEngine/etherealengine/pull/8956/files?diff=unified&w=0#diff-6d528b60b54cd3ab3d8886b704bec0ec0c595aba136d13c5f4892488e2d8f1a6L81-R83))
* Remove `media.track` dependency from `useEffect` hook in `MediaReactor` function to prevent unnecessary re-rendering of media element ([link](https://github.com/EtherealEngine/etherealengine/pull/8956/files?diff=unified&w=0#diff-0b05e36919188e649d61cc405c4bcb5c9c9b066aa2cf2b938becb901aabea59cL446-R446))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f9d41d0</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _the media reactor function, and freed it from the chain_
> _of `media.track`, that swift and changing property_
> _that caused the media element to render oft in vain._

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
