### PR TITLE
collect logs immediately

### DIFF
--- a/packages/taskserver/src/collect-events.ts
+++ b/packages/taskserver/src/collect-events.ts
@@ -36,52 +36,57 @@ const interval = (configInterval || DEFAULT_INTERVAL_SECONDS) * 1000
 
 let lastTimestamp: string // Store the timestamp of the last run
 
-export default (app): void => {
-  logger.info('started event logging.')
+const collectLogs = async () => {
   const k8DefaultClient = getState(ServerState).k8DefaultClient
-  setInterval(async () => {
-    logger.info('Collecting events at %s.', new Date().toString())
+  logger.info('Collecting events at %s.', new Date().toString())
 
-    if (k8DefaultClient) {
-      try {
-        const namespace = 'default' // Replace with your target namespace
-        const currentTimestamp = new Date().toISOString()
-        let eventMessages: any[] = []
+  if (k8DefaultClient) {
+    try {
+      const namespace = 'default' // Replace with your target namespace
+      const currentTimestamp = new Date().toISOString()
+      let eventMessages: any[] = []
 
-        // Fetch all events in the namespace
-        const eventsResponse = await k8DefaultClient.listNamespacedEvent(namespace)
+      // Fetch all events in the namespace
+      const eventsResponse = await k8DefaultClient.listNamespacedEvent(namespace)
 
-        logger.info(eventsResponse.body.items.length)
-        if (lastTimestamp) {
-          eventMessages = eventsResponse.body.items
-            .filter((event) => {
-              if (event.firstTimestamp) {
-                new Date(event.firstTimestamp) > new Date(lastTimestamp)
-              }
-            })
-            .map((event) => ({
-              name: event.involvedObject.name,
-              message: event.message,
-              timestamp: event.firstTimestamp
-            }))
-        } else {
-          eventMessages = eventsResponse.body.items.map((event) => ({
+      logger.info(eventsResponse.body.items.length)
+      if (lastTimestamp) {
+        eventMessages = eventsResponse.body.items
+          .filter((event) => {
+            if (event.firstTimestamp) {
+              new Date(event.firstTimestamp) > new Date(lastTimestamp)
+            }
+          })
+          .map((event) => ({
             name: event.involvedObject.name,
             message: event.message,
             timestamp: event.firstTimestamp
           }))
-        }
-
-        if (eventMessages.length > 0) {
-          // Log the collected events
-          logger.info(eventMessages)
-        }
-
-        lastTimestamp = currentTimestamp
-      } catch (e) {
-        serverLogger.error(e)
-        return e
+      } else {
+        eventMessages = eventsResponse.body.items.map((event) => ({
+          name: event.involvedObject.name,
+          message: event.message,
+          timestamp: event.firstTimestamp
+        }))
       }
+
+      if (eventMessages.length > 0) {
+        // Log the collected events
+        logger.info(eventMessages)
+      }
+
+      lastTimestamp = currentTimestamp
+    } catch (e) {
+      serverLogger.error(e)
+      return e
     }
-  }, interval)
+  }
+}
+
+export default (app): void => {
+  logger.info('started event logging.')
+
+  setInterval(collectLogs, interval)
+
+  collectLogs()
 }


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 15b1f85</samp>

Refactored the event logging code in `packages/taskserver/src/collect-events.ts` to use a separate function `collectLogs` that runs immediately and periodically. This improves the performance and reliability of the feature.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 15b1f85</samp>

* Extracted event collection logic into a separate function `collectLogs` to improve performance and reliability ([link](https://github.com/EtherealEngine/etherealengine/pull/8967/files?diff=unified&w=0#diff-293897afcdde27c17ad4dd2adb9250148a5e43d435762574948b56f9ea57b2a2L39-R92))
* Called `collectLogs` immediately when `collect-events.ts` is loaded, instead of waiting for the first interval ([link](https://github.com/EtherealEngine/etherealengine/pull/8967/files?diff=unified&w=0#diff-293897afcdde27c17ad4dd2adb9250148a5e43d435762574948b56f9ea57b2a2L39-R92))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 15b1f85</samp>

> _`collectLogs` splits_
> _Kubernetes events gathered_
> _Faster in the spring_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
