### PR TITLE
mocap head uses nose

### DIFF
--- a/packages/engine/src/mocap/solveMotionCapturePose.ts
+++ b/packages/engine/src/mocap/solveMotionCapturePose.ts
@@ -236,8 +236,7 @@ export function solveMotionCapturePose(landmarks: NormalizedLandmarkList, screen
     entity,
     landmarks[POSE_LANDMARKS.RIGHT_EAR],
     landmarks[POSE_LANDMARKS.LEFT_EAR],
-    landmarks[POSE_LANDMARKS.LEFT_EYE_INNER],
-    landmarks[POSE_LANDMARKS.RIGHT_EYE_INNER]
+    landmarks[POSE_LANDMARKS.NOSE]
   )
 
   // if (!planeHelper1.parent) {
@@ -570,7 +569,7 @@ export const solveFoot = (
 const headRotation = new Quaternion()
 const leftEarVec3 = new Vector3()
 const rightEarVec3 = new Vector3()
-const eyeCenterVec3 = new Vector3()
+const noseVec3 = new Vector3()
 const parentRotation = new Quaternion()
 
 const rotate90degreesAroundXAxis = new Quaternion().setFromAxisAngle(new Vector3(1, 0, 0), -Math.PI / 2)
@@ -579,17 +578,15 @@ export const solveHead = (
   entity: Entity,
   leftEar: NormalizedLandmark,
   rightEar: NormalizedLandmark,
-  leftEye: NormalizedLandmark,
-  rightEye: NormalizedLandmark
+  nose: NormalizedLandmark
 ) => {
   const rig = getComponent(entity, AvatarRigComponent)
 
   leftEarVec3.set(leftEar.x, -leftEar.y, leftEar.z)
   rightEarVec3.set(rightEar.x, -rightEar.y, rightEar.z)
-  eyeCenterVec3.addVectors(leftEye as Vector3, rightEye as Vector3).multiplyScalar(0.5)
-  eyeCenterVec3.y = -eyeCenterVec3.y
+  noseVec3.set(nose.x, -nose.y, nose.z)
 
-  getQuaternionFromPointsAlongPlane(rightEarVec3, leftEarVec3, eyeCenterVec3, headRotation, false)
+  getQuaternionFromPointsAlongPlane(rightEarVec3, leftEarVec3, noseVec3, headRotation, false)
 
   headRotation.multiply(rotate90degreesAroundXAxis)
 


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c956751</samp>

Improved head rotation calculation for motion capture pose. Used `nose` landmark instead of `eyeCenter` in `solveHead` function in `solveMotionCapturePose.ts`.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c956751</samp>

*  Simplify the input and computation of the head rotation from the mocap landmarks in `solveMotionCapturePose` ([link](https://github.com/EtherealEngine/etherealengine/pull/9005/files?diff=unified&w=0#diff-beee2f0f83dacc9e6c5b25166cb6ae1638375243648f231f8a3856d6024f0faeL239-R239), [link](https://github.com/EtherealEngine/etherealengine/pull/9005/files?diff=unified&w=0#diff-beee2f0f83dacc9e6c5b25166cb6ae1638375243648f231f8a3856d6024f0faeL573-R572), [link](https://github.com/EtherealEngine/etherealengine/pull/9005/files?diff=unified&w=0#diff-beee2f0f83dacc9e6c5b25166cb6ae1638375243648f231f8a3856d6024f0faeL582-R581), [link](https://github.com/EtherealEngine/etherealengine/pull/9005/files?diff=unified&w=0#diff-beee2f0f83dacc9e6c5b25166cb6ae1638375243648f231f8a3856d6024f0faeL589-R589))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c956751</samp>

> _We'll sail the seas with motion capture_
> _And `solveHead` with the nose_
> _We'll simplify the function's input and output_
> _And heave away on the count of three_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
