### PR TITLE
reduce targetFramesToRequest for iOS

### DIFF
--- a/packages/engine/src/scene/components/VolumetricComponent.ts
+++ b/packages/engine/src/scene/components/VolumetricComponent.ts
@@ -35,6 +35,7 @@ import { AvatarDissolveComponent } from '@etherealengine/engine/src/avatar/compo
 import { AvatarEffectComponent, MaterialMap } from '@etherealengine/engine/src/avatar/components/AvatarEffectComponent'
 import { AudioState } from '../../audio/AudioState'
 import { isClient } from '../../common/functions/getEnvironment'
+import { iOS } from '../../common/functions/isMobile'
 import { Entity } from '../../ecs/classes/Entity'
 import {
   defineComponent,
@@ -162,7 +163,8 @@ export function VolumetricReactor() {
               },
               video: element as HTMLVideoElement,
               V1Args: {
-                worker: worker
+                worker: worker,
+                targetFramesToRequest: iOS ? 10 : 90
               },
               paths: [],
               playMode: PlayMode.loop


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7fe7c99</samp>

Added an optimization for volumetric video playback on iOS devices by adjusting the number of frames to request based on the `iOS` function in `VolumetricComponent.ts`.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7fe7c99</samp>

* Import `iOS` function from `isMobile` module to check device type ([link](https://github.com/EtherealEngine/etherealengine/pull/9030/files?diff=unified&w=0#diff-488521cee868606ef11e398a540128d8c0f8c7d535547d76e49778e16e2b029bR38))
* Add `targetFramesToRequest` property to `V1Args` object to specify how many frames to request from server ([link](https://github.com/EtherealEngine/etherealengine/pull/9030/files?diff=unified&w=0#diff-488521cee868606ef11e398a540128d8c0f8c7d535547d76e49778e16e2b029bL165-R167))
* Set `targetFramesToRequest` to 10 for iOS devices and 90 for other devices to optimize network and memory usage ([link](https://github.com/EtherealEngine/etherealengine/pull/9030/files?diff=unified&w=0#diff-488521cee868606ef11e398a540128d8c0f8c7d535547d76e49778e16e2b029bL165-R167))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7fe7c99</samp>

> _To improve video playback on iOS_
> _We imported a function that knows_
> _How to set the target frames_
> _In the V1Args names_
> _And optimize the volumetric flows_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
