### PR TITLE
Add dropdowns to SystemComponent

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -738,14 +738,14 @@
       "lbl-loop": "Loop"
     },
     "systemnode": {
+      "name": "Systems",
       "description": "Attach script.",
-      "lbl-filePath": "Url",
+      "lbl-name": "Name",
       "lbl-insertUUID": "Reference System",
       "lbl-insertOrder": "Insertion Order",
       "lbl-enableClient": "Client",
       "lbl-enableServer": "Server",
-      "lbl-args": "Args",
-      "error-url": "Error Loading Script From URL"
+      "lbl-args": "Args"
     },
     "portal": {
       "lbl-portal": "Linked Portal",


### PR DESCRIPTION
With this PR, `SystemNodeEditor` lists all the systems (across the entities) in the `scene.json` in the dropdown. Short and unique substring from the `filePath` is shown as the system name.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c15b62</samp>

This pull request improves the UI and functionality of the system node editor component in the editor package. It replaces the script URL input with a select input for choosing the system component, and adds logic to handle the system component data conversion and update. It also updates the translation file for the editor UI to remove unused keys and add a label for the system node editor.

## References
Implements #7933

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6c15b62</samp>

*  Add a select input for choosing system components from the scene data in the system node editor component ([link](https://github.com/EtherealEngine/etherealengine/pull/9063/files?diff=unified&w=0#diff-bf1d5e36f2530818ada7c346bcf9f73be7b29aaed8ebf457e160493d012611c5L26-R29), [link](https://github.com/EtherealEngine/etherealengine/pull/9063/files?diff=unified&w=0#diff-bf1d5e36f2530818ada7c346bcf9f73be7b29aaed8ebf457e160493d012611c5L41-R44), [link](https://github.com/EtherealEngine/etherealengine/pull/9063/files?diff=unified&w=0#diff-bf1d5e36f2530818ada7c346bcf9f73be7b29aaed8ebf457e160493d012611c5L83-R158), [link](https://github.com/EtherealEngine/etherealengine/pull/9063/files?diff=unified&w=0#diff-bf1d5e36f2530818ada7c346bcf9f73be7b29aaed8ebf457e160493d012611c5L103-R171))
* Remove unused keys from the `systemnode` object in the `editor.json` file ([link](https://github.com/EtherealEngine/etherealengine/pull/9063/files?diff=unified&w=0#diff-827e8c4336f8ab1c715c553a8028695e3cfe0fa1b3af6432139850e34eb078fdL741-R748))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6c15b62</samp>

> _Sing, O Muse, of the skillful coder who refined the editor UI_
> _And removed the unused keys from the `editor.json` file_
> _He added a `name` key with the value `Systems`, glorious and true_
> _To label the node that controls the entity's system component with style_

## QA Steps
![2023-10-16 23-44-13](https://github.com/EtherealEngine/etherealengine/assets/52322531/3ccb2eb7-5dc0-4f4e-8586-d51309229657)

In the above example,
- https://localhost:9000/etherealengine-static-resources/projects/eepro-cinema/src/systems/CinemaScreenshareSystem.ts is shortened to `CinemaScreenshareSystem.ts`
- https://localhost:9000/etherealengine-static-resources/projects/eepro-cinema/src/clone/CinemaScreenshareSystem.ts is shortened to `clone/CinemaScreenshareSystem.ts`


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
