### PR TITLE
`parentEntity` is null when asset is dropped into the scene.

### DIFF
--- a/packages/editor/src/functions/EditorControlFunctions.ts
+++ b/packages/editor/src/functions/EditorControlFunctions.ts
@@ -221,6 +221,7 @@ const createObjectFromSceneElement = (
   beforeEntity = null as Entity | null,
   updateSelection = true
 ) => {
+  parentEntity = parentEntity ?? getState(SceneState).sceneEntity
   cancelGrabOrPlacement()
 
   const newEntity = createEntity()


### PR DESCRIPTION
Replace it with SceneEntity if that's the case.

## Summary
copilot:summary

## References
closes #_insert number here_

## Explanation
copilot:walkthrough
copilot:poem

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
