### PR TITLE
Fix skeleton helper

### DIFF
--- a/packages/engine/src/avatar/AvatarBoneMatching.ts
+++ b/packages/engine/src/avatar/AvatarBoneMatching.ts
@@ -589,7 +589,7 @@ export function getAllBones(rootBone: Bone) {
   const bones = {} as Record<VRMHumanBoneName, Bone>
   rootBone.traverse((bone: Bone) => {
     if (bone.isBone) {
-      const boneName = mixamoVRMRigMap[bone.name] ?? bone.name
+      const boneName = mixamoVRMRigMap[bone.name] ?? hipRigMap[bone.name] ?? bone.name
       bones[boneName] = bone
     }
   })
@@ -763,6 +763,10 @@ export const mixamoVRMRigMap = {
   mixamorigRightLeg: 'rightLowerLeg',
   mixamorigRightFoot: 'rightFoot',
   mixamorigRightToeBase: 'rightToes'
+}
+
+export const hipRigMap = {
+  CC_Base_Hip: 'hips'
 }
 
 export function makeBindPose(bones: VRMHumanBones) {


### PR DESCRIPTION
Remap a bone name to hips so that skeletonHelper works.

 #9079

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at da3d164</samp>

*  Add a fallback mapping for bones that are not found in the mixamoVRMRigMap ([link](https://github.com/EtherealEngine/etherealengine/pull/9078/files?diff=unified&w=0#diff-a63c2f98c8bc4c5f6fc8212cb0d7d917d4aee5f75096e4be018dfee6a24b0d6dL592-R592))
* Define the hipRigMap object in `packages/engine/src/avatar/AvatarBoneMatching.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9078/files?diff=unified&w=0#diff-a63c2f98c8bc4c5f6fc8212cb0d7d917d4aee5f75096e4be018dfee6a24b0d6dR768-R771))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at da3d164</samp>

> _We're sailing on the virtual sea, with avatars of all kinds_
> _But some of them are out of sync, their bones don't match their minds_
> _So we need a fallback map, for those who use `Mixamo`_
> _We'll align them with the `VRM`, and make them good to go_
