### PR TITLE
save was being blocked if effects were turned off

### DIFF
--- a/packages/editor/src/functions/takeScreenshot.ts
+++ b/packages/editor/src/functions/takeScreenshot.ts
@@ -192,9 +192,9 @@ export async function takeScreenshot(
   scenePreviewCamera.layers.disableAll()
   scenePreviewCamera.layers.set(ObjectLayers.Scene)
 
-  const selection = EngineRenderer.instance.effectComposer.HighlightEffect.selection.values()
+  const selection = EngineRenderer.instance.effectComposer.HighlightEffect?.selection.values()
   if (hideHelpers) {
-    EngineRenderer.instance.effectComposer.HighlightEffect.clearSelection()
+    EngineRenderer.instance.effectComposer.HighlightEffect?.clearSelection()
   }
 
   const originalSize = EngineRenderer.instance.renderer.getSize(new Vector2())
@@ -230,7 +230,7 @@ export async function takeScreenshot(
   EngineRenderer.instance.effectComposer.render()
 
   if (hideHelpers) {
-    EngineRenderer.instance.effectComposer.HighlightEffect.setSelection(selection)
+    EngineRenderer.instance.effectComposer.HighlightEffect?.setSelection(selection)
   }
 
   const canvas = getResizedCanvas(EngineRenderer.instance.renderer.domElement, width, height)


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5033f01</samp>

Fixed screenshot errors and selection loss in editor. Improved `takeScreenshot.ts` code with optional chaining.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5033f01</samp>

*  Prevent errors and crashes when taking a screenshot with the highlight effect disabled or the hide helpers option enabled ([link](https://github.com/EtherealEngine/etherealengine/pull/9053/files?diff=unified&w=0#diff-ce2834ef59bd93a9bee672d2dc2628682c7bfb2e77e6b761a540024fb009f96bL195-R197), [link](https://github.com/EtherealEngine/etherealengine/pull/9053/files?diff=unified&w=0#diff-ce2834ef59bd93a9bee672d2dc2628682c7bfb2e77e6b761a540024fb009f96bL233-R233))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5033f01</samp>

> _When taking a screenshot with code_
> _You don't want to lose your selection mode_
> _So `HighlightEffect` got some checks_
> _With optional chaining syntax_
> _To fix issue #113 and lighten the load_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
