### PR TITLE
Changes for user-api-key, user-relationship hooks refactor

### DIFF
--- a/packages/client-core/src/user/services/AuthService.ts
+++ b/packages/client-core/src/user/services/AuthService.ts
@@ -605,7 +605,15 @@ export const AuthService = {
   },
 
   async updateApiKey() {
-    const apiKey = (await API.instance.client.service(userApiKeyPath).patch(null, {})) as UserApiKeyType
+    const userApiKey = (await Engine.instance.api.service(userApiKeyPath).find()) as Paginated<UserApiKeyType>
+
+    let apiKey: UserApiKeyType | undefined
+    if (userApiKey.data.length > 0) {
+      apiKey = await Engine.instance.api.service(userApiKeyPath).patch(userApiKey.data[0].id, {})
+    } else {
+      apiKey = await Engine.instance.api.service(userApiKeyPath).create({})
+    }
+
     getMutableState(AuthState).user.merge({ apiKey })
   },
 

--- a/packages/server-core/src/hooks/send-invite.ts
+++ b/packages/server-core/src/hooks/send-invite.ts
@@ -177,7 +177,7 @@ export const sendInvite = async (app: Application, result: InviteType, params: I
       await generateSMS(app, result, token, inviteType, authUser.name, targetObjectId)
     } else if (result.inviteeId != null) {
       if (inviteType === 'friend') {
-        const existingRelationshipStatus = await app.service(userRelationshipPath)._find({
+        const existingRelationshipStatus = await app.service(userRelationshipPath).find({
           query: {
             $or: [
               {

--- a/packages/server-core/src/social/channel/channel.hooks.ts
+++ b/packages/server-core/src/social/channel/channel.hooks.ts
@@ -125,7 +125,7 @@ const ensureUsersFriendWithOwner = async (context: HookContext<ChannelService>) 
 
     if (!users || !userId) return context
 
-    const userRelationships = (await context.app.service(userRelationshipPath)._find({
+    const userRelationships = (await context.app.service(userRelationshipPath).find({
       query: {
         userId,
         userRelationshipType: 'friend',
@@ -179,7 +179,7 @@ const handleChannelInstance = async (context: HookContext<ChannelService>) => {
  */
 const checkExistingChannel = async (context: HookContext<ChannelService>) => {
   if (Array.isArray(context.data) || context.method !== 'create') {
-    throw new BadRequest('Channel service only works for single create')
+    throw new BadRequest(`${context.path} service only works for single object create`)
   }
 
   const { users, instanceId } = context.data as ChannelData

--- a/packages/server-core/src/social/channel/channel.hooks.ts
+++ b/packages/server-core/src/social/channel/channel.hooks.ts
@@ -112,7 +112,7 @@ const ensureUserHasChannelAccess = async (context: HookContext<ChannelService>) 
  */
 const ensureUsersFriendWithOwner = async (context: HookContext<ChannelService>) => {
   if (!context.data) {
-    throw new BadRequest('Channel service data is empty')
+    throw new BadRequest(`${context.path} service data is empty`)
   }
 
   const data: ChannelData[] = Array.isArray(context.data) ? context.data : [context.data]

--- a/packages/server-core/src/social/message/message.hooks.ts
+++ b/packages/server-core/src/social/message/message.hooks.ts
@@ -58,7 +58,7 @@ import { MessageService } from './message.class'
  */
 const disallowEmptyMessage = async (context: HookContext<MessageService>) => {
   if (!context.data) {
-    throw new BadRequest('Message service data is empty')
+    throw new BadRequest(`${context.path} service data is empty`)
   }
 
   const data = Array.isArray(context.data) ? context.data : [context.data]
@@ -78,7 +78,7 @@ const disallowEmptyMessage = async (context: HookContext<MessageService>) => {
  */
 const ensureChannelId = async (context: HookContext<MessageService>) => {
   if (!context.data || context.method !== 'create') {
-    throw new BadRequest('Message service only works for data in create')
+    throw new BadRequest(`${context.path} service only works for data in ${context.method}`)
   }
 
   const data: MessageData[] = Array.isArray(context.data) ? context.data : [context.data]

--- a/packages/server-core/src/user/accept-invite/accept-invite.class.ts
+++ b/packages/server-core/src/user/accept-invite/accept-invite.class.ts
@@ -170,7 +170,7 @@ export class AcceptInviteService implements ServiceInterface<AcceptInviteParams>
           throw new BadRequest('Invalid user ID')
         }
 
-        const existingRelationshipResult = await this.app.service(userRelationshipPath)._find({
+        const existingRelationshipResult = await this.app.service(userRelationshipPath).find({
           query: {
             $or: [
               {
@@ -204,7 +204,7 @@ export class AcceptInviteService implements ServiceInterface<AcceptInviteParams>
           )
         }
 
-        const relationshipToPatch = await this.app.service(userRelationshipPath)._find({
+        const relationshipToPatch = await this.app.service(userRelationshipPath).find({
           query: {
             $or: [
               {

--- a/packages/server-core/src/user/user-api-key/user-api-key.class.ts
+++ b/packages/server-core/src/user/user-api-key/user-api-key.class.ts
@@ -23,10 +23,6 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import type { NullableId, Params } from '@feathersjs/feathers'
-import type { KnexAdapterOptions } from '@feathersjs/knex'
-import { KnexAdapter } from '@feathersjs/knex'
-
 import {
   UserApiKeyData,
   UserApiKeyPatch,
@@ -34,66 +30,16 @@ import {
   UserApiKeyType
 } from '@etherealengine/engine/src/schemas/user/user-api-key.schema'
 
-import { Application } from '../../../declarations'
+import { Params } from '@feathersjs/feathers'
+import { KnexService } from '@feathersjs/knex'
 import { RootParams } from '../../api/root-params'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface UserApiKeyParams extends RootParams<UserApiKeyQuery> {}
 
-/**
- * A class for UserApiKey service
- */
-
-export class UserApiKeyService<T = UserApiKeyType, ServiceParams extends Params = UserApiKeyParams> extends KnexAdapter<
+export class UserApiKeyService<T = UserApiKeyType, ServiceParams extends Params = UserApiKeyParams> extends KnexService<
   UserApiKeyType,
   UserApiKeyData,
   UserApiKeyParams,
   UserApiKeyPatch
-> {
-  app: Application
-
-  constructor(options: KnexAdapterOptions, app: Application) {
-    super(options)
-    this.app = app
-  }
-
-  async find(params?: UserApiKeyParams) {
-    return await super._find(params)
-  }
-
-  async create(data: UserApiKeyData, params?: UserApiKeyParams) {
-    return super._create(data, params)
-  }
-
-  async patch(id: NullableId, data: UserApiKeyPatch, params?: UserApiKeyParams) {
-    const loggedInUser = params!.user
-    if (
-      loggedInUser &&
-      loggedInUser.scopes &&
-      loggedInUser.scopes.find((scope) => scope.type === 'admin:admin') &&
-      id != null &&
-      params
-    )
-      return super._patch(id, { ...data })
-
-    const userApiKey = await super._find({
-      query: {
-        userId: loggedInUser?.id
-      }
-    })
-
-    let returned
-    if (userApiKey.data.length > 0) {
-      const patchData: UserApiKeyPatch = { token: data.token }
-      returned = await super._patch(userApiKey.data[0].id, patchData)
-    } else {
-      const patchData: UserApiKeyData = { ...data, userId: loggedInUser?.id }
-      returned = await super._create(patchData)
-    }
-    return returned
-  }
-
-  async remove(id: NullableId, _params?: UserApiKeyParams) {
-    return super._remove(id, _params)
-  }
-}
+> {}

--- a/packages/server-core/src/user/user-api-key/user-api-key.hooks.ts
+++ b/packages/server-core/src/user/user-api-key/user-api-key.hooks.ts
@@ -32,6 +32,7 @@ import {
   userApiKeyQueryValidator
 } from '@etherealengine/engine/src/schemas/user/user-api-key.schema'
 
+import setLoggedInUser from '@etherealengine/server-core/src/hooks/set-loggedin-user-in-body'
 import authenticate from '../../hooks/authenticate'
 import attachOwnerIdInQuery from '../../hooks/set-loggedin-user-in-query'
 import {
@@ -53,15 +54,19 @@ export default {
       () => schemaHooks.validateQuery(userApiKeyQueryValidator),
       schemaHooks.resolveQuery(userApiKeyQueryResolver)
     ],
-    find: [iff(isProvider('external'), attachOwnerIdInQuery('userId') as any)],
-    get: [iff(isProvider('external'), attachOwnerIdInQuery('userId') as any)],
+    find: [iff(isProvider('external'), attachOwnerIdInQuery('userId'))],
+    get: [iff(isProvider('external'), attachOwnerIdInQuery('userId'))],
     create: [
-      disallow('external'),
       () => schemaHooks.validateData(userApiKeyDataValidator),
-      schemaHooks.resolveData(userApiKeyDataResolver)
+      schemaHooks.resolveData(userApiKeyDataResolver),
+      iff(isProvider('external'), setLoggedInUser('userId'))
     ],
     update: [disallow('external')],
-    patch: [() => schemaHooks.validateData(userApiKeyPatchValidator), schemaHooks.resolveData(userApiKeyPatchResolver)],
+    patch: [
+      () => schemaHooks.validateData(userApiKeyPatchValidator),
+      schemaHooks.resolveData(userApiKeyPatchResolver),
+      iff(isProvider('external'), setLoggedInUser('userId'))
+    ],
     remove: [disallow('external')]
   },
 

--- a/packages/server-core/src/user/user-relationship/user-relationship.class.ts
+++ b/packages/server-core/src/user/user-relationship/user-relationship.class.ts
@@ -23,28 +23,17 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { Id, Params } from '@feathersjs/feathers'
+import { Params } from '@feathersjs/feathers'
 
-import { UserID, userPath } from '@etherealengine/engine/src/schemas/user/user.schema'
-
-import { Application } from '../../../declarations'
-import config from '../../appconfig'
-
-import type { KnexAdapterOptions } from '@feathersjs/knex'
-import { KnexAdapter } from '@feathersjs/knex'
+import { KnexService } from '@feathersjs/knex'
 
 import {
   UserRelationshipData,
-  UserRelationshipID,
   UserRelationshipPatch,
   UserRelationshipQuery,
-  UserRelationshipType,
-  userRelationshipPath
+  UserRelationshipType
 } from '@etherealengine/engine/src/schemas/user/user-relationship.schema'
-import { Knex } from 'knex'
-import { v4 } from 'uuid'
 import { RootParams } from '../../api/root-params'
-import { getDateTimeSql } from '../../util/datetime-sql'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface UserRelationshipParams extends RootParams<UserRelationshipQuery> {}
@@ -55,172 +44,4 @@ export interface UserRelationshipParams extends RootParams<UserRelationshipQuery
 export class UserRelationshipService<
   T = UserRelationshipType,
   ServiceParams extends Params = UserRelationshipParams
-> extends KnexAdapter<UserRelationshipType, UserRelationshipData, UserRelationshipParams, UserRelationshipPatch> {
-  app: Application
-
-  constructor(options: KnexAdapterOptions, app: Application) {
-    super(options)
-    this.app = app
-  }
-
-  async find(params?: UserRelationshipParams) {
-    if (!params) params = {}
-
-    const loggedInUserId = params.user?.id
-
-    if (!loggedInUserId) {
-      throw new Error('User must be logged in to get relationships')
-    }
-
-    // Override the user id to be currently logged in user. This is to avoid user finding other user's relationships due to security concerns.
-    params.query = {
-      ...params.query,
-      userId: loggedInUserId
-    }
-
-    return await super._find(params)
-  }
-
-  async create(data: UserRelationshipData, params?: UserRelationshipParams) {
-    if (!params) params = {}
-
-    const loggedInUserEntity = config.authentication.entity
-
-    const userId = data.userId || params[loggedInUserEntity].userId
-    const { relatedUserId, userRelationshipType } = data
-
-    if (userRelationshipType === 'blocking') {
-      await super._remove(null, {
-        query: {
-          $or: [
-            {
-              relatedUserId,
-              userId
-            },
-            {
-              relatedUserId: userId,
-              userId: relatedUserId
-            }
-          ]
-        }
-      })
-    }
-
-    const trx = await (this.app.get('knexClient') as Knex).transaction()
-
-    await trx.from<UserRelationshipType>(userRelationshipPath).insert({
-      id: v4() as UserRelationshipID,
-      createdAt: await getDateTimeSql(),
-      updatedAt: await getDateTimeSql(),
-      userId: userId,
-      relatedUserId: relatedUserId,
-      userRelationshipType: userRelationshipType
-    })
-
-    if (userRelationshipType === 'blocking' || userRelationshipType === 'requested') {
-      await trx.from<UserRelationshipType>(userRelationshipPath).insert({
-        id: v4() as UserRelationshipID,
-        createdAt: await getDateTimeSql(),
-        updatedAt: await getDateTimeSql(),
-        userId: relatedUserId,
-        relatedUserId: userId,
-        userRelationshipType: userRelationshipType === 'blocking' ? 'blocked' : 'pending'
-      })
-    }
-
-    await trx.commit()
-
-    const result = await super._find({
-      query: {
-        userId,
-        relatedUserId
-      }
-    })
-
-    return result.data.length > 0 ? result.data[0] : undefined
-  }
-
-  async patch(id: Id, data: UserRelationshipPatch, params?: UserRelationshipParams) {
-    if (!params) params = {}
-
-    const { userRelationshipType } = data
-
-    let queryParams: UserRelationshipPatch
-
-    try {
-      await this.app.service(userPath).get(id)
-      //The ID resolves to a userId, in which case patch the relation joining that user to the requesting one
-      queryParams = {
-        userId: params.user!.id,
-        relatedUserId: id as UserID
-      }
-    } catch (err) {
-      //The ID does not resolve to a user, in which case it's the ID of the user-relationship object, so patch it
-      queryParams = {
-        id: id as UserRelationshipID
-      }
-    }
-
-    const trx = await (this.app.get('knexClient') as Knex).transaction()
-
-    await trx
-      .from<UserRelationshipType>(userRelationshipPath)
-      .update({
-        userRelationshipType: userRelationshipType
-      })
-      .where(queryParams)
-
-    if (userRelationshipType === 'friend' || userRelationshipType === 'blocking') {
-      const result = await super._find({
-        query: queryParams
-      })
-
-      if (result.data.length > 0) {
-        await trx
-          .from<UserRelationshipType>(userRelationshipPath)
-          .update({
-            userRelationshipType: userRelationshipType === 'friend' ? 'friend' : 'blocked'
-          })
-          .where({
-            userId: result.data[0].relatedUserId,
-            relatedUserId: result.data[0].userId
-          })
-      }
-    }
-
-    await trx.commit()
-
-    const response = await super._find({
-      query: queryParams
-    })
-
-    return response.data.length > 0 ? response.data[0] : undefined
-  }
-
-  async remove(id: UserID, params?: UserRelationshipParams) {
-    if (!params) params = {}
-
-    const loggedInUserEntity = config.authentication.entity
-
-    const authUser = params[loggedInUserEntity]
-    const userId = authUser.userId
-
-    //If the ID provided is not a user ID, as it's expected to be, it'll throw a 404
-    await this.app.service(userPath).get(id)
-
-    return await super._remove(null, {
-      query: {
-        $or: [
-          {
-            userId,
-            relatedUserId: id
-          },
-          {
-            userId: id,
-            relatedUserId: userId
-          }
-        ]
-      }
-    })
-  }
-}
+> extends KnexService<UserRelationshipType, UserRelationshipData, UserRelationshipParams, UserRelationshipPatch> {}

--- a/packages/server-core/src/user/user-relationship/user-relationship.hooks.ts
+++ b/packages/server-core/src/user/user-relationship/user-relationship.hooks.ts
@@ -36,9 +36,11 @@ import {
 } from '@etherealengine/engine/src/schemas/user/user-relationship.schema'
 
 import { UserID, userPath } from '@etherealengine/engine/src/schemas/user/user.schema'
+import setLoggedInUserInQuery from '@etherealengine/server-core/src/hooks/set-loggedin-user-in-query'
 import { BadRequest } from '@feathersjs/errors'
 import { HookContext } from '../../../declarations'
 import disallowNonId from '../../hooks/disallow-non-id'
+import verifyUserId from '../../hooks/verify-userId'
 import { UserRelationshipService } from './user-relationship.class'
 import {
   userRelationshipDataResolver,
@@ -88,6 +90,8 @@ const updateQueryBothWays = async (context: HookContext<UserRelationshipService>
       }
     ]
   }
+
+  context.id = undefined
 }
 
 export default {
@@ -104,7 +108,7 @@ export default {
       () => schemaHooks.validateQuery(userRelationshipQueryValidator),
       schemaHooks.resolveQuery(userRelationshipQueryResolver)
     ],
-    find: [],
+    find: [verifyUserId(), setLoggedInUserInQuery('userId')],
     get: [disallow()],
     create: [
       () => schemaHooks.validateData(userRelationshipDataValidator),

--- a/packages/server-core/src/user/user-relationship/user-relationship.hooks.ts
+++ b/packages/server-core/src/user/user-relationship/user-relationship.hooks.ts
@@ -94,7 +94,7 @@ const updateQueryBothWays = async (context: HookContext<UserRelationshipService>
     ]
   }
 
-  context.id = undefined
+  context.arguments[0] = null
 }
 
 /**
@@ -164,7 +164,7 @@ const ensureValidPatchId = async (context: HookContext<UserRelationshipService>)
       relatedUserId: context.id as UserID
     }
 
-    context.id = undefined
+    context.arguments[0] = null
   }
 }
 
@@ -178,7 +178,7 @@ const updatePatchBothWays = async (context: HookContext<UserRelationshipService>
     throw new BadRequest(`${context.path} service only works for single object patch`)
   }
 
-  const { userId, relatedUserId, userRelationshipType } = context.data as UserRelationshipData
+  const { userId, relatedUserId, userRelationshipType } = context.result![0] as UserRelationshipData
 
   if (
     (context.result || context.dispatch) &&

--- a/packages/server-core/src/user/user-relationship/user-relationship.resolvers.ts
+++ b/packages/server-core/src/user/user-relationship/user-relationship.resolvers.ts
@@ -38,17 +38,18 @@ import { userPath } from '@etherealengine/engine/src/schemas/user/user.schema'
 import { fromDateTimeSql, getDateTimeSql } from '../../util/datetime-sql'
 
 export const userRelationshipResolver = resolve<UserRelationshipType, HookContext>({
+  createdAt: virtual(async (userRelationship) => fromDateTimeSql(userRelationship.createdAt)),
+  updatedAt: virtual(async (userRelationship) => fromDateTimeSql(userRelationship.updatedAt))
+})
+
+export const userRelationshipExternalResolver = resolve<UserRelationshipType, HookContext>({
   user: virtual(async (userRelationship, context) => {
     if (userRelationship.userId) return await context.app.service(userPath)._get(userRelationship.userId)
   }),
   relatedUser: virtual(async (userRelationship, context) => {
     if (userRelationship.relatedUserId) return await context.app.service(userPath)._get(userRelationship.relatedUserId)
-  }),
-  createdAt: virtual(async (userRelationship) => fromDateTimeSql(userRelationship.createdAt)),
-  updatedAt: virtual(async (userRelationship) => fromDateTimeSql(userRelationship.updatedAt))
+  })
 })
-
-export const userRelationshipExternalResolver = resolve<UserRelationshipType, HookContext>({})
 
 export const userRelationshipDataResolver = resolve<UserRelationshipType, HookContext>({
   id: async () => {

--- a/packages/server-core/src/user/user-relationship/user-relationship.ts
+++ b/packages/server-core/src/user/user-relationship/user-relationship.ts
@@ -50,7 +50,7 @@ export default (app: Application): void => {
     multi: true
   }
 
-  app.use(userRelationshipPath, new UserRelationshipService(options, app), {
+  app.use(userRelationshipPath, new UserRelationshipService(options), {
     // A list of all methods this service exposes externally
     methods: userRelationshipMethods,
     // You can add additional custom events to be sent to clients here
@@ -63,7 +63,7 @@ export default (app: Application): void => {
 
   service.publish('created', async (data: UserRelationshipType): Promise<any> => {
     try {
-      const inverseRelationship = await app.service(userRelationshipPath)._find({
+      const inverseRelationship = await app.service(userRelationshipPath).find({
         query: {
           relatedUserId: data.userId,
           userId: data.relatedUserId
@@ -85,7 +85,7 @@ export default (app: Application): void => {
 
   service.publish('patched', async (data: UserRelationshipType): Promise<any> => {
     try {
-      const inverseRelationship = await app.service(userRelationshipPath)._find({
+      const inverseRelationship = await app.service(userRelationshipPath).find({
         query: {
           relatedUserId: data.userId,
           userId: data.relatedUserId


### PR DESCRIPTION
## Summary
Services Covered:
- user-api-key
- user-relationship

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f1a5944</samp>

This pull request refactors the user API key service and its client-side usage to use the new `Engine` and `KnexService` classes, which provide a simpler and more consistent way of accessing the backend services. It also adds a new hook function `is-scope` that checks the user's authorization scopes for different resources. It removes some unused and redundant code and updates the license headers.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f1a5944</samp>

*  Simplified the `UserApiKeyService` class by removing unnecessary properties and methods and using the `KnexService` class ([link](https://github.com/EtherealEngine/etherealengine/pull/8988/files?diff=unified&w=0#diff-b784bc36fe523ecf86dfd50feff42f2e223783d67ba6eb8fb34820e8037749cbL26-L29), [link](https://github.com/EtherealEngine/etherealengine/pull/8988/files?diff=unified&w=0#diff-b784bc36fe523ecf86dfd50feff42f2e223783d67ba6eb8fb34820e8037749cbL37-R34), [link](https://github.com/EtherealEngine/etherealengine/pull/8988/files?diff=unified&w=0#diff-b784bc36fe523ecf86dfd50feff42f2e223783d67ba6eb8fb34820e8037749cbL43-R45), [link](https://github.com/EtherealEngine/etherealengine/pull/8988/files?diff=unified&w=0#diff-5f3be39aeaecd83c0918d4219f3120290f81583616fdf9018e31fb32fce08ff2L47-R47))
*  Updated the `AuthService` class and the `UserApiKeyService` class to use the `Engine.instance.api` instead of the deprecated `API` class to access the user API key service ([link](https://github.com/EtherealEngine/etherealengine/pull/8988/files?diff=unified&w=0#diff-a44d309ed91c41e0c2ede4bcc269ccbf298f923b9575c5b51a2f7bef4c6a97dbL608-R616), [link](https://github.com/EtherealEngine/etherealengine/pull/8988/files?diff=unified&w=0#diff-b784bc36fe523ecf86dfd50feff42f2e223783d67ba6eb8fb34820e8037749cbL43-R45))
*  Added the `is-scope.ts` file that exports a hook to check the user's scope for a resource type ([link](https://github.com/EtherealEngine/etherealengine/pull/8988/files?diff=unified&w=0#diff-13350889b21ba0d8e099d57f7a9ffca8c45091d382a369acf9a3a0666f4ab36eR1-R55))
*  Modified the `create` and `patch` hooks for the user API key service to allow external calls and use the `setLoggedInUser` hook to set the user ID ([link](https://github.com/EtherealEngine/etherealengine/pull/8988/files?diff=unified&w=0#diff-c168d9cbf97d990db464a85277780135a8c79b65ef3dcba2e55f34c59715188bR35), [link](https://github.com/EtherealEngine/etherealengine/pull/8988/files?diff=unified&w=0#diff-c168d9cbf97d990db464a85277780135a8c79b65ef3dcba2e55f34c59715188bL56-R69))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f1a5944</samp>

> _The user API key service got a makeover_
> _It now uses the `Engine` and `KnexService` to be clever_
> _The `is-scope` hook checks the user's scope_
> _The `setLoggedInUser` hook sets the user's hope_
> _And the `API` class is deprecated forever_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
