### PR TITLE
fix media window sometimes showing multiple windows for the same user

### DIFF
--- a/packages/client-core/src/components/UserMediaWindows/index.tsx
+++ b/packages/client-core/src/components/UserMediaWindows/index.tsx
@@ -52,7 +52,6 @@ export const useMediaWindows = () => {
   const mediaNetworkInstanceState = useMediaNetwork()
   const mediaNetwork = NetworkState.mediaNetwork
   const selfUser = useHookstate(getMutableState(AuthState).user)
-  useHookstate(NetworkState.mediaNetworkState.ornull?.peers?.keys)
   const mediaNetworkConnected = mediaNetwork && mediaNetworkInstanceState?.ready?.value
 
   const consumers = Object.entries(peerMediaChannelState.get({ noproxy: true })) as [

--- a/packages/client-core/src/components/UserMediaWindows/index.tsx
+++ b/packages/client-core/src/components/UserMediaWindows/index.tsx
@@ -52,6 +52,7 @@ export const useMediaWindows = () => {
   const mediaNetworkInstanceState = useMediaNetwork()
   const mediaNetwork = NetworkState.mediaNetwork
   const selfUser = useHookstate(getMutableState(AuthState).user)
+  useHookstate(NetworkState.mediaNetworkState.ornull?.peers?.keys)
   const mediaNetworkConnected = mediaNetwork && mediaNetworkInstanceState?.ready?.value
 
   const consumers = Object.entries(peerMediaChannelState.get({ noproxy: true })) as [
@@ -100,7 +101,7 @@ export const useMediaWindows = () => {
     .filter(({ peerID }) => peerMediaChannelState[peerID].value)
 
   // if window doesnt exist for self, add it
-  if (!windows.find(({ peerID }) => peerID === selfPeerID)) {
+  if (mediaNetworkConnected && !windows.find(({ peerID }) => mediaNetwork.users[selfUserID]?.includes(peerID))) {
     windows.unshift({ peerID: selfPeerID, type: 'cam' })
   }
 


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7347684</samp>

This pull request improves the user media windows component by fixing the hook that manages the peer-to-peer video calls. It uses a new dependency to track the peer connections and updates the self window accordingly.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7347684</samp>

*  Add dependency to `useMediaWindows` hook on peer connections state ([link](https://github.com/EtherealEngine/etherealengine/pull/8993/files?diff=unified&w=0#diff-3afa846400efbbe2a1e63889e376b9ae1bec1893d632bbb525aae730ec816827R55))
*  Change condition for adding self window to check media network users map ([link](https://github.com/EtherealEngine/etherealengine/pull/8993/files?diff=unified&w=0#diff-3afa846400efbbe2a1e63889e376b9ae1bec1893d632bbb525aae730ec816827L103-R104))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7347684</samp>

> _Sing, O Muse, of the skillful coder who updated the hook_
> _That handles peer connections and media streaming with care_
> _He added a new dependency to `useMediaWindows`, the crook_
> _And changed the logic for the self window, a task most rare_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
