### PR TITLE
Added api-job table and service

### DIFF
--- a/packages/engine/src/schemas/cluster/api-job.schema.ts
+++ b/packages/engine/src/schemas/cluster/api-job.schema.ts
@@ -39,9 +39,9 @@ export const apiJobSchema = Type.Object(
       format: 'uuid'
     }),
     name: Type.String(),
-    startTime: Type.String(),
+    startTime: Type.String({ format: 'date-time' }),
     endTime: Type.String({ format: 'date-time' }),
-    status: Type.String({ format: 'date-time' }),
+    status: Type.String(),
     returnData: Type.String(),
     createdAt: Type.String({ format: 'date-time' }),
     updatedAt: Type.String({ format: 'date-time' })

--- a/packages/engine/src/schemas/cluster/api-job.schema.ts
+++ b/packages/engine/src/schemas/cluster/api-job.schema.ts
@@ -1,0 +1,87 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+// For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
+import type { Static } from '@feathersjs/typebox'
+import { getValidator, querySyntax, Type } from '@feathersjs/typebox'
+import { dataValidator, queryValidator } from '../validators'
+
+export const apiJobPath = 'api-job'
+
+export const apiJobMethods = ['find', 'get', 'create', 'patch', 'remove'] as const
+
+// Main data model schema
+export const apiJobSchema = Type.Object(
+  {
+    id: Type.String({
+      format: 'uuid'
+    }),
+    name: Type.String(),
+    startTime: Type.String(),
+    endTime: Type.String({ format: 'date-time' }),
+    status: Type.String({ format: 'date-time' }),
+    returnData: Type.String(),
+    createdAt: Type.String({ format: 'date-time' }),
+    updatedAt: Type.String({ format: 'date-time' })
+  },
+  { $id: 'ApiJob', additionalProperties: false }
+)
+export type ApiJobType = Static<typeof apiJobSchema>
+
+// Schema for creating new entries
+export const apiJobDataSchema = Type.Pick(apiJobSchema, ['name', 'startTime', 'endTime', 'status', 'returnData'], {
+  $id: 'ApiJobData'
+})
+export type ApiJobData = Static<typeof apiJobDataSchema>
+
+// Schema for updating existing entries
+export const apiJobPatchSchema = Type.Partial(apiJobSchema, {
+  $id: 'ApiJobPatch'
+})
+export type ApiJobPatch = Static<typeof apiJobPatchSchema>
+
+// Schema for allowed query properties
+export const apiJobQueryProperties = Type.Pick(apiJobSchema, [
+  'id',
+  'name',
+  'startTime',
+  'endTime',
+  'status',
+  'returnData'
+])
+export const apiJobQuerySchema = Type.Intersect(
+  [
+    querySyntax(apiJobQueryProperties),
+    // Add additional query properties here
+    Type.Object({}, { additionalProperties: false })
+  ],
+  { additionalProperties: false }
+)
+export type ApiJobQuery = Static<typeof apiJobQuerySchema>
+
+export const apiJobValidator = getValidator(apiJobSchema, dataValidator)
+export const apiJobDataValidator = getValidator(apiJobDataSchema, dataValidator)
+export const apiJobPatchValidator = getValidator(apiJobPatchSchema, dataValidator)
+export const apiJobQueryValidator = getValidator(apiJobQuerySchema, queryValidator)

