### PR TITLE
fix-spline-component

### DIFF
--- a/packages/editor/src/components/properties/SplineNodeEditor.tsx
+++ b/packages/editor/src/components/properties/SplineNodeEditor.tsx
@@ -32,6 +32,7 @@ import { SplineComponent } from '@etherealengine/engine/src/scene/components/Spl
 import ClearIcon from '@mui/icons-material/Clear'
 import TimelineIcon from '@mui/icons-material/Timeline'
 
+import { NO_PROXY } from '@etherealengine/hyperflux'
 import { Quaternion, Vector3 } from 'three'
 import { PropertiesPanelButton } from '../inputs/Button'
 import EulerInput from '../inputs/EulerInput'
@@ -57,7 +58,7 @@ export const SplineNodeEditor: EditorComponentType = (props) => {
         <PropertiesPanelButton
           onClick={() => {
             const elem = { position: new Vector3(), quaternion: new Quaternion() }
-            const newElements = [...elements.value, elem]
+            const newElements = [...elements.get(NO_PROXY), elem]
             commitProperty(SplineComponent, 'elements')(newElements)
           }}
         >
@@ -70,7 +71,7 @@ export const SplineNodeEditor: EditorComponentType = (props) => {
           <div style={{ display: 'flex-row' }}>
             <ClearIcon
               onClick={() => {
-                const newElements = [...elements.value].filter((_, i) => i !== index)
+                const newElements = [...elements.get(NO_PROXY)].filter((_, i) => i !== index)
                 commitProperty(SplineComponent, 'elements')(newElements)
               }}
               style={{ color: 'white' }}
@@ -82,7 +83,10 @@ export const SplineNodeEditor: EditorComponentType = (props) => {
                 smallStep={0.01}
                 mediumStep={0.1}
                 largeStep={1}
-                onChange={commitProperty(SplineComponent, `elements.${index}.position` as any)}
+                onChange={(position) => {
+                  const changePosition = commitProperty(SplineComponent, `elements.${index}.position` as any)
+                  changePosition(new Vector3(position.x, position.y, position.z))
+                }}
               />
             </InputGroup>
             <InputGroup name="Rotation" label={`${t('editor:properties.transform.lbl-rotation')} ${index + 1}`}>
@@ -90,7 +94,10 @@ export const SplineNodeEditor: EditorComponentType = (props) => {
                 //style={{ maxWidth: 'calc(100% - 2px)', paddingRight: `3px`, width: '100%' }}
                 quaternion={elem.quaternion.value}
                 unit="°"
-                onChange={commitProperty(SplineComponent, `elements.${index}.quaternion` as any)}
+                onChange={(euler) => {
+                  const changeEuler = commitProperty(SplineComponent, `elements.${index}.quaternion` as any)
+                  changeEuler(new Quaternion().setFromEuler(euler))
+                }}
               />
             </InputGroup>
           </div>

--- a/packages/editor/src/components/properties/SplineNodeEditor.tsx
+++ b/packages/editor/src/components/properties/SplineNodeEditor.tsx
@@ -84,8 +84,10 @@ export const SplineNodeEditor: EditorComponentType = (props) => {
                 mediumStep={0.1}
                 largeStep={1}
                 onChange={(position) => {
-                  const changePosition = commitProperty(SplineComponent, `elements.${index}.position` as any)
-                  changePosition(new Vector3(position.x, position.y, position.z))
+                  commitProperty(
+                    SplineComponent,
+                    `elements.${index}.position` as any
+                  )(new Vector3(position.x, position.y, position.z))
                 }}
               />
             </InputGroup>
@@ -95,8 +97,10 @@ export const SplineNodeEditor: EditorComponentType = (props) => {
                 quaternion={elem.quaternion.value}
                 unit="°"
                 onChange={(euler) => {
-                  const changeEuler = commitProperty(SplineComponent, `elements.${index}.quaternion` as any)
-                  changeEuler(new Quaternion().setFromEuler(euler))
+                  commitProperty(
+                    SplineComponent,
+                    `elements.${index}.quaternion` as any
+                  )(new Quaternion().setFromEuler(euler))
                 }}
               />
             </InputGroup>

--- a/packages/editor/src/components/properties/SplineTrackNodeEditor.tsx
+++ b/packages/editor/src/components/properties/SplineTrackNodeEditor.tsx
@@ -40,7 +40,7 @@ import NumericInput from '../inputs/NumericInput'
 import SelectInput from '../inputs/SelectInput'
 import { Vector3Scrubber } from '../inputs/Vector3Input'
 import NodeEditor from './NodeEditor'
-import { EditorComponentType, commitProperty } from './Util'
+import { EditorComponentType, commitProperty, updateProperty } from './Util'
 
 /**
  * SplineTrackNodeEditor adds rotation editing to splines.
@@ -83,13 +83,13 @@ export const SplineTrackNodeEditor: EditorComponentType = (props) => {
       <InputGroup name="Velocity" label={t('editor:properties.splinetrack.lbl-velocity')}>
         <NumericInput
           value={velocity.value}
-          onChange={commitProperty(SplineTrackComponent, 'velocity')}
+          onChange={updateProperty(SplineTrackComponent, 'velocity')}
           onRelease={commitProperty(SplineTrackComponent, 'velocity')}
           prefix={
             <Vector3Scrubber
               tag="div"
               value={velocity.value}
-              onChange={commitProperty(SplineTrackComponent, 'velocity')}
+              onChange={updateProperty(SplineTrackComponent, 'velocity')}
               onPointerUp={commitProperty(SplineTrackComponent, 'velocity')}
             />
           }

--- a/packages/editor/src/components/properties/SplineTrackNodeEditor.tsx
+++ b/packages/editor/src/components/properties/SplineTrackNodeEditor.tsx
@@ -65,23 +65,9 @@ export const SplineTrackNodeEditor: EditorComponentType = (props) => {
   })
 
   // @todo allow these to be passed in or remove this capability
-  const onChange = () => {}
-  const onRelease = () => {}
 
   const setAlpha = (value) => {
     component.alpha.set(value)
-  }
-
-  const setRunning = (value) => {
-    component.loop.set(component.loop.value ? false : true)
-  }
-
-  const setVelocity = (value) => {
-    component.velocity.set(value)
-  }
-
-  const setRoll = () => {
-    component.enableRotation.set(component.enableRotation.value ? false : true)
   }
 
   return (
@@ -97,9 +83,16 @@ export const SplineTrackNodeEditor: EditorComponentType = (props) => {
       <InputGroup name="Velocity" label={t('editor:properties.splinetrack.lbl-velocity')}>
         <NumericInput
           value={velocity.value}
-          onChange={setVelocity}
-          onRelease={onRelease}
-          prefix={<Vector3Scrubber tag="div" value={velocity.value} onChange={setVelocity} onPointerUp={onRelease} />}
+          onChange={commitProperty(SplineTrackComponent, 'velocity')}
+          onRelease={commitProperty(SplineTrackComponent, 'velocity')}
+          prefix={
+            <Vector3Scrubber
+              tag="div"
+              value={velocity.value}
+              onChange={commitProperty(SplineTrackComponent, 'velocity')}
+              onPointerUp={commitProperty(SplineTrackComponent, 'velocity')}
+            />
+          }
         />
       </InputGroup>
       <InputGroup name="Enable Rotation" label={t('editor:properties.splinetrack.lbl-enableRotation')}>


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a166595</samp>

Improved the performance and code quality of spline editing components in the editor package. Used `NO_PROXY` to avoid unnecessary reactivity for `SplineComponent.elements`, and ensured proper type conversion for `position` and `quaternion` properties. Removed unused and redundant code from `SplineTrackNodeEditor.tsx`.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a166595</samp>

* Imported `NO_PROXY` symbol to access raw values of reactive properties without triggering reactivity ([link](https://github.com/EtherealEngine/etherealengine/pull/9037/files?diff=unified&w=0#diff-169490c2bf153c78497eee4d3bc46098505e6a23d669d749a1ea318772f24f31R35))
* Used `get` method with `NO_PROXY` argument to avoid reactive dependency on `elements` array of `SplineComponent` ([link](https://github.com/EtherealEngine/etherealengine/pull/9037/files?diff=unified&w=0#diff-169490c2bf153c78497eee4d3bc46098505e6a23d669d749a1ea318772f24f31L60-R61), [link](https://github.com/EtherealEngine/etherealengine/pull/9037/files?diff=unified&w=0#diff-169490c2bf153c78497eee4d3bc46098505e6a23d669d749a1ea318772f24f31L73-R74))
* Converted input values to `Vector3` and `Quaternion` instances before updating `position` and `quaternion` properties of `SplineComponent` ([link](https://github.com/EtherealEngine/etherealengine/pull/9037/files?diff=unified&w=0#diff-169490c2bf153c78497eee4d3bc46098505e6a23d669d749a1ea318772f24f31L85-R89), [link](https://github.com/EtherealEngine/etherealengine/pull/9037/files?diff=unified&w=0#diff-169490c2bf153c78497eee4d3bc46098505e6a23d669d749a1ea318772f24f31L93-R100))
* Removed unused `onChange` and `onRelease` functions from `SplineTrackNodeEditor` component ([link](https://github.com/EtherealEngine/etherealengine/pull/9037/files?diff=unified&w=0#diff-ce528ab4ae700c41abc8370f4995357d68c9774c60f02bc42fe11bd18a5968bdL68-L69), [link](https://github.com/EtherealEngine/etherealengine/pull/9037/files?diff=unified&w=0#diff-ce528ab4ae700c41abc8370f4995357d68c9774c60f02bc42fe11bd18a5968bdL75-L86))
* Replaced `onChange` and `onRelease` handlers with `commitProperty` function to update `velocity` property of `SplineTrackComponent` ([link](https://github.com/EtherealEngine/etherealengine/pull/9037/files?diff=unified&w=0#diff-ce528ab4ae700c41abc8370f4995357d68c9774c60f02bc42fe11bd18a5968bdL100-R95))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a166595</samp>

> _Sing, O Muse, of the skillful coder who refined the SplineNodeEditor_
> _And made it faster and more accurate, avoiding the reactive error_
> _By using the `NO_PROXY` symbol, a cunning trick of the mind_
> _To manipulate the `elements` array, as the gods themselves designed_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
