### PR TITLE
Fix `AvatarDissolveComponent`

### DIFF
--- a/packages/engine/src/avatar/components/AvatarDissolveComponent.ts
+++ b/packages/engine/src/avatar/components/AvatarDissolveComponent.ts
@@ -99,6 +99,10 @@ export const AvatarDissolveComponent = defineComponent({
       })
     }
 
+    if ('map' in uniforms) {
+      uniforms['origin_texture'] = uniforms['map']
+    }
+
     uniforms = UniformsUtils.merge([UniformsLib['lights'], uniforms])
 
     const vertexNonUVShader = `


### PR DESCRIPTION
`origin_texture` uniform is used by fragment shader, but never passed to it.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 79ad017</samp>

Added support for texture maps in `AvatarDissolveComponent`. Modified `uniforms` object to include `origin_texture` property for `DissolveShader`.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 79ad017</samp>

*  Add a new property `origin_texture` to the `uniforms` object of the `AvatarDissolveComponent` to store the original texture map of the material ([link](https://github.com/EtherealEngine/etherealengine/pull/9008/files?diff=unified&w=0#diff-d7b1d1168082ec890b6c497b80d0f1a68f6e13165f6234008e4aca81317409eaR102-R105))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 79ad017</samp>

> _`map` becomes `origin_texture`_
> _blending with dissolve effect_
> _a new look for spring_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
