### PR TITLE
Refactor error boundary

### DIFF
--- a/packages/client-core/src/common/components/ErrorBoundary.tsx
+++ b/packages/client-core/src/common/components/ErrorBoundary.tsx
@@ -25,41 +25,9 @@ Ethereal Engine. All Rights Reserved.
 
 import React from 'react'
 
-type Props = {
-  children: React.ReactNode
-}
+import { createErrorBoundary } from '@etherealengine/common/src/utils/createErrorBoundary'
 
-type ErrorHandler = (error: Error, info: React.ErrorInfo) => void
-type ErrorHandlingComponent<Props> = (props: Props, error?: Error) => React.ReactNode
-
-type ErrorState = { error?: Error }
-
-function Catch<Props extends object>(
-  component: ErrorHandlingComponent<Props>,
-  errorHandler?: ErrorHandler
-): React.ComponentType<Props> {
-  return class extends React.Component<Props, ErrorState> {
-    state: ErrorState = {
-      error: undefined
-    }
-
-    static getDerivedStateFromError(error: Error) {
-      return { error }
-    }
-
-    componentDidCatch(error: Error, info: React.ErrorInfo) {
-      if (errorHandler) {
-        errorHandler(error, info)
-      }
-    }
-
-    render() {
-      return component(this.props, this.state.error)
-    }
-  }
-}
-
-const ErrorBoundary = Catch(function error(props: Props, error?: Error) {
+const ErrorBoundary = createErrorBoundary(function error(props, error?: Error) {
   if (error) {
     return (
       <div className="error-screen">

--- a/packages/client-core/src/components/Debug/index.tsx
+++ b/packages/client-core/src/components/Debug/index.tsx
@@ -299,14 +299,13 @@ export const Debug = ({ showingStateRef }: { showingStateRef: React.MutableRefOb
           data={dag}
           labelRenderer={(raw, ...keyPath) => {
             const label = raw[0]
-            if (label === 'preSystems') return <span style={{ color: 'red' }}>{t('common:debug.preSystems')}</span>
-            if (label === 'simulation') return <span style={{ color: 'green' }}>{t('common:debug.simulation')}</span>
-            if (label === 'subSystems') return <span style={{ color: 'red' }}>{t('common:debug.subSystems')}</span>
-            if (label === 'postSystems') return <span style={{ color: 'red' }}>{t('common:debug.postSystems')}</span>
+            if (label === 'preSystems' || label === 'simulation' || label === 'subSystems' || label === 'postSystems')
+              return <span style={{ color: 'green' }}>{t(`common:debug.${label}`)}</span>
             return <span style={{ color: 'black' }}>{label}</span>
           }}
           valueRenderer={(raw, value, ...keyPath) => {
             const system = SystemDefinitions.get((keyPath[0] === 'enabled' ? keyPath[1] : keyPath[0]) as SystemUUID)!
+            const systemReactor = system ? Engine.instance.activeSystemReactors.get(system.uuid) : undefined
             return (
               <>
                 <input
@@ -320,6 +319,11 @@ export const Debug = ({ showingStateRef }: { showingStateRef: React.MutableRefOb
                     }
                   }}
                 ></input>
+                {systemReactor?.error && (
+                  <span style={{ color: 'red' }}>
+                    {systemReactor.error.name}: {systemReactor.error.message}
+                  </span>
+                )}
               </>
             )
           }}

--- a/packages/common/src/utils/createErrorBoundary.ts
+++ b/packages/common/src/utils/createErrorBoundary.ts
@@ -1,3 +1,28 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
 import React from 'react'
 
 type Props = {

--- a/packages/common/src/utils/createErrorBoundary.ts
+++ b/packages/common/src/utils/createErrorBoundary.ts
@@ -1,0 +1,35 @@
+import React from 'react'
+
+type Props = {
+  children: React.ReactNode
+}
+
+type ErrorHandler = (error: Error, info: React.ErrorInfo) => void
+type ErrorHandlingComponent<Props> = (props: Props, error?: Error) => React.ReactNode
+
+type ErrorState = { error?: Error }
+
+export function createErrorBoundary<P extends Props>(
+  component: ErrorHandlingComponent<P>,
+  errorHandler?: ErrorHandler
+): React.ComponentType<P> {
+  return class extends React.Component<P, ErrorState> {
+    state: ErrorState = {
+      error: undefined
+    }
+
+    static getDerivedStateFromError(error: Error) {
+      return { error }
+    }
+
+    componentDidCatch(error: Error, info: React.ErrorInfo) {
+      if (errorHandler) {
+        errorHandler(error, info)
+      }
+    }
+
+    render() {
+      return component(this.props, this.state.error)
+    }
+  }
+}

--- a/packages/hyperflux/functions/ReactorFunctions.tsx
+++ b/packages/hyperflux/functions/ReactorFunctions.tsx
@@ -29,6 +29,8 @@ import { ConcurrentRoot, DefaultEventPriority } from 'react-reconciler/constants
 
 import { isDev } from '@etherealengine/common/src/config'
 
+import { createErrorBoundary } from '@etherealengine/common/src/utils/createErrorBoundary'
+
 import { HyperFlux } from './StoreFunctions'
 
 const ReactorReconciler = Reconciler({
@@ -89,6 +91,19 @@ const ReactorRootContext = React.createContext<ReactorRoot>(undefined as any)
 export function useReactorRootContext(): ReactorRoot {
   return React.useContext(ReactorRootContext)
 }
+
+const ReactorErrorBoundary = createErrorBoundary(function error(props, error?: Error) {
+  if (error) {
+    return (
+      <div className="error-screen">
+        <h2>An error has occured</h2>
+        <h4>{error.message}</h4>
+      </div>
+    )
+  } else {
+    return <React.Fragment>{props.children}</React.Fragment>
+  }
+})
 
 export function startReactor(Reactor: React.FC): ReactorRoot {
   const isStrictMode = false

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -96,7 +96,7 @@
     "jest-scss-transform": "^1.0.3",
     "path-browserify": "^1.0.1",
     "postcss": "^8.4.23",
-    "react": "^18.2.0",
+    "react": "18.2.0",
     "react-dom": "18.2.0",
     "sass": "1.59.3",
     "storybook": "^7.1.0-alpha.37",


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8c15e38</samp>

Added and refactored error boundaries for React components. Created a `createErrorBoundary` utility function in the `common` package and used it to wrap the `Reactor` component in the `hyperflux` package and the `ErrorBoundary` component in the `client-core` package. This improves error handling and code reuse.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8c15e38</samp>

*  Refactored `ErrorBoundary` component in `client-core` to use `createErrorBoundary` utility function from `common` ([link](https://github.com/EtherealEngine/etherealengine/pull/9040/files?diff=unified&w=0#diff-c699f64558722f77c5430b546d507a28f95da55d2c49e85ba5e44e2b6e891e8bL28-R30))
* Added `createErrorBoundary` utility function to `common` to create higher-order components that catch and render errors ([link](https://github.com/EtherealEngine/etherealengine/pull/9040/files?diff=unified&w=0#diff-8a1fc511e236289d3a2d95f5f50321f35b2567740e076f9828aa6b7b89880a6dR1-R35))
* Imported `createErrorBoundary` in `hyperflux` and created `ReactorErrorBoundary` component to wrap `Reactor` component and render error screen ([link](https://github.com/EtherealEngine/etherealengine/pull/9040/files?diff=unified&w=0#diff-729112a19e69583d2079be2d1d1fc3dbb0e52b0cb634a7bb8fcb7ed46ec66775R32-R33), [link](https://github.com/EtherealEngine/etherealengine/pull/9040/files?diff=unified&w=0#diff-729112a19e69583d2079be2d1d1fc3dbb0e52b0cb634a7bb8fcb7ed46ec66775R95-R107))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8c15e38</samp>

> _To handle errors with grace_
> _We refactored `ErrorBoundary`'s base_
> _Using `createErrorBoundary` from `common`_
> _We wrapped the `Reactor` in `hyperflux` with a new one_
> _Now errors won't blow up the whole place_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
