### PR TITLE
Support docker compose v2

### DIFF
--- a/scripts/start-containers.sh
+++ b/scripts/start-containers.sh
@@ -2,19 +2,23 @@
 
 if which docker > /dev/null 2>&1
 then
-    if which docker-compose > /dev/null 2>&1
-    then
-        echo "✅ Docker & Docker-Compose Detected:"
-        echo -e "\e[32m💾 Initializing docker containers..."
-
-        export COMPOSE_IGNORE_ORPHANS=true
-
-        docker-compose up -d
-        if [[ -z "${IS_LOCAL_FS}" || "${IS_LOCAL_FS}" == 'false' ]]; then
-            docker-compose -f docker-compose-minio.yml up -d
-        fi
+    if which docker-compose > /dev/null 2>&1; then
+        command_to_execute="docker-compose"
+    elif docker compose version > /dev/null 2>&1; then
+        command_to_execute="docker compose"
     else
-        echo "❌ Please install docker-compose..."
+        echo "❌ Please install docker-compose or docker compose v2"
+        exit 1
+    fi
+
+    echo "✅ Docker & Docker-Compose Detected:"
+    echo -e "\e[32m💾 Initializing docker containers..."
+
+    export COMPOSE_IGNORE_ORPHANS=true
+
+    eval "$command_to_execute up -d"
+    if [[ -z "${IS_LOCAL_FS}" || "${IS_LOCAL_FS}" == 'false' ]]; then
+        eval "$command_to_execute -f docker-compose-minio.yml up -d"
     fi
 else
     echo "❌ Please install docker..."


### PR DESCRIPTION
docker-compose v1 is deprecated on July, 2023.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d601274</samp>

Improved `scripts/start-containers.sh` to support both docker-compose and docker compose v2 commands. This makes the script more compatible and usable with different docker environments.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d601274</samp>

*  Added support for docker compose v2 commands in `start-containers.sh` ([link](https://github.com/EtherealEngine/etherealengine/pull/8961/files?diff=unified&w=0#diff-d8b99ab2f1e3c1f897d31711849ab262e43de830bf041fec4eea9c58acd44dffL5-R21))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d601274</samp>

> _`command_to_execute`_
> _evals docker compose v2_
> _autumn of updates_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
