### PR TITLE
Changes to use hooks in various avatar service

### DIFF
--- a/packages/client-core/src/admin/components/Avatars/AvatarTable.tsx
+++ b/packages/client-core/src/admin/components/Avatars/AvatarTable.tsx
@@ -56,9 +56,11 @@ const AvatarTable = ({ className, search, selectedAvatarIds, setSelectedAvatarId
 
   const adminAvatarQuery = useFind(avatarPath, {
     query: {
-      admin: true,
+      action: 'admin',
+      name: {
+        $like: `%${search}%`
+      },
       $limit: 20,
-      search: search,
       $sort: {
         name: 1
       }

--- a/packages/client-core/src/admin/components/Users/UserDrawer.tsx
+++ b/packages/client-core/src/admin/components/Users/UserDrawer.tsx
@@ -88,7 +88,7 @@ const UserDrawer = ({ open, mode, selectedUser, onClose }: Props) => {
 
   const avatars = useFind(avatarPath, {
     query: {
-      admin: true /** @todo - this should not be paginated */
+      action: 'admin' /** @todo - this should not be paginated */
     }
   }).data
   const scopeTypes = useFind(scopeTypePath, {

--- a/packages/client-core/src/user/components/UserMenu/menus/AvatarSelectMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/AvatarSelectMenu.tsx
@@ -65,7 +65,9 @@ const AvatarMenu = () => {
 
   const avatarsData = useFind(avatarPath, {
     query: {
-      search: search.query.value,
+      name: {
+        $like: `%${search.query.value}%`
+      },
       $skip: page.value * AVATAR_PAGE_LIMIT,
       $limit: AVATAR_PAGE_LIMIT
     }

--- a/packages/client-core/src/user/services/AvatarService.ts
+++ b/packages/client-core/src/user/services/AvatarService.ts
@@ -68,7 +68,9 @@ export const AvatarService = {
       incDec === 'increment' ? skip + AVATAR_PAGE_LIMIT : incDec === 'decrement' ? skip - AVATAR_PAGE_LIMIT : skip
     const result = (await Engine.instance.api.service(avatarPath).find({
       query: {
-        search,
+        name: {
+          $like: `%${search}%`
+        },
         $skip: newSkip,
         $limit: AVATAR_PAGE_LIMIT
       }

--- a/packages/engine/src/schemas/user/avatar.schema.ts
+++ b/packages/engine/src/schemas/user/avatar.schema.ts
@@ -104,10 +104,7 @@ export const avatarQuerySchema = Type.Intersect(
       }
     }),
     // Add additional query properties here
-    Type.Object(
-      { admin: Type.Optional(Type.Boolean()), search: Type.Optional(Type.String()) },
-      { additionalProperties: false }
-    )
+    Type.Object({ action: Type.Optional(Type.String()) }, { additionalProperties: false })
   ],
   { additionalProperties: false }
 )

--- a/packages/server-core/src/hooks/disallow-non-id.ts
+++ b/packages/server-core/src/hooks/disallow-non-id.ts
@@ -23,18 +23,18 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { Params } from '@feathersjs/feathers'
+import { HookContext } from '@feathersjs/feathers'
 
-import { AvatarData, AvatarPatch, AvatarQuery, AvatarType } from '@etherealengine/engine/src/schemas/user/avatar.schema'
-import { KnexService } from '@feathersjs/knex'
-import { RootParams } from '../../api/root-params'
+import { BadRequest } from '@feathersjs/errors'
+import { AsyncLocalStorage } from 'async_hooks'
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface AvatarParams extends RootParams<AvatarQuery> {}
+export const asyncLocalStorage = new AsyncLocalStorage<{ headers: any }>()
 
-export class AvatarService<T = AvatarType, ServiceParams extends Params = AvatarParams> extends KnexService<
-  AvatarType,
-  AvatarData,
-  AvatarParams,
-  AvatarPatch
-> {}
+/**
+ * A method that disallows the use of non id in request.
+ */
+export default async (context: HookContext) => {
+  if (!context.id) {
+    throw new BadRequest(`Can only ${context.method} via id`)
+  }
+}

--- a/packages/server-core/src/user/avatar/avatar.resolvers.ts
+++ b/packages/server-core/src/user/avatar/avatar.resolvers.ts
@@ -34,6 +34,11 @@ import type { HookContext } from '@etherealengine/server-core/declarations'
 import { fromDateTimeSql, getDateTimeSql } from '../../util/datetime-sql'
 
 export const avatarResolver = resolve<AvatarType, HookContext>({
+  createdAt: virtual(async (avatar) => fromDateTimeSql(avatar.createdAt)),
+  updatedAt: virtual(async (avatar) => fromDateTimeSql(avatar.updatedAt))
+})
+
+export const avatarExternalResolver = resolve<AvatarType, HookContext>({
   modelResource: virtual(async (avatar, context) => {
     if (context.event !== 'removed' && avatar.modelResourceId)
       return context.app.service(staticResourcePath).get(avatar.modelResourceId)
@@ -41,16 +46,15 @@ export const avatarResolver = resolve<AvatarType, HookContext>({
   thumbnailResource: virtual(async (avatar, context) => {
     if (context.event !== 'removed' && avatar.thumbnailResourceId)
       return context.app.service(staticResourcePath).get(avatar.thumbnailResourceId)
-  }),
-  createdAt: virtual(async (avatar) => fromDateTimeSql(avatar.createdAt)),
-  updatedAt: virtual(async (avatar) => fromDateTimeSql(avatar.updatedAt))
+  })
 })
-
-export const avatarExternalResolver = resolve<AvatarType, HookContext>({})
 
 export const avatarDataResolver = resolve<AvatarDatabaseType, HookContext>({
   id: async () => {
     return v4()
+  },
+  isPublic: async (isPublic) => {
+    return isPublic ?? true
   },
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql

--- a/packages/server-core/src/user/avatar/avatar.ts
+++ b/packages/server-core/src/user/avatar/avatar.ts
@@ -47,7 +47,7 @@ export default (app: Application): void => {
     multi: true
   }
 
-  app.use(avatarPath, new AvatarService(options, app), {
+  app.use(avatarPath, new AvatarService(options), {
     // A list of all methods this service exposes externally
     methods: avatarMethods,
     // You can add additional custom events to be sent to clients here


### PR DESCRIPTION
## Summary
Services addressed:
- avatar

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f96d7f</samp>

The pull request refactors and simplifies the avatar service and its related components, hooks, and schemas. It introduces a new `action` parameter for querying avatars by role and a new `disallow-non-id` hook for preventing bulk operations. It also improves the data validation and user access control for avatars and adds some new fields to the avatar schema and resolver.

## References
#8871

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5f96d7f</samp>

*  Refactored the avatar service and hooks to use a new `action` query parameter instead of `admin` and to simplify the logic for finding, creating, and removing avatars ([link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-dfa429bf78698e5df4df82c929c4821f0c17e2ed635b06d117d649feac87c2b8L59-R63), [link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-40e51a77bde823c7304157ff0511d5843f27aa3d4969f8857bc844b3ca67f51eL91-R91), [link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-5b9433b387297dc0c6ed55db1406c2fd9fae45fd0b569dbee5c096f0a671ff7cL68-R70), [link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-249c92c587a296616cbfc5fa98143685c49067d046101c220bad2305a5408d65L71-R73), [link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-81108cdb5690aa587b75b4f0dee4a7d94eeb31bc2c15c72e7ac2bd64c30a18acL107-R107), [link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-87be37b08a68926dde323b6477b6902cc0675642772b0b3534d1fed9d3ef3fe8L26-R29), [link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-87be37b08a68926dde323b6477b6902cc0675642772b0b3534d1fed9d3ef3fe8L47-R40), [link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-5d8f220f6a127251c7b3c898887efb63a8dff4dfd9d9daab035d926c1ecb48d0L27-R44), [link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-5d8f220f6a127251c7b3c898887efb63a8dff4dfd9d9daab035d926c1ecb48d0R54-R151), [link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-5d8f220f6a127251c7b3c898887efb63a8dff4dfd9d9daab035d926c1ecb48d0L56-R172), [link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-5d8f220f6a127251c7b3c898887efb63a8dff4dfd9d9daab035d926c1ecb48d0L65-R184), [link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-5d8f220f6a127251c7b3c898887efb63a8dff4dfd9d9daab035d926c1ecb48d0L71-R190), [link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-6b5aeae4493318635d793807407029812cd7c00630cff03f0f2dadbba98879adL50-R50))
* Added a new hook function `disallowNonId` to prevent requests that do not have an id parameter in `packages/server-core/src/hooks/disallow-non-id.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-dce6ca7b8c78a6ad060dbc2d78c157c48bf9cb7ce48dd7f91fd8ec7add609cfeR1-R40))
* Updated the avatar resolver to add virtual fields for `createdAt` and `updatedAt` and to remove the external resolver in `packages/server-core/src/user/avatar/avatar.resolvers.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-4fc3166d2e818a31e3644b5f6bc62a29dedc4471d891217be755a5b39765d156R37-R41), [link](https://github.com/EtherealEngine/etherealengine/pull/8973/files?diff=unified&w=0#diff-4fc3166d2e818a31e3644b5f6bc62a29dedc4471d891217be755a5b39765d156L44-R58))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5f96d7f</samp>

> _Sing, O Muse, of the skillful refactorer_
> _Who simplified the code of `AvatarService`_
> _And made the queries more precise and faster_
> _With `$like` and `action` as his keys._

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
