### PR TITLE
behave graph uses state definition instead of state instance

### DIFF
--- a/packages/engine/src/behave-graph/nodes/Profiles/Engine/helper/stateHelper.test.ts
+++ b/packages/engine/src/behave-graph/nodes/Profiles/Engine/helper/stateHelper.test.ts
@@ -1,3 +1,28 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
 import { StateDefinitions } from '@etherealengine/hyperflux'
 
 import assert from 'assert'

--- a/packages/engine/src/behave-graph/nodes/Profiles/Engine/helper/stateHelper.test.ts
+++ b/packages/engine/src/behave-graph/nodes/Profiles/Engine/helper/stateHelper.test.ts
@@ -1,0 +1,66 @@
+import { StateDefinitions } from '@etherealengine/hyperflux'
+
+import assert from 'assert'
+import { BehaveGraphState } from '../../../../state/BehaveGraphState'
+import { getStateGetters, getStateSetters } from './stateHelper'
+
+const skipState = [BehaveGraphState.name]
+
+describe('stateHelper', () => {
+  describe('getStateSetters', () => {
+    it('should return an array of NodeDefinition objects', () => {
+      const setters = getStateSetters()
+      assert(Array.isArray(setters))
+      assert(setters.every((node) => typeof node === 'object'))
+    })
+
+    it('should skip states in the skipState array', () => {
+      const skippedState = ''
+      const setters = getStateSetters()
+      assert(!setters.some((node) => node.typeName === `engine/state/set${skippedState}`))
+    })
+
+    it('should generate a NodeDefinition for each state in StateDefinitions', () => {
+      const stateNames = Array.from(StateDefinitions.keys())
+      const setters = getStateSetters()
+      console.log(stateNames, setters)
+      assert.strictEqual(setters.length, stateNames.length - skipState.length)
+      assert(
+        stateNames.every((stateName) => {
+          if (skipState.includes(stateName)) {
+            return true
+          }
+          return setters.some((node) => node.typeName === `engine/state/set${stateName}`)
+        })
+      )
+    })
+  })
+
+  describe('getStateGetters', () => {
+    it('should return an array of NodeDefinition objects', () => {
+      const getters = getStateGetters()
+      assert(Array.isArray(getters))
+      assert(getters.every((node) => typeof node === 'object'))
+    })
+
+    it('should skip states in the skipState array', () => {
+      const skippedState = ''
+      const getters = getStateGetters()
+      assert(!getters.some((node) => node.typeName === `engine/state/get${skippedState}`))
+    })
+
+    it('should generate a NodeDefinition for each state in StateDefinitions', () => {
+      const stateNames = Array.from(StateDefinitions.keys())
+      const getters = getStateGetters()
+      assert.strictEqual(getters.length, stateNames.length - skipState.length)
+      assert(
+        stateNames.every((stateName) => {
+          if (skipState.includes(stateName)) {
+            return true
+          }
+          return getters.some((node) => node.typeName === `engine/state/get${stateName}`)
+        })
+      )
+    })
+  })
+})

--- a/packages/engine/src/behave-graph/nodes/Profiles/Engine/helper/stateHelper.ts
+++ b/packages/engine/src/behave-graph/nodes/Profiles/Engine/helper/stateHelper.ts
@@ -26,9 +26,8 @@ Ethereal Engine. All Rights Reserved.
 import { NodeCategory, NodeDefinition, makeFlowNodeDefinition } from '@behave-graph/core'
 import { StateDefinition, StateDefinitions } from '@etherealengine/hyperflux'
 import { Engine } from '../../../../../ecs/classes/Engine'
+import { StatesToSkip } from '../../../../state/BehaveGraphState'
 import { EnginetoNodetype, NodetoEnginetype, getSocketType } from './commonHelper'
