### PR TITLE
scene loading improvement

### DIFF
--- a/packages/editor/src/services/EditorHistory.ts
+++ b/packages/editor/src/services/EditorHistory.ts
@@ -39,6 +39,7 @@ import {
 import { defineAction, defineState, getMutableState, getState, useHookstate } from '@etherealengine/hyperflux'
 import { Topic, defineActionQueue, dispatchAction } from '@etherealengine/hyperflux/functions/ActionFunctions'
 
+import { NotificationService } from '@etherealengine/client-core/src/common/services/NotificationService'
 import { EngineActions, EngineState } from '@etherealengine/engine/src/ecs/classes/EngineState'
 import { defineQuery, setComponent } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
 import { EntityTreeComponent } from '@etherealengine/engine/src/ecs/functions/EntityTree'
@@ -77,9 +78,17 @@ export const EditorHistoryState = defineState({
 
   resetHistory: () => {
     const sceneData = getState(SceneState).sceneData!
+    let migratedSceneData
+    try {
+      migratedSceneData = migrateSceneData(sceneData)
+    } catch (e) {
+      console.error(e)
+      migratedSceneData = JSON.parse(JSON.stringify(sceneData))
+      NotificationService.dispatchNotify('Failed to migrate scene.', { variant: 'error' })
+    }
     getMutableState(EditorHistoryState).set({
       index: 0,
-      history: [{ data: migrateSceneData(sceneData), selectedEntities: [] }]
+      history: [{ data: migratedSceneData, selectedEntities: [] }]
     })
     EditorHistoryState.applyCurrentSnapshot()
   },

--- a/packages/engine/src/transform/components/TransformComponent.ts
+++ b/packages/engine/src/transform/components/TransformComponent.ts
@@ -99,6 +99,7 @@ export const TransformComponent = defineComponent({
     component.matrix.value.compose(component.position.value, component.rotation.value, component.scale.value)
     component.matrixInverse.value.copy(component.matrix.value).invert()
 
+    /** Update local transform */
     const localTransform = getOptionalComponent(entity, LocalTransformComponent)
     const entityTree = getOptionalComponent(entity, EntityTreeComponent)
     if (localTransform && entityTree?.parentEntity) {
@@ -193,5 +194,3 @@ export const LocalTransformComponent = defineComponent({
     component.matrix.value.compose(component.position.value, component.rotation.value, component.scale.value)
   }
 })
-
-globalThis.TransformComponent = TransformComponent

--- a/packages/engine/src/transform/components/TransformComponent.ts
+++ b/packages/engine/src/transform/components/TransformComponent.ts
@@ -46,6 +46,7 @@ export type TransformComponentType = {
   rotation: Quaternion
   scale: Vector3
   matrix: Matrix4
+  matrixInverse: Matrix4
 }
 
 const { f64 } = Types
@@ -68,42 +69,32 @@ export const TransformComponent = defineComponent({
   schema: TransformSchema,
 
   onInit: (entity) => {
-    return {
-      position: null! as Vector3,
-      rotation: null! as Quaternion,
-      scale: null! as Vector3,
+    const dirtyTransforms = TransformComponent.dirtyTransforms
+    const component = {
+      position: proxifyVector3WithDirty(TransformComponent.position, entity, dirtyTransforms) as Vector3,
+      rotation: proxifyQuaternionWithDirty(TransformComponent.rotation, entity, dirtyTransforms) as Quaternion,
+      scale: proxifyVector3WithDirty(
+        TransformComponent.scale,
+        entity,
+        dirtyTransforms,
+        new Vector3(1, 1, 1)
+      ) as Vector3,
       matrix: new Matrix4(),
       matrixInverse: new Matrix4()
-    }
+    } as TransformComponentType
+    return component
   },
 
   onSet: (entity, component, json) => {
-    const dirtyTransforms = TransformComponent.dirtyTransforms
-
-    if (!component.position.value)
-      component.position.set(
-        proxifyVector3WithDirty(TransformComponent.position, entity, dirtyTransforms, new Vector3())
-      )
-    if (!component.rotation.value)
-      component.rotation.set(
-        proxifyQuaternionWithDirty(TransformComponent.rotation, entity, dirtyTransforms, new Quaternion())
-      )
-    if (!component.scale.value)
-      component.scale.set(
-        proxifyVector3WithDirty(TransformComponent.scale, entity, dirtyTransforms, new Vector3(1, 1, 1))
-      )
-
-    if (!json) return
-
-    const rotation = json.rotation
+    const rotation = json?.rotation
       ? typeof json.rotation.w === 'number'
         ? json.rotation
         : new Quaternion().setFromEuler(new Euler().setFromVector3(json.rotation as any as Vector3))
       : undefined
 
-    if (json.position) component.position.value.copy(json.position)
+    if (json?.position) component.position.value.copy(json.position)
     if (rotation) component.rotation.value.copy(rotation)
-    if (json.scale && !isZero(json.scale)) component.scale.value.copy(json.scale)
+    if (json?.scale && !isZero(json.scale)) component.scale.value.copy(json.scale)
 
     component.matrix.value.compose(component.position.value, component.rotation.value, component.scale.value)
     component.matrixInverse.value.copy(component.matrix.value).invert()


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 225cd39</samp>

This pull request improves the editor and the engine by adding better error handling and user feedback for scene data migration, and by enhancing the `TransformComponent` with a new property and cleaner code. It affects the files `EditorHistory.ts` and `TransformComponent.ts`.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 225cd39</samp>

* Import NotificationService to display user messages in the editor ([link](https://github.com/EtherealEngine/etherealengine/pull/9025/files?diff=unified&w=0#diff-19241e1be13fd73cc5e4cdad005b0a5418cec46a3b0e3d5f8c8d2f45da03f7f1R42))
* Handle migration errors by logging, copying, and notifying the user ([link](https://github.com/EtherealEngine/etherealengine/pull/9025/files?diff=unified&w=0#diff-19241e1be13fd73cc5e4cdad005b0a5418cec46a3b0e3d5f8c8d2f45da03f7f1L80-R91))
* Add matrixInverse property to TransformComponentType for relative transformations ([link](https://github.com/EtherealEngine/etherealengine/pull/9025/files?diff=unified&w=0#diff-5c3f93b0eae7e0c8ed7a22128c9b41a9d0003e4aad0cdc562bd7b8750a48257bR49))
* Refactor onInit and onSet functions of TransformComponent using proxify and optional chaining ([link](https://github.com/EtherealEngine/etherealengine/pull/9025/files?diff=unified&w=0#diff-5c3f93b0eae7e0c8ed7a22128c9b41a9d0003e4aad0cdc562bd7b8750a48257bL71-R89), [link](https://github.com/EtherealEngine/etherealengine/pull/9025/files?diff=unified&w=0#diff-5c3f93b0eae7e0c8ed7a22128c9b41a9d0003e4aad0cdc562bd7b8750a48257bL104-R97))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 225cd39</samp>

> _Sing, O Muse, of the skillful engineers who toiled_
> _To improve the editor of scenes, where many forms are coiled._
> _They added graceful error handling and user feedback bright_
> _With `NotificationService`, like Hermes' winged flight._

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