--- a/packages/engine/src/schemas/media/archiver.schema.ts
+++ b/packages/engine/src/schemas/media/archiver.schema.ts
@@ -34,7 +34,8 @@ export const archiverMethods = ['get'] as const
 export const archiverQueryProperties = Type.Object({
   directory: Type.Optional(Type.String()),
   storageProviderName: Type.Optional(Type.String()),
-  isJob: Type.Optional(Type.Boolean())
+  isJob: Type.Optional(Type.Boolean()),
+  jobId: Type.Optional(Type.String())
 })
 export const archiverQuerySchema = Type.Intersect(
   [

--- a/packages/server-core/src/cluster/api-job/api-job.class.ts
+++ b/packages/server-core/src/cluster/api-job/api-job.class.ts
@@ -23,9 +23,23 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import ApiJob from './api-job/api-job'
-import BuildStatus from './build-status/build-status'
-import LogsApi from './logs-api/logs-api'
-import Pods from './pods/pods'
+import type { Params } from '@feathersjs/feathers'
+import { KnexService } from '@feathersjs/knex'
 
-export default [LogsApi, BuildStatus, Pods, ApiJob]
+import {
+  ApiJobData,
+  ApiJobPatch,
+  ApiJobQuery,
+  ApiJobType
+} from '@etherealengine/engine/src/schemas/cluster/api-job.schema'
+import { RootParams } from '../../api/root-params'
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ApiJobParams extends RootParams<ApiJobQuery> {}
+
+export class ApiJobService<T = ApiJobType, ServiceParams extends Params = ApiJobParams> extends KnexService<
+  ApiJobType,
+  ApiJobData,
+  ApiJobParams,
+  ApiJobPatch
+> {}

--- a/packages/server-core/src/cluster/api-job/api-job.docs.ts
+++ b/packages/server-core/src/cluster/api-job/api-job.docs.ts
@@ -23,9 +23,24 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import ApiJob from './api-job/api-job'
-import BuildStatus from './build-status/build-status'
-import LogsApi from './logs-api/logs-api'
-import Pods from './pods/pods'
+import { createSwaggerServiceOptions } from 'feathers-swagger'
 
-export default [LogsApi, BuildStatus, Pods, ApiJob]
+import {
+  apiJobDataSchema,
+  apiJobPatchSchema,
+  apiJobQuerySchema,
+  apiJobSchema
+} from '@etherealengine/engine/src/schemas/cluster/api-job.schema'
+
+export default createSwaggerServiceOptions({
+  schemas: {
+    apiJobDataSchema,
+    apiJobPatchSchema,
+    apiJobQuerySchema,
+    apiJobSchema
+  },
+  docs: {
+    description: 'Build status service description',
+    securities: ['all']
+  }
+})

--- a/packages/server-core/src/cluster/api-job/api-job.hooks.ts
+++ b/packages/server-core/src/cluster/api-job/api-job.hooks.ts
@@ -1,0 +1,94 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import { hooks as schemaHooks } from '@feathersjs/schema'
+import { iff, isProvider } from 'feathers-hooks-common'
+
+import {
+  apiJobDataValidator,
+  apiJobPatchValidator,
+  apiJobQueryValidator
+} from '@etherealengine/engine/src/schemas/cluster/api-job.schema'
+
+import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
+import {
+  apiJobDataResolver,
+  apiJobExternalResolver,
+  apiJobPatchResolver,
+  apiJobQueryResolver,
+  apiJobResolver
+} from './api-job.resolvers'
+
+export default {
+  around: {
+    all: [schemaHooks.resolveExternal(apiJobExternalResolver), schemaHooks.resolveResult(apiJobResolver)]
+  },
+
+  before: {
+    all: [
+      authenticate(),
+      iff(isProvider('external'), verifyScope('admin', 'admin')),
+      () => schemaHooks.validateQuery(apiJobQueryValidator),
+      schemaHooks.resolveQuery(apiJobQueryResolver)
+    ],
+    find: [authenticate(), iff(isProvider('external'), verifyScope('admin', 'admin'))],
+    get: [authenticate(), iff(isProvider('external'), verifyScope('admin', 'admin'))],
+    create: [
+      authenticate(),
+      iff(isProvider('external'), verifyScope('admin', 'admin')),
+      () => schemaHooks.validateData(apiJobDataValidator),
+      schemaHooks.resolveData(apiJobDataResolver)
+    ],
+    update: [authenticate(), iff(isProvider('external'), verifyScope('admin', 'admin'))],
+    patch: [
+      authenticate(),
+      iff(isProvider('external'), verifyScope('admin', 'admin')),
+      () => schemaHooks.validateData(apiJobPatchValidator),
+      schemaHooks.resolveData(apiJobPatchResolver)
+    ],
+    remove: []
+  },
+
+  after: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  },
+
+  error: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: []
+  }
+} as any

--- a/packages/server-core/src/cluster/api-job/api-job.resolvers.ts
+++ b/packages/server-core/src/cluster/api-job/api-job.resolvers.ts
@@ -45,15 +45,11 @@ export const apiJobDataResolver = resolve<ApiJobType, HookContext>({
   id: async () => {
     return v4()
   },
-  startTime: getDateTimeSql,
-  endTime: getDateTimeSql,
   createdAt: getDateTimeSql,
   updatedAt: getDateTimeSql
 })
 
 export const apiJobPatchResolver = resolve<ApiJobType, HookContext>({
-  startTime: getDateTimeSql,
-  endTime: getDateTimeSql,
   updatedAt: getDateTimeSql
 })
 

--- a/packages/server-core/src/cluster/api-job/api-job.resolvers.ts
+++ b/packages/server-core/src/cluster/api-job/api-job.resolvers.ts
@@ -1,0 +1,60 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+// For more information about this file see https://dove.feathersjs.com/guides/cli/service.schemas.html
+import { resolve, virtual } from '@feathersjs/schema'
+
+import { ApiJobQuery, ApiJobType } from '@etherealengine/engine/src/schemas/cluster/api-job.schema'
+import type { HookContext } from '@etherealengine/server-core/declarations'
+
+import { v4 } from 'uuid'
+import { fromDateTimeSql, getDateTimeSql } from '../../util/datetime-sql'
+
+export const apiJobResolver = resolve<ApiJobType, HookContext>({
+  startTime: virtual(async (apiJob) => fromDateTimeSql(apiJob.startTime)),
+  endTime: virtual(async (apiJob) => fromDateTimeSql(apiJob.endTime)),
+  createdAt: virtual(async (apiJob) => fromDateTimeSql(apiJob.createdAt)),
+  updatedAt: virtual(async (apiJob) => fromDateTimeSql(apiJob.updatedAt))
+})
+
+export const apiJobExternalResolver = resolve<ApiJobType, HookContext>({})
+
+export const apiJobDataResolver = resolve<ApiJobType, HookContext>({
+  id: async () => {
+    return v4()
+  },
+  startTime: getDateTimeSql,
+  endTime: getDateTimeSql,
+  createdAt: getDateTimeSql,
+  updatedAt: getDateTimeSql
+})
+
+export const apiJobPatchResolver = resolve<ApiJobType, HookContext>({
+  startTime: getDateTimeSql,
+  endTime: getDateTimeSql,
+  updatedAt: getDateTimeSql
+})
+
+export const apiJobQueryResolver = resolve<ApiJobQuery, HookContext>({})