-
-const skipState = [''] // behave graph state is skipped since its a type of record we do want to skip it anyways
 
 export function generateStateNodeSchema(stateDefinition: StateDefinition<any>) {
   const nodeschema = {}
@@ -55,7 +54,7 @@ export function getStateSetters() {
   const setters: NodeDefinition[] = []
   const skipped: string[] = []
   for (const [stateName, stateDefinition] of StateDefinitions) {
-    if (skipState.includes(stateName)) {
+    if (StatesToSkip.includes(stateName)) {
       skipped.push(stateName)
       continue
     }
@@ -93,7 +92,7 @@ export function getStateGetters() {
   const getters: NodeDefinition[] = []
   const skipped: string[] = []
   for (const [stateName, stateDefinition] of StateDefinitions) {
-    if (skipState.includes(stateName)) {
+    if (StatesToSkip.includes(stateName)) {
       skipped.push(stateName)
       continue
     }

--- a/packages/engine/src/behave-graph/nodes/Profiles/Engine/helper/stateHelper.ts
+++ b/packages/engine/src/behave-graph/nodes/Profiles/Engine/helper/stateHelper.ts
@@ -54,8 +54,7 @@ export function generateStateNodeSchema(stateDefinition: StateDefinition<any>) {
 export function getStateSetters() {
   const setters: NodeDefinition[] = []
   const skipped: string[] = []
-  for (const stateDefinition of StateDefinitions) {
-    const stateName = stateDefinition.name
+  for (const [stateName, stateDefinition] of StateDefinitions) {
     if (skipState.includes(stateName)) {
       skipped.push(stateName)
       continue
@@ -93,8 +92,7 @@ export function getStateSetters() {
 export function getStateGetters() {
   const getters: NodeDefinition[] = []
   const skipped: string[] = []
-  for (const stateDefinition of StateDefinitions) {
-    const stateName = stateDefinition.name
+  for (const [stateName, stateDefinition] of StateDefinitions) {
     if (skipState.includes(stateName)) {
       skipped.push(stateName)
       continue

--- a/packages/engine/src/behave-graph/state/BehaveGraphState.ts
+++ b/packages/engine/src/behave-graph/state/BehaveGraphState.ts
@@ -34,3 +34,5 @@ export const BehaveGraphState = defineState({
     registries: { ECS: createECSRegistry() } as Record<BehaveGraphDomain, IRegistry>
   })
 })
+
+export const StatesToSkip = [BehaveGraphState.name] // behave graph state is skipped since its a type of record we do want to skip it anyways

--- a/packages/hyperflux/functions/StateFunctions.ts
+++ b/packages/hyperflux/functions/StateFunctions.ts
@@ -55,6 +55,7 @@ export type StateActionReceptor<S, A extends ActionShape<Action>> = [
 export type StateDefinition<S> = {
   name: string
   initial: SetInitialStateAction<S>
+  schema?: any
   receptors?: StateActionReceptor<S, any>[]
   receptorActionQueue?: ActionQueueDefinition
   onCreate?: (store: HyperStore, state: State<S>) => void

--- a/packages/hyperflux/functions/StateFunctions.ts
+++ b/packages/hyperflux/functions/StateFunctions.ts
@@ -60,11 +60,11 @@ export type StateDefinition<S> = {
   onCreate?: (store: HyperStore, state: State<S>) => void
 }
 
-export const StateDefinitions = new Set<StateDefinition<any>>()
+export const StateDefinitions = new Map<string, StateDefinition<any>>()
 
 export function defineState<S, StateExtras = unknown>(definition: StateDefinition<S> & StateExtras) {
-  if (StateDefinitions.has(definition)) throw new Error(`State ${definition} already defined`)
-  StateDefinitions.add(definition)
+  if (StateDefinitions.has(definition.name)) throw new Error(`State ${definition.name} already defined`)
+  StateDefinitions.set(definition.name, definition)
   return definition as StateDefinition<S> & { _TYPE: S } & StateExtras
 }
 

--- a/packages/hyperflux/functions/StateFunctions.ts
+++ b/packages/hyperflux/functions/StateFunctions.ts
@@ -60,11 +60,11 @@ export type StateDefinition<S> = {
   onCreate?: (store: HyperStore, state: State<S>) => void
 }
 
-const StateDefinitions = new Set<string>()
+export const StateDefinitions = new Set<StateDefinition<any>>()
 
 export function defineState<S, StateExtras = unknown>(definition: StateDefinition<S> & StateExtras) {
-  if (StateDefinitions.has(definition.name)) throw new Error(`State ${definition.name} already defined`)
-  StateDefinitions.add(definition.name)
+  if (StateDefinitions.has(definition)) throw new Error(`State ${definition} already defined`)
+  StateDefinitions.add(definition)
   return definition as StateDefinition<S> & { _TYPE: S } & StateExtras
 }
 


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 83cc724</samp>

Refactored the engine state management to use a new `StateDefinition` interface and a `StateDefinitions` set from `@etherealengine/hyperflux`. Moved the state definition functions from `StateFunctions.ts` to `stateHelper.ts` to reduce package coupling.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 83cc724</samp>

*  Refactored `stateHelper.ts` to use `StateDefinition` interface and `StateDefinitions` set for storing and accessing engine state definitions ([link](https://github.com/EtherealEngine/etherealengine/pull/9080/files?diff=unified&w=0#diff-66416719b2b8c8727e04952be54bd327dcc9caab1cfe2795fcd0458783dadee2L27-R27), [link](https://github.com/EtherealEngine/etherealengine/pull/9080/files?diff=unified&w=0#diff-66416719b2b8c8727e04952be54bd327dcc9caab1cfe2795fcd0458783dadee2L33-R40), [link](https://github.com/EtherealEngine/etherealengine/pull/9080/files?diff=unified&w=0#diff-66416719b2b8c8727e04952be54bd327dcc9caab1cfe2795fcd0458783dadee2L52-R63), [link](https://github.com/EtherealEngine/etherealengine/pull/9080/files?diff=unified&w=0#diff-66416719b2b8c8727e04952be54bd327dcc9caab1cfe2795fcd0458783dadee2R81), [link](https://github.com/EtherealEngine/etherealengine/pull/9080/files?diff=unified&w=0#diff-66416719b2b8c8727e04952be54bd327dcc9caab1cfe2795fcd0458783dadee2L89-R102), [link](https://github.com/EtherealEngine/etherealengine/pull/9080/files?diff=unified&w=0#diff-66416719b2b8c8727e04952be54bd327dcc9caab1cfe2795fcd0458783dadee2L113-R121))
* Moved `StateDefinitions` set and `defineState` function from `StateFunctions.ts` to `stateHelper.ts` to reduce coupling between packages ([link](https://github.com/EtherealEngine/etherealengine/pull/9080/files?diff=unified&w=0#diff-f2390dbc38e3279f400bec94dec8979e30baf141888a6e3e61c664f27d3729a5L63-R67))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 83cc724</samp>

> _`StateDefinitions`_
> _Moved to `stateHelper.ts`_
> _Less coupling now_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
