### PR TITLE
teardown csm

### DIFF
--- a/packages/engine/src/assets/csm/CSM.ts
+++ b/packages/engine/src/assets/csm/CSM.ts
@@ -378,6 +378,22 @@ export class CSM {
     addOBCPlugin(material, material.userData.CSMPlugin)
   }
 
+  teardownMaterial(mesh: Mesh): void {
+    const material = mesh.material as Material
+    if (!material.userData) material.userData = {}
+    if (material.userData.CSMPlugin) {
+      removeOBCPlugin(material, material.userData.CSMPlugin)
+      delete material.userData.CSMPlugin
+    }
+    if (material.defines) {
+      delete material.defines.USE_CSM
+      delete material.defines.CSM_CASCADES
+      delete material.defines.CSM_FADE
+    }
+    material.needsUpdate = true
+    this.shaders.delete(material)
+  }
+
   updateUniforms(): void {
     const far = Math.min(this.camera.far, this.maxFar)
     this.shaders.forEach(function (shader: ShaderType, material: Material) {

--- a/packages/engine/src/scene/systems/SceneObjectSystem.tsx
+++ b/packages/engine/src/scene/systems/SceneObjectSystem.tsx
@@ -175,6 +175,15 @@ function SceneObjectReactor(props: { entity: Entity; obj: Object3DWithEntity }) 
         csm.setupMaterial(child)
       }
     })
+
+    return () => {
+      obj.traverse((child: Mesh<any, Material>) => {
+        if (!child.isMesh) return
+        if (csm) {
+          csm.teardownMaterial(child)
+        }
+      })
+    }
   }, [shadowComponent?.cast, shadowComponent?.receive, csm])
 
   return null


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9cf6df9</samp>

This pull request adds a method to remove the CSM plugin from mesh materials and calls it when an object is unmounted from the scene. This improves the memory management and performance of the CSM feature.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9cf6df9</samp>

*  Add a method to remove CSM plugin and defines from a mesh material ([link](https://github.com/EtherealEngine/etherealengine/pull/8979/files?diff=unified&w=0#diff-d9b41d114e05156cabc3421c1f872da63e7c9db2fcf741f97fa2940547922af3R381-R396))
*  Call this method on each mesh child of an object when it is unmounted from the scene ([link](https://github.com/EtherealEngine/etherealengine/pull/8979/files?diff=unified&w=0#diff-601c404f33a386e1c357a1e92b5d98135980256dcb9d3e1d01fd4aa15a834601R178-R186))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9cf6df9</samp>

> _`teardownMaterial`_
> _cleans up shadow map plugin_
> _leaves no trace in scene_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