--- a/packages/server-core/src/cluster/api-job/api-job.test.ts
+++ b/packages/server-core/src/cluster/api-job/api-job.test.ts
@@ -1,0 +1,94 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import assert from 'assert'
+
+import { destroyEngine } from '@etherealengine/engine/src/ecs/classes/Engine'
+
+import { apiJobPath } from '@etherealengine/engine/src/schemas/cluster/api-job.schema'
+import { Application } from '../../../declarations'
+import { createFeathersKoaApp } from '../../createApp'
+
+const getRandomizedName = (name: string, suffix = '', prefix = 'test') =>
+  `${prefix}-${name}-${(Math.random() + 1).toString(36).substring(7)}${suffix}`
+
+/**appends trailing `/` for directory paths */
+const getDirectoryPath = (name: string) => name + '/'
+
+describe('api job service', () => {
+  let app: Application
+  before(async () => {
+    app = createFeathersKoaApp()
+    await app.setup()
+  })
+  after(() => {
+    return destroyEngine()
+  })
+
+  it('should register the service', () => {
+    const service = app.service(apiJobPath)
+    assert.ok(service, 'Registered the service')
+  })
+
+  it('find service', () => {
+    assert.doesNotThrow(async () => await app.service(apiJobPath).get(''))
+  })
+
+  let jobId
+  it('creates a job', async () => {
+    const createdJob = await app.service(apiJobPath).create({
+      name: 'test-job',
+      startTime: new Date().toISOString().slice(0, 19).replace('T', ' '),
+      endTime: new Date().toISOString().slice(0, 19).replace('T', ' '),
+      returnData: '',
+      status: 'pending'
+    })
+    jobId = createdJob.id
+    assert.ok(createdJob)
+  })
+
+  it('gets the job', async () => {
+    assert.doesNotThrow(async () => await app.service(apiJobPath).get(jobId))
+  })
+
+  it('finds multiple jobs', async () => {
+    const foundJobs = await app.service(apiJobPath).find({ query: { name: 'test-job' } })
+    assert.equal(foundJobs.total, 1)
+  })
+
+  it('patches the job', async () => {
+    await app.service(apiJobPath).patch(jobId, { name: 'updated-job', status: 'succeeded', returnData: 'success' })
+    const patchedJob = await app.service(apiJobPath).get(jobId)
+    assert.equal(patchedJob.name, 'updated-job')
+    assert.equal(patchedJob.status, 'succeeded')
+    assert.equal(patchedJob.returnData, 'success')
+  })
+
+  it('removes a job', async () => {
+    await app.service(apiJobPath).remove(jobId)
+    const foundJobs = await app.service(apiJobPath).find({ query: { name: 'updated-job' } })
+    assert.equal(foundJobs.total, 0)
+  })
+})

