### PR TITLE
Changed recording IP to 127.0.0.1

### DIFF
--- a/packages/instanceserver/src/NetworkFunctions.ts
+++ b/packages/instanceserver/src/NetworkFunctions.ts
@@ -96,7 +96,7 @@ export const setupIPs = async () => {
     announcedIp
   }
 
-  localConfig.mediasoup.recording.ip = announcedIp
+  localConfig.mediasoup.recording.ip = '127.0.0.1'
 }
 
 export async function cleanupOldInstanceservers(app: Application): Promise<void> {


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5eba88b</samp>

Fixed a bug in the mediasoup recording feature by hardcoding the IP address in `setupIPs`. This avoids network problems with the docker container.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5eba88b</samp>

* Use a fixed IP address for mediasoup recording feature to avoid connectivity issues ([link](https://github.com/EtherealEngine/etherealengine/pull/8997/files?diff=unified&w=0#diff-4b6d0fcf01661321157ffc938c90143772b61022c88eba2140824700b046bdc6L99-R99))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5eba88b</samp>

> _`setupIPs` changed_
> _Fixed IP for recording_
> _Snow melts, workaround_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
