### PR TITLE
Added ability to get folder size.

### DIFF
--- a/packages/editor/src/components/assets/AssetsPreviewPanel.tsx
+++ b/packages/editor/src/components/assets/AssetsPreviewPanel.tsx
@@ -53,6 +53,7 @@ export type AssetSelectionChangePropsType = {
   resourceUrl: string
   name: string
   contentType: string
+  size: string | undefined
 }
 
 /**
@@ -62,7 +63,7 @@ export const AssetsPreviewPanel = React.forwardRef(({ hideHeading }: Props, ref)
   useImperativeHandle(ref, () => ({ onSelectionChanged }))
   const [previewPanel, usePreviewPanel] = useState({
     PreviewSource: null as any,
-    resourceProps: { resourceUrl: '', name: '' }
+    resourceProps: { resourceUrl: '', name: '', size: '' }
   })
 
   const thumbnail = useHookstate('')
@@ -91,7 +92,7 @@ export const AssetsPreviewPanel = React.forwardRef(({ hideHeading }: Props, ref)
       case AssetType.FBX:
         const modelPreviewPanel = {
           PreviewSource: ModelPreviewPanel,
-          resourceProps: { resourceUrl: props.resourceUrl, name: props.name }
+          resourceProps: { resourceUrl: props.resourceUrl, name: props.name, size: props.size }
         }
         usePreviewPanel(modelPreviewPanel)
         break
@@ -102,7 +103,7 @@ export const AssetsPreviewPanel = React.forwardRef(({ hideHeading }: Props, ref)
       case 'jpg':
         const imagePreviewPanel = {
           PreviewSource: ImagePreviewPanel,
-          resourceProps: { resourceUrl: props.resourceUrl, name: props.name }
+          resourceProps: { resourceUrl: props.resourceUrl, name: props.name, size: props.size }
         }
         usePreviewPanel(imagePreviewPanel)
         break
@@ -110,7 +111,7 @@ export const AssetsPreviewPanel = React.forwardRef(({ hideHeading }: Props, ref)
       case 'image/ktx2':
         const compImgPreviewPanel = {
           PreviewSource: ImagePreviewPanel,
-          resourceProps: { resourceUrl: thumbnail.value, name: props.name }
+          resourceProps: { resourceUrl: thumbnail.value, name: props.name, size: props.size }
         }
         usePreviewPanel(compImgPreviewPanel)
         break
@@ -120,7 +121,7 @@ export const AssetsPreviewPanel = React.forwardRef(({ hideHeading }: Props, ref)
       case 'm3u8':
         const videoPreviewPanel = {
           PreviewSource: VideoPreviewPanel,
-          resourceProps: { resourceUrl: props.resourceUrl, name: props.name }
+          resourceProps: { resourceUrl: props.resourceUrl, name: props.name, size: props.size }
         }
         usePreviewPanel(videoPreviewPanel)
         break
@@ -129,7 +130,7 @@ export const AssetsPreviewPanel = React.forwardRef(({ hideHeading }: Props, ref)
       case 'mp3':
         const audioPreviewPanel = {
           PreviewSource: AudioPreviewPanel,
-          resourceProps: { resourceUrl: props.resourceUrl, name: props.name }
+          resourceProps: { resourceUrl: props.resourceUrl, name: props.name, size: props.size }
         }
         usePreviewPanel(audioPreviewPanel)
         break
@@ -137,14 +138,14 @@ export const AssetsPreviewPanel = React.forwardRef(({ hideHeading }: Props, ref)
       case 'ts':
         const txtPreviewPanel = {
           PreviewSource: TxtPreviewPanel,
-          resourceProps: { resourceUrl: props.resourceUrl, name: props.name }
+          resourceProps: { resourceUrl: props.resourceUrl, name: props.name, size: props.size }
         }
         usePreviewPanel(txtPreviewPanel)
         break
       case 'json':
         const jsonPreviewPanel = {
           PreviewSource: JsonPreviewPanel,
-          resourceProps: { resourceUrl: props.resourceUrl, name: props.name }
+          resourceProps: { resourceUrl: props.resourceUrl, name: props.name, size: props.size }
         }
         usePreviewPanel(jsonPreviewPanel)
         break
@@ -152,7 +153,7 @@ export const AssetsPreviewPanel = React.forwardRef(({ hideHeading }: Props, ref)
       default:
         const unavailable = {
           PreviewSource: PreviewUnavailable,
-          resourceProps: { resourceUrl: props.resourceUrl, name: props.name }
+          resourceProps: { resourceUrl: props.resourceUrl, name: props.name, size: props.size }
         }
         usePreviewPanel(unavailable)
         break
@@ -161,7 +162,11 @@ export const AssetsPreviewPanel = React.forwardRef(({ hideHeading }: Props, ref)
 
   return (
     <>
-      {!hideHeading && <div style={assetHeadingStyles as React.CSSProperties}>{previewPanel.resourceProps.name}</div>}
+      {!hideHeading && (
+        <div style={assetHeadingStyles as React.CSSProperties}>
+          {`${previewPanel.resourceProps.name} (${previewPanel.resourceProps.size})`}{' '}
+        </div>
+      )}
       {previewPanel.PreviewSource && <previewPanel.PreviewSource resourceProps={previewPanel.resourceProps} />}
     </>
   )

--- a/packages/editor/src/components/assets/FileBrowserContentPanel.tsx
+++ b/packages/editor/src/components/assets/FileBrowserContentPanel.tsx
@@ -206,7 +206,8 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
       props.onSelectionChanged({
         resourceUrl: params.url,
         name: params.name,
-        contentType: params.type
+        contentType: params.type,
+        size: params.size
       })
     } else {
       const newPath = `${selectedDirectory.value}${params.name}/`
@@ -303,7 +304,7 @@ const FileBrowserContentPanel: React.FC<FileBrowserContentPanelProps> = (props) 
     isLoading.set(true)
     openConfirm.set(false)
     await FileBrowserService.deleteContent(contentToDeletePath.value)
-    props.onSelectionChanged({ resourceUrl: '', name: '', contentType: '' })
+    props.onSelectionChanged({ resourceUrl: '', name: '', contentType: '', size: '' })
     await refreshDirectory()
   }
 

--- a/packages/server-core/src/media/file-browser-upload/file-browser-upload.hooks.ts
+++ b/packages/server-core/src/media/file-browser-upload/file-browser-upload.hooks.ts
@@ -23,14 +23,51 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
+import { iff, isProvider } from 'feathers-hooks-common'
+import { SYNC } from 'feathers-sync'
+
+import authenticate from '../../hooks/authenticate'
+import verifyScope from '../../hooks/verify-scope'
+
+// An example of calculating the remaining space left on a hypothetical project max size
+// const projectNameRegex = /projects\/([^/]+)/
+// const PROJECT_MAX_SIZE = 100 * 1000 * 1000 //100 MB
+
+// const checkProjectSize = async (context: HookContext) => {
+//   const { data, params } = context
+//   const projectNameExec = projectNameRegex.exec(data.path)
+//   if (!projectNameExec) throw new BadRequest('Files must be uploaded in a project')
+//   const storageProvider = getStorageProvider()
+//   const projectName = projectNameExec[1]
+//   const projectSize = await storageProvider.getFolderSize(`projects/${projectName}`)
+//   const isCurrentFile = await storageProvider.doesExist(data.fileName, data.path)
+//   let existingFileSize = 0
+//   if (isCurrentFile) existingFileSize = (await storageProvider.getObject(`${data.path}${data.fileName}`)).Body.length
+//   const newFileSize = params.files[0].size
+//   if (newFileSize - existingFileSize + projectSize > PROJECT_MAX_SIZE) throw new BadRequest(
+//       `The file you are uploading would put this project over the max project size of ${PROJECT_MAX_SIZE / 1000000} MB. Uploaded file size: ${newFileSize / 1000000 } MB. Free space in project: ${(PROJECT_MAX_SIZE - projectSize) / 1000000} MB.`
+//   )
+//   return context
+// }
+
 export default {
   before: {
-    all: [],
+    all: [authenticate(), iff(isProvider('external'), verifyScope('editor', 'write'))],
     find: [],
     get: [],
-    create: [],
+    create: [
+      (context) => {
+        context[SYNC] = false
+        return context
+      }
+    ],
     update: [],
-    patch: [],
+    patch: [
+      (context) => {
+        context[SYNC] = false
+        return context
+      }
+    ],
     remove: []
   },
   after: {

--- a/packages/server-core/src/media/static-resource/static-resource.hooks.ts
+++ b/packages/server-core/src/media/static-resource/static-resource.hooks.ts
@@ -35,7 +35,7 @@ import collectAnalytics from '@etherealengine/server-core/src/hooks/collect-anal
 import authenticate from '../../hooks/authenticate'
 import verifyScope from '../../hooks/verify-scope'
 
-import { Forbidden, NotFound } from '@feathersjs/errors'
+import { Forbidden } from '@feathersjs/errors'
 import { HookContext } from '../../../declarations'
 import setLoggedinUserInBody from '../../hooks/set-loggedin-user-in-body'
 import { getStorageProvider } from '../storageprovider/storageprovider'

--- a/packages/server-core/src/media/storageprovider/ipfs.storage.ts
+++ b/packages/server-core/src/media/storageprovider/ipfs.storage.ts
@@ -293,6 +293,11 @@ export class IPFSStorage implements StorageProviderInterface {
     return results
   }
 
+  async getFolderSize(folderName: string): Promise<number> {
+    const folderContent = await this.listObjects(folderName, true)
+    return folderContent.Contents.reduce((accumulator, value) => accumulator + value.Size, 0)
+  }
+
   /**
    * Move or copy object from one place to another in the IPFS storage.
    * @param oldName Name of the old object.

--- a/packages/server-core/src/media/storageprovider/local.storage.ts
+++ b/packages/server-core/src/media/storageprovider/local.storage.ts
@@ -119,7 +119,7 @@ export class LocalStorage implements StorageProviderInterface {
   listObjects = async (
     prefix: string,
     recursive = false,
-    continuationToken: string
+    continuationToken?: string
   ): Promise<StorageListObjectInterface> => {
     const filePath = path.join(this.PATH_PREFIX, prefix)
     if (!fs.existsSync(filePath)) return { Contents: [] }
@@ -367,6 +367,11 @@ export class LocalStorage implements StorageProviderInterface {
 
     folder.push(...files)
     return folder
+  }
+
+  async getFolderSize(relativeDirStringPath: string): Promise<number> {
+    const folderContent = await this.listObjects(relativeDirStringPath, true)
+    return folderContent.Contents.reduce((accumulator, value) => accumulator + value.Size, 0)
   }
 
   /**

--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -651,11 +651,13 @@ export class S3Provider implements StorageProviderInterface {
       promises.push(
         new Promise(async (resolve) => {
           const key = folderContent.CommonPrefixes![i].Prefix.slice(0, -1)
+          const size = await this.getFolderSize(key)
           const cont: FileBrowserContentType = {
             key,
             url: `${this.bucketAssetURL}/${key}`,
             name: key.split('/').pop()!,
-            type: 'folder'
+            type: 'folder',
+            size
           }
           resolve(cont)
         })
@@ -684,6 +686,11 @@ export class S3Provider implements StorageProviderInterface {
     }
 
     return await Promise.all(promises)
+  }
+
+  async getFolderSize(folderName: string): Promise<number> {
+    const folderContent = await this.listObjects(folderName, true)
+    return folderContent.Contents.reduce((accumulator, value) => accumulator + value.Size, 0)
   }
 
   /**

--- a/packages/server-core/src/media/storageprovider/storageprovider.interface.ts
+++ b/packages/server-core/src/media/storageprovider/storageprovider.interface.ts
@@ -277,4 +277,6 @@ export interface StorageProviderInterface {
    * @param params Parameters of the add request.
    */
   putObject(object: StorageObjectPutInterface, params?: PutObjectParams): Promise<any>