--- a/packages/server-core/src/cluster/api-job/api-job.test.ts
+++ b/packages/server-core/src/cluster/api-job/api-job.test.ts
@@ -30,12 +30,7 @@ import { destroyEngine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { apiJobPath } from '@etherealengine/engine/src/schemas/cluster/api-job.schema'
 import { Application } from '../../../declarations'
 import { createFeathersKoaApp } from '../../createApp'
-
-const getRandomizedName = (name: string, suffix = '', prefix = 'test') =>
-  `${prefix}-${name}-${(Math.random() + 1).toString(36).substring(7)}${suffix}`
-
-/**appends trailing `/` for directory paths */
-const getDirectoryPath = (name: string) => name + '/'
+import { getDateTimeSql } from '../../util/datetime-sql'
 
 describe('api job service', () => {
   let app: Application
@@ -58,10 +53,11 @@ describe('api job service', () => {
 
   let jobId
   it('creates a job', async () => {
+    const date = await getDateTimeSql()
     const createdJob = await app.service(apiJobPath).create({
       name: 'test-job',
-      startTime: new Date().toISOString().slice(0, 19).replace('T', ' '),
-      endTime: new Date().toISOString().slice(0, 19).replace('T', ' '),
+      startTime: date,
+      endTime: date,
       returnData: '',
       status: 'pending'
     })

--- a/packages/server-core/src/cluster/api-job/api-job.ts
+++ b/packages/server-core/src/cluster/api-job/api-job.ts
@@ -23,9 +23,35 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import ApiJob from './api-job/api-job'
-import BuildStatus from './build-status/build-status'
-import LogsApi from './logs-api/logs-api'
-import Pods from './pods/pods'
+import { apiJobMethods, apiJobPath } from '@etherealengine/engine/src/schemas/cluster/api-job.schema'
 
-export default [LogsApi, BuildStatus, Pods, ApiJob]
+import { Application } from '../../../declarations'
+import { ApiJobService } from './api-job.class'
+import apiJobDocs from './api-job.docs'
+import hooks from './api-job.hooks'
+
+declare module '@etherealengine/common/declarations' {
+  interface ServiceTypes {
+    [apiJobPath]: ApiJobService
+  }
+}
+
+export default (app: Application): void => {
+  const options = {
+    name: apiJobPath,
+    paginate: app.get('paginate'),
+    Model: app.get('knexClient'),
+    multi: true
+  }
+
+  app.use(apiJobPath, new ApiJobService(options), {
+    // A list of all methods this service exposes externally
+    methods: apiJobMethods,
+    // You can add additional custom events to be sent to clients here
+    events: [],
+    docs: apiJobDocs
+  })
+
+  const service = app.service(apiJobPath)
+  service.hooks(hooks)
+}

--- a/packages/server-core/src/cluster/api-job/migrations/20231003181504_api-job.ts
+++ b/packages/server-core/src/cluster/api-job/migrations/20231003181504_api-job.ts
@@ -32,13 +32,6 @@ import { apiJobPath } from '@etherealengine/engine/src/schemas/cluster/api-job.s
  * @returns { Promise<void> }
  */
 export async function up(knex: Knex): Promise<void> {
-  const oldTableName = 'api-job'
-
-  const oldNamedTableExists = await knex.schema.hasTable(oldTableName)
-  if (oldNamedTableExists) {
-    await knex.schema.renameTable(oldTableName, apiJobPath)
-  }
-
   const tableExists = await knex.schema.hasTable(apiJobPath)
 
   if (tableExists === false) {

--- a/packages/server-core/src/cluster/api-job/migrations/20231003181504_api-job.ts
+++ b/packages/server-core/src/cluster/api-job/migrations/20231003181504_api-job.ts
@@ -1,0 +1,75 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import type { Knex } from 'knex'
+
+import { apiJobPath } from '@etherealengine/engine/src/schemas/cluster/api-job.schema'
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function up(knex: Knex): Promise<void> {
+  const oldTableName = 'api-job'
+
+  const oldNamedTableExists = await knex.schema.hasTable(oldTableName)
+  if (oldNamedTableExists) {
+    await knex.schema.renameTable(oldTableName, apiJobPath)
+  }
+
+  const tableExists = await knex.schema.hasTable(apiJobPath)
+
+  if (tableExists === false) {
+    await knex.schema.createTable(apiJobPath, (table) => {
+      //@ts-ignore
+      table.uuid('id').collate('utf8mb4_bin').primary()
+      table.string('status', 255).defaultTo('pending')
+      table.text('returnData', 'mediumtext')
+      table.dateTime('startTime')
+      table.dateTime('endTime')
+      table.string('name', 255)
+      table.dateTime('createdAt').notNullable()
+      table.dateTime('updatedAt').notNullable()
+    })
+  }
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+export async function down(knex: Knex): Promise<void> {
+  const trx = await knex.transaction()
+  await trx.raw('SET FOREIGN_KEY_CHECKS=0')
+
+  const tableExists = await trx.schema.hasTable(apiJobPath)
+
+  if (tableExists === true) {
+    await trx.schema.dropTable(apiJobPath)
+  }
+
+  await trx.raw('SET FOREIGN_KEY_CHECKS=1')
+  await trx.commit()
+}

--- a/packages/server-core/src/media/recursive-archiver/archiver.class.ts
+++ b/packages/server-core/src/media/recursive-archiver/archiver.class.ts
@@ -35,6 +35,7 @@ import logger from '../../ServerLogger'
 import { RootParams } from '../../api/root-params'
 import config from '../../appconfig'
 import { createExecutorJob, getDirectoryArchiveJobBody } from '../../projects/project/project-helper'
+import { getDateTimeSql } from '../../util/datetime-sql'
 import { getStorageProvider } from '../storageprovider/storageprovider'
 
 const DIRECTORY_ARCHIVE_TIMEOUT = 60 * 10 //10 minutes
@@ -107,12 +108,14 @@ const archive = async (app: Application, directory, params?: ArchiverParams): Pr
 
   logger.info(`Archived ${directory} to ${zipOutputDirectory}`)
 
-  if (params.query.jobId)
+  if (params.query.jobId) {
+    const date = await getDateTimeSql()
     await app.service(apiJobPath).patch(params.query.jobId as string, {
       status: 'succeeded',
       returnData: zipOutputDirectory,
-      endTime: new Date().toISOString().slice(0, 19).replace('T', ' ')
+      endTime: date
     })
+  }
 
   return zipOutputDirectory
 }
@@ -138,10 +141,11 @@ export class ArchiverService implements ServiceInterface<string, ArchiverParams>
       else projectName = split[split.length - 1]
       projectName = projectName.toLowerCase()
 
+      const date = await getDateTimeSql()
       const newJob = await this.app.service(apiJobPath).create({
         name: '',
-        startTime: new Date().toISOString().slice(0, 19).replace('T', ' '),
-        endTime: new Date().toISOString().slice(0, 19).replace('T', ' '),
+        startTime: date,
+        endTime: date,
         returnData: '',
         status: 'pending'
       })

--- a/packages/server-core/src/media/recursive-archiver/archiver.class.ts
+++ b/packages/server-core/src/media/recursive-archiver/archiver.class.ts
@@ -27,6 +27,7 @@ import { NullableId, ServiceInterface } from '@feathersjs/feathers/lib/declarati
 import JSZip from 'jszip'
 import fetch from 'node-fetch'
 
+import { apiJobPath } from '@etherealengine/engine/src/schemas/cluster/api-job.schema'
 import { ArchiverQuery } from '@etherealengine/engine/src/schemas/media/archiver.schema'
 import { BadRequest } from '@feathersjs/errors'
 import { Application } from '../../../declarations'
@@ -45,7 +46,7 @@ const DIRECTORY_ARCHIVE_TIMEOUT = 60 * 10 //10 minutes
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ArchiverParams extends RootParams<ArchiverQuery> {}
 
-const archive = async (directory, params?: ArchiverParams): Promise<string> => {
+const archive = async (app: Application, directory, params?: ArchiverParams): Promise<string> => {
   if (directory.at(0) === '/') directory = directory.slice(1)
   if (!directory.startsWith('projects/') || ['projects', 'projects/'].includes(directory)) {
     return Promise.reject(new Error('Cannot archive non-project directories'))
@@ -106,6 +107,13 @@ const archive = async (directory, params?: ArchiverParams): Promise<string> => {
 
   logger.info(`Archived ${directory} to ${zipOutputDirectory}`)
 
+  if (params.query.jobId)
+    await app.service(apiJobPath).patch(params.query.jobId as string, {
+      status: 'succeeded',
+      returnData: zipOutputDirectory,
+      endTime: new Date().toISOString().slice(0, 19).replace('T', ' ')
+    })
+
   return zipOutputDirectory
 }
 
@@ -122,23 +130,40 @@ export class ArchiverService implements ServiceInterface<string, ArchiverParams>
     const directory = params?.query?.directory!.toString()
     delete params.query?.directory
 
-    if (!config.kubernetes.enabled || params?.query?.isJob) return archive(directory, params)
+    if (!config.kubernetes.enabled || params?.query?.isJob) return archive(this.app, directory, params)
     else {
       const split = directory!.split('/')
       let projectName
       if (split[split.length - 1].length === 0) projectName = split[split.length - 2]
       else projectName = split[split.length - 1]
       projectName = projectName.toLowerCase()
-      const jobBody = await getDirectoryArchiveJobBody(this.app, directory!, projectName)
+
+      const newJob = await this.app.service(apiJobPath).create({
+        name: '',
+        startTime: new Date().toISOString().slice(0, 19).replace('T', ' '),
+        endTime: new Date().toISOString().slice(0, 19).replace('T', ' '),
+        returnData: '',
+        status: 'pending'
+      })
+      const jobBody = await getDirectoryArchiveJobBody(this.app, directory!, projectName, newJob.id)
+      await this.app.service(apiJobPath).patch(newJob.id, {
+        name: jobBody.metadata!.name
+      })
       const jobLabelSelector = `etherealengine/directoryField=${projectName},etherealengine/release=${process.env.RELEASE_NAME},etherealengine/directoryArchiver=true`
-      const jobFinishedPromise = createExecutorJob(this.app, jobBody, jobLabelSelector, DIRECTORY_ARCHIVE_TIMEOUT)
+      const jobFinishedPromise = createExecutorJob(
+        this.app,
+        jobBody,
+        jobLabelSelector,
+        DIRECTORY_ARCHIVE_TIMEOUT,
+        newJob.id
+      )
       try {
         await jobFinishedPromise
-        const zipOutputDirectory = `temp/${projectName}.zip`
+        const job = await this.app.service(apiJobPath).get(newJob.id)
 
-        logger.info(`Archived ${directory} to ${zipOutputDirectory}`)
+        logger.info(`Archived ${directory} to ${job.returnData}`)
 
-        return zipOutputDirectory
+        return job.returnData
       } catch (err) {
         console.log('Error: Directory was not properly archived', directory, err)
         throw new BadRequest('Directory was not properly archived')

--- a/packages/server-core/src/projects/project/github-helper.ts
+++ b/packages/server-core/src/projects/project/github-helper.ts
@@ -53,7 +53,7 @@ import logger from '../../ServerLogger'
 import config from '../../appconfig'
 import { getFileKeysRecursive } from '../../media/storageprovider/storageProviderUtils'
 import { getStorageProvider } from '../../media/storageprovider/storageprovider'
-import { toDateTimeSql } from '../../util/datetime-sql'
+import { getDateTimeSql, toDateTimeSql } from '../../util/datetime-sql'
 import { deleteFolderRecursive, writeFileSyncRecursive } from '../../util/fsHelperFunctions'
 import { useGit } from '../../util/gitHelperFunctions'
 import { createExecutorJob, getProjectPushJobBody } from './project-helper'
@@ -251,18 +251,22 @@ export const pushProject = async (
         githubIdentityProvider.data[0].oauthToken,
         app
       )
-    if (jobId)
+    if (jobId) {
+      const date = await getDateTimeSql()
       await app.service(apiJobPath).patch(jobId, {
         status: 'succeeded',
-        endTime: new Date().toISOString().slice(0, 19).replace('T', ' ')
+        endTime: date
       })
+    }
   } catch (err) {
-    if (jobId)
+    if (jobId) {
+      const date = await getDateTimeSql()
       await app.service(apiJobPath).patch(jobId, {
         status: 'failed',
         returnData: err.toString(),
-        endTime: new Date().toISOString().slice(0, 19).replace('T', ' ')
+        endTime: date
       })
+    }
     logger.error(err)
     throw err
   }
@@ -283,10 +287,11 @@ export const pushProjectToGithub = async (
   else {
     const projectName = project.name.toLowerCase()
 
+    const date = await getDateTimeSql()
     const newJob = await app.service(apiJobPath).create({
       name: '',
-      startTime: new Date().toISOString().slice(0, 19).replace('T', ' '),
-      endTime: new Date().toISOString().slice(0, 19).replace('T', ' '),
+      startTime: date,
+      endTime: date,
       returnData: '',
       status: 'pending'
     })

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -1337,9 +1337,10 @@ export const createExecutorJob = async (
       if (job.status === 'failed') reject()
       if (counter >= timeout) {
         clearInterval(interval)
+        const date = await getDateTimeSql()
         await app.service(apiJobPath).patch(jobId, {
           status: 'failed',
-          endTime: new Date().toISOString().slice(0, 19).replace('T', ' ')
+          endTime: date
         })
         reject('Job timed out; try again later or check error logs of job')
       }
@@ -1400,11 +1401,13 @@ export const updateProject = async (
   if (data.sourceURL === 'default-project') {
     copyDefaultProject()
     await uploadLocalProjectToProvider(app, 'default-project')
-    if (params?.jobId)
+    if (params?.jobId) {
+      const date = await getDateTimeSql()
       await app.service(apiJobPath).patch(params.jobId as string, {
         status: 'succeeded',
-        endTime: new Date().toISOString().slice(0, 19).replace('T', ' ')
+        endTime: date
       })
+    }
     return (
       (await app.service(projectPath).find({
         query: {
@@ -1472,12 +1475,14 @@ export const updateProject = async (
       await git.checkoutLocalBranch(branchName)
     } else await git.checkout(branchName)
   } catch (err) {
-    if (params?.jobId)
+    if (params?.jobId) {
+      const date = await getDateTimeSql()
       await app.service(apiJobPath).patch(params.jobId as string, {
         status: 'failed',
         returnData: err.toString(),
-        endTime: new Date().toISOString().slice(0, 19).replace('T', ' ')
+        endTime: date
       })
+    }
     logger.error(err)
     throw err
   }
@@ -1570,11 +1575,13 @@ export const updateProject = async (
   } else if (k8BatchClient && (data.updateType === 'none' || data.updateType == null))
     await removeProjectUpdateJob(app, projectName)
 
-  if (params?.jobId)
+  if (params?.jobId) {
+    const date = await getDateTimeSql()
     await app.service(apiJobPath).patch(params.jobId as string, {
       status: 'succeeded',
-      endTime: new Date().toISOString().slice(0, 19).replace('T', ' ')
+      endTime: date
     })
+  }
 
   return returned
 }

--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -40,6 +40,7 @@ import {
 } from '@etherealengine/engine/src/schemas/user/github-repo-access.schema'
 import templateProjectJson from '@etherealengine/projects/template-project/package.json'
 
+import { apiJobPath } from '@etherealengine/engine/src/schemas/cluster/api-job.schema'
 import { StaticResourceType, staticResourcePath } from '@etherealengine/engine/src/schemas/media/static-resource.schema'
 import { projectPermissionPath } from '@etherealengine/engine/src/schemas/projects/project-permission.schema'
 import {
@@ -90,6 +91,7 @@ const projectsRootFolder = path.join(appRootPath.path, 'packages/projects/projec
 export type ProjectUpdateParams = {
   user?: UserType
   isJob?: boolean
+  jobId?: string
 }
 
 export interface ProjectParams extends RootParams<ProjectQuery>, ProjectUpdateParams {}
@@ -186,9 +188,20 @@ export class ProjectService<T = ProjectType, ServiceParams extends Params = Proj
       projectName = projectName.toLowerCase()
       if (projectName.substring(projectName.length - 4) === '.git') projectName = projectName.slice(0, -4)
       if (projectName.substring(projectName.length - 1) === '/') projectName = projectName.slice(0, -1)
-      const jobBody = await getProjectUpdateJobBody(data, this.app, params!.user!.id)
+
+      const newJob = await this.app.service(apiJobPath).create({
+        name: '',
+        startTime: new Date().toISOString().slice(0, 19).replace('T', ' '),
+        endTime: new Date().toISOString().slice(0, 19).replace('T', ' '),
+        returnData: '',
+        status: 'pending'
+      })
+      const jobBody = await getProjectUpdateJobBody(data, this.app, params!.user!.id, newJob.id)
+      await this.app.service(apiJobPath).patch(newJob.id, {
+        name: jobBody.metadata!.name
+      })
       const jobLabelSelector = `etherealengine/projectField=${data.name},etherealengine/release=${process.env.RELEASE_NAME},etherealengine/autoUpdate=false`
-      const jobFinishedPromise = createExecutorJob(this.app, jobBody, jobLabelSelector, 1000)
+      const jobFinishedPromise = createExecutorJob(this.app, jobBody, jobLabelSelector, 1000, newJob.id)
       try {
         await jobFinishedPromise
         const result = (await super._find({

--- a/packages/server-core/src/projects/project/project.class.ts
+++ b/packages/server-core/src/projects/project/project.class.ts
@@ -189,10 +189,11 @@ export class ProjectService<T = ProjectType, ServiceParams extends Params = Proj
       if (projectName.substring(projectName.length - 4) === '.git') projectName = projectName.slice(0, -4)
       if (projectName.substring(projectName.length - 1) === '/') projectName = projectName.slice(0, -1)
 
+      const date = await getDateTimeSql()
       const newJob = await this.app.service(apiJobPath).create({
         name: '',
-        startTime: new Date().toISOString().slice(0, 19).replace('T', ' '),
-        endTime: new Date().toISOString().slice(0, 19).replace('T', ' '),
+        startTime: date,
+        endTime: date,
         returnData: '',
         status: 'pending'
       })

--- a/scripts/archive-directory.ts
+++ b/scripts/archive-directory.ts
@@ -52,16 +52,17 @@ cli.enable('status')
 
 const options = cli.parse({
   directory: [false, 'Directory to archive', 'string'],
-  storageProviderName: [false, 'Storage Provider Name', 'string']
+  storageProviderName: [false, 'Storage Provider Name', 'string'],
+  jobId: [false, 'ID of Job record', 'string']
 })
 
 cli.main(async () => {
   try {
     const app = createFeathersKoaApp(ServerMode.API)
     await app.setup()
-    const { directory, storageProviderName } = options
+    const { directory, jobId, storageProviderName } = options
     await app.service(archiverPath).get(null, {
-      query: { storageProviderName: storageProviderName || undefined, isJob: true, directory: directory }
+      query: { storageProviderName: storageProviderName || undefined, isJob: true, directory, jobId }
     })
     cli.exit(0)
   } catch (err) {

--- a/scripts/push-project.ts
+++ b/scripts/push-project.ts
@@ -57,17 +57,18 @@ const options = cli.parse({
   userId: [false, 'ID of user updating project', 'string'],
   reset: [false, 'Whether to force reset the project', 'string'],
   commitSHA: [false, 'Commit SHA to use for project', 'string'],
-  storageProviderName: [false, 'Storage provider name', 'string']
+  storageProviderName: [false, 'Storage provider name', 'string'],
+  jobId: [false, 'ID of Job record', 'string']
 })
 
 cli.main(async () => {
   try {
     const app = createFeathersKoaApp(ServerMode.API)
     await app.setup()
-    const { userId, projectId, reset, commitSHA, storageProviderName } = options
+    const { userId, projectId, reset, commitSHA, storageProviderName, jobId } = options
     const user = await app.service(userPath).get(userId)
     const project = await app.service(projectPath)._get(projectId)
-    await pushProjectToGithub(app, project, user, reset, commitSHA, storageProviderName || undefined, true)
+    await pushProjectToGithub(app, project, user, reset, commitSHA, storageProviderName || undefined, true, jobId)
     cli.exit(0)
   } catch (err) {
     console.log(err)

--- a/scripts/update-project.ts
+++ b/scripts/update-project.ts
@@ -61,18 +61,19 @@ const options = cli.parse({
   commitSHA: [false, 'Commit SHA to use for project', 'string'],
   sourceBranch: [false, 'Branch to use for project source', 'string'],
   updateType: [false, 'Type of updating for project', 'string'],
-  updateSchedule: [false, 'Schedule for auto-updating project', 'string']
+  updateSchedule: [false, 'Schedule for auto-updating project', 'string'],
+  jobId: [false, 'ID of Job record', 'string']
 })
 
 cli.main(async () => {
   try {
     const app = createFeathersKoaApp(ServerMode.API)
     await app.setup()
-    const { userId, ...data } = options
+    const { userId, jobId, ...data } = options
     data.reset = data.reset === 'true'
     data.needsRebuild = data.needsRebuild === true
     const user = await app.service(userPath).get(userId)
-    await app.service(projectPath).update(data, null, { user: user, isJob: true })
+    await app.service(projectPath).update(data, null, { user: user, isJob: true, jobId })
     cli.exit(0)
   } catch (err) {
     console.log(err)


### PR DESCRIPTION
## Summary
Converted existing API job creation to use new service.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 31fe758</samp>

This pull request adds a new service called `api-job` that tracks the status and results of long-running tasks in the cluster, such as archiving and pushing project files. It modifies several existing services and scripts to integrate with the `api-job` service, by passing and updating a `jobId` parameter that identifies the corresponding api-job record. It also adds license header comments to the files related to the `api-job` service.

## References
closes #8850 

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 31fe758</samp>

*  Add license header comments to files that define the api-job service and its schema, documentation, hooks, resolvers, migration, and registration ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-53df689ec9a033630c19d39da388d51b668f52811fd602361e63482e8697c2fdR1-R87), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-61ea525a2bf5d1a57ce2b8cdcaf6154bf87e6197099fd0bfae805d66836a694bR1-R45), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-185a8d05e6f500db8d46dcd3ccbb0129d4dad6b35578a08897bca6f1ef0db0ceR1-R46), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-5ceeb9506973a3be875f0b571285eef40461b1685b48ff862d90473009a32faeR1-R94), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-6a5552b6beab50e9b931736714a63f83896e0e8512f644b747b61dd53861283dR1-R60), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-e1334b0ed8732d60dbcad7ca1a94fb881d5b7e48c162a2329a7adb76efbaec39R1-R57), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-cdd7b32ace7e6c322b7de860a772077ee8987506417742a783eb99b0206c7fd1R1-R75))
*  Add `jobId` property to the `archiverQueryProperties` object in the archiver schema, to allow the archiver service to accept a query parameter that specifies the ID of the api-job that is associated with the archiving operation ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-6a5746be813ac8285adaeab95431d6be71cb7dc2ae2fcb7832940dc861910987L37-R38))
*  Add `jobId` parameter to the `archive` function and the `get` method of the `ArchiverService` class in the archiver class, to pass and use the ID of the api-job record that is associated with the archiving operation ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-86190c7aad4ac6a7fe05be1309a128094d21fd945d5f624ea8ea10df1f30d0c5L48-R49), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-86190c7aad4ac6a7fe05be1309a128094d21fd945d5f624ea8ea10df1f30d0c5L125-R133), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-86190c7aad4ac6a7fe05be1309a128094d21fd945d5f624ea8ea10df1f30d0c5L132-R166))
*  Add logic to the `archive` function in the archiver class, to update the api-job record with the status, return data, and end time of the archiving operation, if the `jobId` query parameter is present ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-86190c7aad4ac6a7fe05be1309a128094d21fd945d5f624ea8ea10df1f30d0c5R110-R116))
*  Add `jobId` parameter to the `pushProject` and `pushProjectToGithub` functions in the GitHub helper, to pass and use the ID of the api-job record that is associated with the push operation ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-b651502d77caa5c46c93b5c78a2493b55970a88d67453d4d6136be8ba64f5ddfR170), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-b651502d77caa5c46c93b5c78a2493b55970a88d67453d4d6136be8ba64f5ddfL265-R298))
*  Add logic to the `pushProject` function in the GitHub helper, to update the api-job record with the status and end time of the push operation, if the `jobId` parameter is present ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-b651502d77caa5c46c93b5c78a2493b55970a88d67453d4d6136be8ba64f5ddfL252-R265))
*  Add `jobId` parameter to the `getProjectUpdateJobBody`, `getProjectPushJobBody`, and `getDirectoryArchiveJobBody` functions in the project helper, to pass and use the ID of the api-job record that is associated with the update, push, or archiving operation ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-e3b26c02b27ede7deb0ddbcacfe426dc9775fe1c5d10ca23beb184fe844de111L914-R916), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-e3b26c02b27ede7deb0ddbcacfe426dc9775fe1c5d10ca23beb184fe844de111R1006), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-e3b26c02b27ede7deb0ddbcacfe426dc9775fe1c5d10ca23beb184fe844de111L1138-R1147))
*  Add `jobId` to the command arguments of the Kubernetes job body in the `getProjectUpdateJobBody`, `getProjectPushJobBody`, and `getDirectoryArchiveJobBody` functions in the project helper, to pass the ID of the api-job record that is associated with the update, push, or archiving operation to the script that executes the operation ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-e3b26c02b27ede7deb0ddbcacfe426dc9775fe1c5d10ca23beb184fe844de111L944-R948), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-e3b26c02b27ede7deb0ddbcacfe426dc9775fe1c5d10ca23beb184fe844de111L1023-R1030), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-e3b26c02b27ede7deb0ddbcacfe426dc9775fe1c5d10ca23beb184fe844de111L1149-R1167))
*  Replace `process.env.RELEASE_NAME` with `process.env.RELEASE_NAME || ''` in the metadata and spec template labels of the Kubernetes job body in the `getDirectoryArchiveJobBody` function in the project helper, to avoid a TypeScript error when the `process.env.RELEASE_NAME` is undefined ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-e3b26c02b27ede7deb0ddbcacfe426dc9775fe1c5d10ca23beb184fe844de111L1160-R1178), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-e3b26c02b27ede7deb0ddbcacfe426dc9775fe1c5d10ca23beb184fe844de111L1169-R1187))
*  Add `jobId` parameter to the `createExecutorJob` function in the project helper, to pass and use the ID of the api-job record that is associated with the Kubernetes job ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-e3b26c02b27ede7deb0ddbcacfe426dc9775fe1c5d10ca23beb184fe844de111L1297-R1316))
*  Replace the logic of checking the status and results of the Kubernetes job in the `createExecutorJob` function in the project helper, to use the app service to get the api-job record with the given ID and check the status and return data of the record ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-e3b26c02b27ede7deb0ddbcacfe426dc9775fe1c5d10ca23beb184fe844de111L1313-R1343))
*  Add logic to the `updateProject` function in the project helper, to update the api-job record with the status and end time of the update operation, if the `jobId` parameter is present and the update operation succeeds or fails ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-e3b26c02b27ede7deb0ddbcacfe426dc9775fe1c5d10ca23beb184fe844de111R1403-R1407), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-e3b26c02b27ede7deb0ddbcacfe426dc9775fe1c5d10ca23beb184fe844de111R1475-R1480), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-e3b26c02b27ede7deb0ddbcacfe426dc9775fe1c5d10ca23beb184fe844de111R1573-R1578))
*  Add `jobId` property to the `ProjectUpdateParams` type in the project class, to allow the project service to accept a parameter that specifies the ID of the api-job that is associated with the update operation ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-be91b9c522bf776ef246cee46bf6c9e79af8dd6a39605d15e00f65f1dad846e5R94))
*  Add `jobId` parameter to the `getProjectUpdateJobBody` function call in the `update` method of the `ProjectService` class in the project class, to pass the ID of the api-job record that is associated with the update operation ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-be91b9c522bf776ef246cee46bf6c9e79af8dd6a39605d15e00f65f1dad846e5L189-R204))
*  Add `jobId` option to the `options` object in the `archive-directory`, `push-project`, and `update-project` scripts, to allow the scripts to accept an argument that specifies the ID of the api-job that is associated with the archiving, push, or update operation ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-be389d3d3010aa709338faab4268a6b422d0e8318d6262195a60c522681f4246L55-R56), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-adba147b052bc35d13ea0eb3d02e7e86872334361045084c59fb9e5db12a7cb6L60-R61), [link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-323b1d094226ae10971a5e202d616fc597918b871ee2d6c1649b872a0638dcedL64-R65))
*  Add `jobId` parameter to the `get` method call of the archiver service in the `archive-directory` script, to pass the ID of the api-job record that is associated with the archiving operation ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-be389d3d3010aa709338faab4268a6b422d0e8318d6262195a60c522681f4246L62-R65))
*  Add `jobId` parameter to the `pushProjectToGithub` function call in the `push-project` script, to pass the ID of the api-job record that is associated with the push operation ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-adba147b052bc35d13ea0eb3d02e7e86872334361045084c59fb9e5db12a7cb6L67-R71))
*  Add `jobId` parameter to the `update` method call of the project service in the `update-project` script, to pass the ID of the api-job record that is associated with the update operation ([link](https://github.com/EtherealEngine/etherealengine/pull/8977/files?diff=unified&w=0#diff-323b1d094226ae10971a5e202d616fc597918b871ee2d6c1649b872a0638dcedL71-R76))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 31fe758</samp>

> _We're adding `jobId` to the services and scripts_
> _To track the tasks that run for long and slow_
> _We're calling `api-job` to update the status_
> _And let the users know how things go_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
