### PR TITLE
Refactor Notification Service

### DIFF
--- a/packages/client/src/pages/_app.tsx
+++ b/packages/client/src/pages/_app.tsx
@@ -29,20 +29,15 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import { initGA, logPageView } from '@etherealengine/client-core/src/common/analytics'
 import { defaultAction } from '@etherealengine/client-core/src/common/components/NotificationActions'
-import {
-  NotificationAction,
-  NotificationActions
-} from '@etherealengine/client-core/src/common/services/NotificationService'
+import { NotificationState } from '@etherealengine/client-core/src/common/services/NotificationService'
 import { ProjectService, ProjectState } from '@etherealengine/client-core/src/common/services/ProjectService'
 import Debug from '@etherealengine/client-core/src/components/Debug'
 import InviteToast from '@etherealengine/client-core/src/components/InviteToast'
 import { theme } from '@etherealengine/client-core/src/theme'
 import { AuthState } from '@etherealengine/client-core/src/user/services/AuthService'
 import GlobalStyle from '@etherealengine/client-core/src/util/GlobalStyle'
-import { AudioEffectPlayer } from '@etherealengine/engine/src/audio/systems/MediaSystem'
-import { matches } from '@etherealengine/engine/src/common/functions/MatchesUtils'
 import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
-import { addActionReceptor, getMutableState, removeActionReceptor, useHookstate } from '@etherealengine/hyperflux'
+import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
 import { loadWebappInjection } from '@etherealengine/projects/loadWebappInjection'
 
 import { StyledEngineProvider, Theme, ThemeProvider } from '@mui/material/styles'
@@ -64,6 +59,7 @@ const AppPage = ({ route }: { route: string }) => {
   const [projectComponents, setProjectComponents] = useState<Array<any>>([])
   const [fetchedProjectComponents, setFetchedProjectComponents] = useState(false)
   const projectState = useHookstate(getMutableState(ProjectState))
+  const notificationstate = useHookstate(getMutableState(NotificationState))
 
   const initApp = useCallback(() => {
     initGA()
@@ -71,22 +67,8 @@ const AppPage = ({ route }: { route: string }) => {
   }, [])
 
   useEffect(() => {
-    const receptor = (action): any => {
-      // @ts-ignore
-      matches(action).when(NotificationAction.notify.matches, (action) => {
-        AudioEffectPlayer.instance.play(AudioEffectPlayer.SOUNDS.alert, 0.5)
-        notistackRef.current?.enqueueSnackbar(action.message, {
-          variant: action.options.variant,
-          action: NotificationActions[action.options.actionType ?? 'default']
-        })
-      })
-    }
-    addActionReceptor(receptor)
-
-    return () => {
-      removeActionReceptor(receptor)
-    }
-  }, [])
+    notificationstate.snackbar.set(notistackRef.current)
+  }, [notistackRef.current])
 
   useEffect(initApp, [])
 

