### PR TITLE
Changes to persist user if internal request and user was explicitly p…

### DIFF
--- a/packages/server-core/src/hooks/authenticate.ts
+++ b/packages/server-core/src/hooks/authenticate.ts
@@ -56,6 +56,10 @@ export default async (context: HookContext<Application>, next: NextFunction): Pr
   // No need to authenticate if it's an internal call.
   const isInternal = isProvider('server')(context)
   if (isInternal) {
+    if (context.params.user) {
+      asyncLocalStorage.enterWith({ user: context.params.user })
+    }
+
     return next()
   }
 


### PR DESCRIPTION
…assed.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6180382</samp>

Added user object to async local storage in `authenticate.ts` hook. This allows other modules to access the user information for logging or error handling purposes.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6180382</samp>

* Enable the use of the user object in async local storage by checking and entering it in the `authenticate` hook ([link](https://github.com/EtherealEngine/etherealengine/pull/9085/files?diff=unified&w=0#diff-4ab91f94883760f9590988693f87d9f525f4ddf9e33e7f28cd1638db7e4eb93eR59-R62))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6180382</samp>

> _`context` has user_
> _enter async storage now_
> _autumn of errors_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
