### PR TITLE
Updates to use scope type service instead of seedFile object

### DIFF
--- a/packages/server-core/src/user/identity-provider/identity-provider.class.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.class.ts
@@ -44,9 +44,9 @@ import { scopePath, ScopeType } from '@etherealengine/engine/src/schemas/scope/s
 import { userPath, UserType } from '@etherealengine/engine/src/schemas/user/user.schema'
 import { Application } from '../../../declarations'
 
+import { scopeTypePath } from '@etherealengine/engine/src/schemas/scope/scope-type.schema'
 import { KnexAdapterParams } from '@feathersjs/knex'
 import appConfig from '../../appconfig'
-import { scopeTypeSeed } from '../../scope/scope-type/scope-type.seed'
 import getFreeInviteCode from '../../util/get-free-invite-code'
 
 export interface IdentityProviderParams extends KnexAdapterParams<IdentityProviderQuery> {
@@ -255,7 +255,11 @@ export class IdentityProviderService<
         .createAccessToken({}, { subject: result.id.toString() })
     } else if (isDev && type === 'admin') {
       // in dev mode, add all scopes to the first user made an admin
-      const data = scopeTypeSeed.map(({ type }) => {
+      const scopeTypes = await this.app.service(scopeTypePath).find({
+        paginate: false
+      })
+
+      const data = scopeTypes.map(({ type }) => {
         return { userId, type }
       })
       await this.app.service(scopePath).create(data)

--- a/packages/server-core/src/util/make-initial-admin.ts
+++ b/packages/server-core/src/util/make-initial-admin.ts
@@ -25,21 +25,25 @@ Ethereal Engine. All Rights Reserved.
 
 import { UserID } from '@etherealengine/engine/src/schemas/user/user.schema'
 
-import { ScopeType, scopePath } from '@etherealengine/engine/src/schemas/scope/scope.schema'
+import { scopeTypePath } from '@etherealengine/engine/src/schemas/scope/scope-type.schema'
+import { scopePath } from '@etherealengine/engine/src/schemas/scope/scope.schema'
 import { Application } from '../../declarations'
-import { scopeTypeSeed } from '../scope/scope-type/scope-type.seed'
 
 export default async (app: Application, userId: UserID) => {
-  const adminCount = (await app.service(scopePath).find({
+  const adminCount = await app.service(scopePath).find({
     query: {
       $select: ['id'],
       type: 'admin:admin'
     },
     paginate: false
-  })) as ScopeType[]
+  })
 
   if (adminCount.length === 0) {
-    const data = scopeTypeSeed.map(({ type }) => {
+    const scopeTypes = await app.service(scopeTypePath).find({
+      paginate: false
+    })
+
+    const data = scopeTypes.map(({ type }) => {
       return { userId, type }
     })
     await app.service(scopePath).create(data)


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 539ac5a</samp>

Refactored the identity provider and initial admin creation logic to use the scope type service instead of a static seed file. This improves the modularity and configurability of the engine schema.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 539ac5a</samp>

*  Replaced `scopeTypeSeed` import with `scopeTypePath` import from engine schema in `identity-provider.class.ts` and `make-initial-admin.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9044/files?diff=unified&w=0#diff-4778cf1a03ca8f98b5143fbd19a64e7f0401e9f3d18321ef2cf8a26a1c697e44L47-R49), [link](https://github.com/EtherealEngine/etherealengine/pull/9044/files?diff=unified&w=0#diff-8f29cc9b35bf3d83fcf011d848976aa8ccc903e9e9915d148530effa12ae4616L28-R33))
*  Updated logic for adding all scopes to the first user made an admin in dev mode to use `scopeTypePath` service instead of `scopeTypeSeed` array in `identity-provider.class.ts` and `make-initial-admin.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9044/files?diff=unified&w=0#diff-4778cf1a03ca8f98b5143fbd19a64e7f0401e9f3d18321ef2cf8a26a1c697e44L258-R262), [link](https://github.com/EtherealEngine/etherealengine/pull/9044/files?diff=unified&w=0#diff-8f29cc9b35bf3d83fcf011d848976aa8ccc903e9e9915d148530effa12ae4616L39-R46))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 539ac5a</samp>

> _No more seeds of static scope_
> _We unleash the dynamic mode_
> _`scopeTypeService` is our guide_
> _We defy the engine's code_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
