### PR TITLE
Fixed issue with pushing project to empty GitHub repo

### DIFF
--- a/packages/client-core/src/admin/components/Resources/ResourceDrawer.tsx
+++ b/packages/client-core/src/admin/components/Resources/ResourceDrawer.tsx
@@ -50,7 +50,7 @@ import { StaticResourceType } from '@etherealengine/engine/src/schemas/media/sta
 import { NotificationService } from '../../../common/services/NotificationService'
 import { AuthState } from '../../../user/services/AuthService'
 import DrawerView from '../../common/DrawerView'
-import { AdminResourceState, ResourceService } from '../../services/ResourceService'
+import { ResourceService } from '../../services/ResourceService'
 import styles from '../../styles/admin.module.scss'
 
 export enum ResourceDrawerMode {
@@ -87,7 +87,6 @@ const ResourceDrawerContent = ({ mode, selectedResource, onClose }: Props) => {
   const editMode = useHookstate(false)
   const state = useHookstate({ ...defaultState })
 
-  const adminResourceState = useHookstate(getMutableState(AdminResourceState))
   const user = useHookstate(getMutableState(AuthState).user).value
 
   const hasWriteAccess = user.scopes && user.scopes.find((item) => item.type === 'static_resource:write')

--- a/packages/client-core/src/common/services/ProjectService.ts
+++ b/packages/client-core/src/common/services/ProjectService.ts
@@ -203,10 +203,10 @@ export const ProjectService = {
         getMutableState(ProjectState).updateNeeded.set(true)
       }
 
-      API.instance.client.service(projectPath).on('patched', projectPatchedListener)
+      Engine.instance.api.service(projectPath).on('patched', projectPatchedListener)
 
       return () => {
-        API.instance.client.service(projectPath).off('patched', projectPatchedListener)
+        Engine.instance.api.service(projectPath).off('patched', projectPatchedListener)
       }
     }, [])
   },

--- a/packages/editor/src/components/projects/ProjectsPage.tsx
+++ b/packages/editor/src/components/projects/ProjectsPage.tsx
@@ -63,7 +63,8 @@ import {
 } from '@mui/material'
 
 import { userIsAdmin } from '@etherealengine/client-core/src/user/userHasAccess'
-import { ProjectType } from '@etherealengine/engine/src/schemas/projects/project.schema'
+import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
+import { projectPath, ProjectType } from '@etherealengine/engine/src/schemas/projects/project.schema'
 import { getProjects } from '../../functions/projectFunctions'
 import { Button, MediumButton } from '../inputs/Button'
 import { CreateProjectDialog } from './CreateProjectDialog'
@@ -192,6 +193,10 @@ const ProjectsPage = () => {
   const githubProvider = user.identityProviders.value?.find((ip) => ip.type === 'github')
 
   const { t } = useTranslation()
+
+  useEffect(() => {
+    Engine.instance.api.service(projectPath).on('patched', () => fetchInstalledProjects())
+  }, [])
 
   const fetchInstalledProjects = async () => {
     loading.set(true)

--- a/packages/server-core/src/projects/project/github-helper.ts
+++ b/packages/server-core/src/projects/project/github-helper.ts
@@ -330,8 +330,14 @@ const uploadToRepo = async (
     currentCommit = await getCurrentCommit(octo, org, repo, branch)
   } catch (err) {
     if (err.status === 409 && err.message === 'Git Repository is empty.') {
-      await octo.repos.delete({ owner: org, repo })
-      await octo.repos.createInOrg({ org, name: repo, auto_init: true })
+      await octo.repos.createOrUpdateFileContents({
+        owner: org,
+        repo,
+        path: 'README.md',
+        message: 'Initial commit',
+        content: 'ZHVtbXk=',
+        branch: 'main'
+      })
       currentCommit = await getCurrentCommit(octo, org, repo, branch)
     } else throw err
   }

--- a/packages/server-core/src/projects/project/project.ts
+++ b/packages/server-core/src/projects/project/project.ts
@@ -69,7 +69,8 @@ export default (app: Application): void => {
       let targetIds: string[] = []
       const projectOwners = (await app.service(projectPermissionPath).find({
         query: {
-          projectId: data.id
+          projectId: data.id,
+          type: 'owner'
         },
         paginate: false
       })) as any as ProjectPermissionType[]


### PR DESCRIPTION
## Summary
Backend code was trying to delete an empty repo and then crete it with auto_init set to true. This needs the `admin` GH scope, though, which is not requested. Changed this to creating a dummy readme file instead.

Fixed bug in edit ProjectsPage that was not refreshing the installed projects on project patch. This was causing projects that were patched to have a GitHub repo link to not have their options updated to reflect that.

copilot:summary

## References
closes #9081 #9082 

## Explanation
copilot:walkthrough
copilot:poem

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
