### PR TITLE
Fixed bug where patching users was deleting scopes

### DIFF
--- a/packages/server-core/src/hooks/add-scope-to-user.ts
+++ b/packages/server-core/src/hooks/add-scope-to-user.ts
@@ -38,15 +38,23 @@ export default () => {
         paginate: false
       })) as ScopeType[]
 
+      const removePromise = [] as Promise<ScopeType | null>[]
       if (foundItem.length > 0) {
-        foundItem.forEach(async (scp) => {
-          try {
-            await context.app.service(scopePath).remove(scp.id)
-          } catch (e) {
-            return
-          }
+        foundItem.forEach((scp) => {
+          removePromise.push(
+            new Promise<ScopeType | null>(async (resolve) => {
+              try {
+                const removedScope = await context.app.service(scopePath).remove(scp.id)
+                resolve(removedScope)
+              } catch (e) {
+                resolve(null)
+              }
+            })
+          )
         })
       }
+
+      await Promise.all(removePromise)
 
       const data = context.arguments[1].scopes.map((el) => {
         return {


### PR DESCRIPTION


## Summary
The deletion of existing scopes was not being awaited before attempting to make new scopes. New scopes that were replacing existing ones were not being created, as the old one still existed, and then the old one would finish deleting, potentially leaving the user without any scopes. Made an array of promises for the scope deletion that is awaited before making the new scopes.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2008733</samp>

Improved the `add-scope-to-user` hook by using `Promise.all` to remove scopes concurrently and handle errors gracefully.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2008733</samp>

* Improve concurrency and error handling of removing scopes from user ([link](https://github.com/EtherealEngine/etherealengine/pull/8980/files?diff=unified&w=0#diff-b7a01c84c96328d11e53018eaa5b184b5371b123123867f1cfc3edb0fedc6852L41-R58))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2008733</samp>

> _`Promise.all` waits_
> _for scopes to be removed_
> _then moves to next step_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