+
+  getFolderSize(folderName: string): Promise<number>
 }


### PR DESCRIPTION
## Summary
Returning folder sizes as part of s3.listFolderContent now.

Displaying file sizes as part of preview.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fcc319b</samp>

This pull request adds the feature to display the size of the selected asset in the file browser of the editor, and implements the necessary logic for different storage providers to calculate the folder size. It also adds authentication and scope verification hooks to the file browser upload service, and removes an unused import from the static resource service. It modifies the files `AssetsPreviewPanel.tsx`, `FileBrowserContentPanel.tsx`, `local.storage.ts`, `s3.storage.ts`, `file-browser-upload.hooks.ts`, `static-resource.hooks.ts`, `ipfs.storage.ts`, and `storageprovider.interface.ts`.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fcc319b</samp>

*  Add `size` property to `AssetSelectionChangePropsType` and pass it to `onSelectionChanged` function prop of `FileBrowserContentPanel` component ([link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-d6f3837d733aa181bf834ec146bff20f596b2c73dff6f256ce24be0408f40ae0R56), [link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-5ef17280c22d3bd2b41075f135ca0374d375555609a4360a37de3f942363ed8cL209-R210), [link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-5ef17280c22d3bd2b41075f135ca0374d375555609a4360a37de3f942363ed8cL306-R307))
*  Pass `size` property to `resourceProps` object of different state objects in `AssetsPreviewPanel` component and display it in the heading ([link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-d6f3837d733aa181bf834ec146bff20f596b2c73dff6f256ce24be0408f40ae0L65-R66), [link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-d6f3837d733aa181bf834ec146bff20f596b2c73dff6f256ce24be0408f40ae0L94-R95), [link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-d6f3837d733aa181bf834ec146bff20f596b2c73dff6f256ce24be0408f40ae0L105-R106), [link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-d6f3837d733aa181bf834ec146bff20f596b2c73dff6f256ce24be0408f40ae0L113-R114), [link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-d6f3837d733aa181bf834ec146bff20f596b2c73dff6f256ce24be0408f40ae0L123-R124), [link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-d6f3837d733aa181bf834ec146bff20f596b2c73dff6f256ce24be0408f40ae0L132-R133), [link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-d6f3837d733aa181bf834ec146bff20f596b2c73dff6f256ce24be0408f40ae0L140-R141), [link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-d6f3837d733aa181bf834ec146bff20f596b2c73dff6f256ce24be0408f40ae0L147-R148), [link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-d6f3837d733aa181bf834ec146bff20f596b2c73dff6f256ce24be0408f40ae0L155-R156), [link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-d6f3837d733aa181bf834ec146bff20f596b2c73dff6f256ce24be0408f40ae0L164-R169))
*  Add `getFolderSize` method to `StorageProvider` interface and implement it for `IPFSStorage`, `LocalStorage` and `S3Provider` classes ([link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-4368a61cd5b710a63ee655a556fe72505574140e8a10f852a4fa5517d1d081acR280-R281), [link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-55b70c23f9cfdaaf30e5d144708c0800ea4f81961224f919318e7175eed08e97R296-R300), [link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-78cfe92ef17e616c0552b40388263dded87e398023e41f0152b5f500331ff791R372-R376), [link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-8355cc6812ded09068b1c27fb6c745d20017ce5fe28ee5235d676e5399fea10eR691-R695))
*  Assign `size` property to `cont` object in `listObjects` method of `S3Provider` class ([link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-8355cc6812ded09068b1c27fb6c745d20017ce5fe28ee5235d676e5399fea10eL654-R660))
*  Make `continuationToken` parameter optional in `listObjects` method of `LocalStorage` class ([link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-78cfe92ef17e616c0552b40388263dded87e398023e41f0152b5f500331ff791L122-R122))
*  Add authentication and scope verification hooks to `file-browser-upload` service and disable `feathers-sync` middleware for `create` and `patch` methods ([link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-1c7abac97c0522564c435b48420b39bf5b9a0a5aeebc56c0720d59d7d8503095L26-R70))
*  Remove unused import of `NotFound` error from `static-resource` service hooks ([link](https://github.com/EtherealEngine/etherealengine/pull/9004/files?diff=unified&w=0#diff-3a7a131d94f9ddb152bed687e8b02877c751b4765bb0d57f8d68747498586105L38-R38))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fcc319b</samp>

> _Oh we are the coders of the file browser_
> _We upload and serve the assets with power_
> _We add hooks and methods to get the folder size_
> _And we sync and select with the `size` property_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