--- a/packages/client/src/pages/_app_tw.tsx
+++ b/packages/client/src/pages/_app_tw.tsx
@@ -36,17 +36,12 @@ import {
 import { API } from '@etherealengine/client-core/src/API'
 import { initGA, logPageView } from '@etherealengine/client-core/src/common/analytics'
 import { defaultAction } from '@etherealengine/client-core/src/common/components/NotificationActions'
-import {
-  NotificationAction,
-  NotificationActions
-} from '@etherealengine/client-core/src/common/services/NotificationService'
+import { NotificationState } from '@etherealengine/client-core/src/common/services/NotificationService'
 import { ProjectService, ProjectState } from '@etherealengine/client-core/src/common/services/ProjectService'
 import Debug from '@etherealengine/client-core/src/components/Debug'
 import { AuthState } from '@etherealengine/client-core/src/user/services/AuthService'
-import { AudioEffectPlayer } from '@etherealengine/engine/src/audio/systems/MediaSystem'
-import { matches } from '@etherealengine/engine/src/common/functions/MatchesUtils'
 import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
-import { addActionReceptor, getMutableState, removeActionReceptor, useHookstate } from '@etherealengine/hyperflux'
+import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
 import { loadWebappInjection } from '@etherealengine/projects/loadWebappInjection'
 
 import EngineTW from '../engine_tw'
@@ -119,24 +114,11 @@ const AppPage = () => {
 
 const TailwindPage = () => {
   const notistackRef = useRef<SnackbarProvider>()
+  const notificationstate = useHookstate(getMutableState(NotificationState))
 
   useEffect(() => {
-    const receptor = (action): any => {
-      // @ts-ignore
-      matches(action).when(NotificationAction.notify.matches, (action) => {
-        AudioEffectPlayer.instance.play(AudioEffectPlayer.SOUNDS.alert, 0.5)
-        notistackRef.current?.enqueueSnackbar(action.message, {
-          variant: action.options.variant,
-          action: NotificationActions[action.options.actionType ?? 'default']
-        })
-      })
-    }
-    addActionReceptor(receptor)
-
-    return () => {
-      removeActionReceptor(receptor)
-    }
-  }, [])
+    notificationstate.snackbar.set(notistackRef.current)
+  }, [notistackRef.current])
 
   return (
     <EngineTW>

--- a/packages/ui/src/pages/Capture/index.stories.tsx
+++ b/packages/ui/src/pages/Capture/index.stories.tsx
@@ -31,31 +31,21 @@ import React, { useEffect, useRef, useState } from 'react'
 
 // import { useLocation, useNavigate } from 'react-router-dom'
 
-import {
-  NotificationAction,
-  NotificationActions
-} from '@etherealengine/client-core/src/common/services/NotificationService'
+import { NotificationState } from '@etherealengine/client-core/src/common/services/NotificationService'
 import { ProjectService, ProjectState } from '@etherealengine/client-core/src/common/services/ProjectService'
 import { useLoadLocationScene } from '@etherealengine/client-core/src/components/World/LoadLocationScene'
 import { ClientNetworkingSystem } from '@etherealengine/client-core/src/networking/ClientNetworkingSystem'
 import { LocationState } from '@etherealengine/client-core/src/social/services/LocationService'
 import { AuthService, AuthState } from '@etherealengine/client-core/src/user/services/AuthService'
 import { SceneService } from '@etherealengine/client-core/src/world/services/SceneService'
-import { AudioEffectPlayer, MediaSystem } from '@etherealengine/engine/src/audio/systems/MediaSystem'
-import { matches } from '@etherealengine/engine/src/common/functions/MatchesUtils'
+import { MediaSystem } from '@etherealengine/engine/src/audio/systems/MediaSystem'
 import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { EngineActions } from '@etherealengine/engine/src/ecs/classes/EngineState'
 import { InputSystemGroup, PresentationSystemGroup } from '@etherealengine/engine/src/ecs/functions/EngineFunctions'
 import { startSystem, startSystems } from '@etherealengine/engine/src/ecs/functions/SystemFunctions'
 import { MotionCaptureSystem } from '@etherealengine/engine/src/mocap/MotionCaptureSystem'
 import { NetworkState } from '@etherealengine/engine/src/networking/NetworkState'
-import {
-  addActionReceptor,
-  dispatchAction,
-  getMutableState,
-  removeActionReceptor,
-  useHookstate
-} from '@etherealengine/hyperflux'
+import { dispatchAction, getMutableState, useHookstate } from '@etherealengine/hyperflux'
 import { loadEngineInjection } from '@etherealengine/projects/loadEngineInjection'
 
 import Component from './index'
@@ -99,24 +89,11 @@ const decorators = [
     const [fetchedProjectComponents, setFetchedProjectComponents] = useState(false)
     const projectState = useHookstate(getMutableState(ProjectState))
 
-    useEffect(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const receptor = (action): any => {
-        // @ts-ignore
-        matches(action).when(NotificationAction.notify.matches, (action) => {
-          AudioEffectPlayer.instance.play(AudioEffectPlayer.SOUNDS.alert, 0.5)
-          notistackRef.current?.enqueueSnackbar(action.message, {
-            variant: action.options.variant,
-            action: NotificationActions[action.options.actionType ?? 'default']
-          })
-        })
-      }
-      addActionReceptor(receptor)
+    const notificationstate = useHookstate(getMutableState(NotificationState))
 
-      return () => {
-        removeActionReceptor(receptor)
-      }
-    }, [])
+    useEffect(() => {
+      notificationstate.snackbar.set(notistackRef.current)
+    }, [notistackRef.current])
 
     useEffect(() => {
       if (selfUser?.id.value && projectState.updateNeeded.value) {


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1552940</samp>

Refactored the notification system to use SnackbarProvider and AudioEffectPlayer components and NotificationState hookstate. This improves the performance, simplicity, and consistency of displaying and playing notifications across different pages and components. Removed unused and redundant code from various files.

## References
#8305

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1552940</samp>

*  Refactored NotificationService to use NotificationState instead of NotificationAction ([link](https://github.com/EtherealEngine/etherealengine/pull/9065/files?diff=unified&w=0#diff-e5ec9c032703e4587ca213f2ea2de53fd255e9b15a69dc8f9ad3bf14cfcd205dL26-R42), [link](https://github.com/EtherealEngine/etherealengine/pull/9065/files?diff=unified&w=0#diff-e5ec9c032703e4587ca213f2ea2de53fd255e9b15a69dc8f9ad3bf14cfcd205dL50-R65))
*  Updated _app.tsx and _app_tw.tsx to import NotificationState and use useHookstate hook ([link](https://github.com/EtherealEngine/etherealengine/pull/9065/files?diff=unified&w=0#diff-1780c4458868da6e1a5ad300033cf07abffa5ba8c03fb2d863adcf6c7b4398d9L32-R32), [link](https://github.com/EtherealEngine/etherealengine/pull/9065/files?diff=unified&w=0#diff-1780c4458868da6e1a5ad300033cf07abffa5ba8c03fb2d863adcf6c7b4398d9R62), [link](https://github.com/EtherealEngine/etherealengine/pull/9065/files?diff=unified&w=0#diff-5f9f52804fb2e639aa2cef02cfb90b993cdd0c6b1ba015738618bac28786155fL39-R44))
*  Removed unused imports of AudioEffectPlayer, matches, addActionReceptor, and removeActionReceptor from _app.tsx and _app_tw.tsx ([link](https://github.com/EtherealEngine/etherealengine/pull/9065/files?diff=unified&w=0#diff-1780c4458868da6e1a5ad300033cf07abffa5ba8c03fb2d863adcf6c7b4398d9L42-R40), [link](https://github.com/EtherealEngine/etherealengine/pull/9065/files?diff=unified&w=0#diff-5f9f52804fb2e639aa2cef02cfb90b993cdd0c6b1ba015738618bac28786155fL122-R122))
*  Replaced useEffect hook that added and removed action receptor for NotificationAction with useEffect hook that sets snackbar reference in notificationstate in _app.tsx, _app_tw.tsx, and index.stories.tsx ([link](https://github.com/EtherealEngine/etherealengine/pull/9065/files?diff=unified&w=0#diff-1780c4458868da6e1a5ad300033cf07abffa5ba8c03fb2d863adcf6c7b4398d9L74-R72), [link](https://github.com/EtherealEngine/etherealengine/pull/9065/files?diff=unified&w=0#diff-5f9f52804fb2e639aa2cef02cfb90b993cdd0c6b1ba015738618bac28786155fL122-R122), [link](https://github.com/EtherealEngine/etherealengine/pull/9065/files?diff=unified&w=0#diff-e6e065f08c49b049f8542dd53073f31881edfe9c259f76bda8d42094617f9175L102-R97))
*  Removed unused imports of AudioEffectPlayer, matches, addActionReceptor, and removeActionReceptor from index.stories.tsx ([link](https://github.com/EtherealEngine/etherealengine/pull/9065/files?diff=unified&w=0#diff-e6e065f08c49b049f8542dd53073f31881edfe9c259f76bda8d42094617f9175L44-R41), [link](https://github.com/EtherealEngine/etherealengine/pull/9065/files?diff=unified&w=0#diff-e6e065f08c49b049f8542dd53073f31881edfe9c259f76bda8d42094617f9175L52-R48))
*  Updated index.stories.tsx to import NotificationState ([link](https://github.com/EtherealEngine/etherealengine/pull/9065/files?diff=unified&w=0#diff-e6e065f08c49b049f8542dd53073f31881edfe9c259f76bda8d42094617f9175L34-R34))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1552940</samp>

> _To display and play notifications_
> _We refactored some implementations_
> _We used `NotificationState`_
> _And removed some dead weight_
> _From imports and action receptors_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
