### PR TITLE
git documentation is behind apparently on issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-description: Create a report to help us improve
+about: Create a report to help us improve
 title: '[Bug]: '
 labels: '[bug]'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,14 +1,14 @@
 ---
 name: Epic
-description: Let's work towards something epic!
+about: Let's work towards something epic!
 title: '[Epic]: '
 labels: '[epic]'
 ---
 
 ## Dependent on
 
-- [ ] 
+- [ ]
 
 ## Stories
 
-- [ ] 
+- [ ]

--- a/.github/ISSUE_TEMPLATE/tech_support.md
+++ b/.github/ISSUE_TEMPLATE/tech_support.md
@@ -1,6 +1,6 @@
 ---
 name: Installation Tech Support
-description: I'm having difficulty installing Ethereal Engine
+about: I'm having difficulty installing Ethereal Engine
 title: '[Ticket]: '
 labels: '[ticket]'
 assignees: ''


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43fd798</samp>

Updated and renamed issue templates in `.github/ISSUE_TEMPLATE` folder. Fixed `description` field name to `about` in bug report and tech support templates.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 43fd798</samp>

*  Rename `description` fields to `about` in issue templates to match GitHub convention and avoid confusion ([link](https://github.com/EtherealEngine/etherealengine/pull/9068/files?diff=unified&w=0#diff-185833cb26d7ac66a4d39042fd576a820c2c2c6d05ad18973bb9c7dce77267c5L3-R3), [link](https://github.com/EtherealEngine/etherealengine/pull/9068/files?diff=unified&w=0#diff-6c928735ab2bc283d433f2b381cdfd7a24834c990be91ed4561d9d59571053d4L3-R3), [link](https://github.com/EtherealEngine/etherealengine/pull/9068/files?diff=unified&w=0#diff-eb4ea77060509c67d4e8d2b61b70aa74497a705db8c22264ebc058099e56f485L3-R3))
* Move `epic.md` file to `.github/ISSUE_TEMPLATE` directory to make it visible as an issue template option ([link](https://github.com/EtherealEngine/etherealengine/pull/9068/files?diff=unified&w=0#diff-6c928735ab2bc283d433f2b381cdfd7a24834c990be91ed4561d9d59571053d4L3-R3))
* Format `Dependent on` section in `epic.md` template to have a blank line between the checkbox and the `Stories` section ([link](https://github.com/EtherealEngine/etherealengine/pull/9068/files?diff=unified&w=0#diff-6c928735ab2bc283d433f2b381cdfd7a24834c990be91ed4561d9d59571053d4L10-R14))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 43fd798</samp>

> _Oh we're the GitHub sailors and we work on the code_
> _We rename and we move files as we sail on the road_
> _We heave away on `description` and we haul on `about`_
> _We tidy up the templates and we make them all stand out_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
