### PR TITLE
behave-graph-reactivity-regression-fix

### DIFF
--- a/packages/editor/src/components/graph/ee-flow/components/Flow.tsx
+++ b/packages/editor/src/components/graph/ee-flow/components/Flow.tsx
@@ -79,7 +79,7 @@ export const Flow: React.FC<FlowProps> = ({ initialGraph: graph, examples, regis
 
   const debouncedOnChangeGraph = _.debounce(() => {
     onChangeGraph(graphJson ?? graph)
-  }, 2000)
+  }, 1000)
 
   useEffect(() => {
     debouncedOnChangeGraph()

--- a/packages/editor/src/components/graph/ee-flow/components/Node.tsx
+++ b/packages/editor/src/components/graph/ee-flow/components/Node.tsx
@@ -94,7 +94,7 @@ export const Node: React.FC<NodeProps> = ({ id, data, spec, selected, specGenera
             <InputSocket
               {...input}
               specGenerator={specGenerator}
-              value={data[input.name] ?? input.defaultValue}
+              value={data.values?.[input.name] ?? input.defaultValue}
               onChange={handleChange}
               connected={isHandleConnected(edges, id, input.name, 'target')}
             />

--- a/packages/editor/src/components/graph/ee-flow/hooks/useChangeNodeData.ts
+++ b/packages/editor/src/components/graph/ee-flow/hooks/useChangeNodeData.ts
@@ -38,7 +38,10 @@ export const useChangeNodeData = (id: string) => {
             ...n,
             data: {
               ...n.data,
-              [key]: value
+              values: {
+                ...n.data.values,
+                [key]: value
+              }
             }
           }
         })

--- a/packages/editor/src/components/graph/ee-flow/transformers/behaveToFlow.ts
+++ b/packages/editor/src/components/graph/ee-flow/transformers/behaveToFlow.ts
@@ -23,10 +23,9 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
+import { GraphJSON, NodeConfigurationJSON } from '@behave-graph/core'
 import { Edge, Node } from 'reactflow'
 import { v4 as uuidv4 } from 'uuid'
-
-import { GraphJSON } from '@behave-graph/core'
 
 export const behaveToFlow = (graph: GraphJSON): [Node[], Edge[]] => {
   const nodes: Node[] = []
@@ -40,10 +39,19 @@ export const behaveToFlow = (graph: GraphJSON): [Node[], Edge[]] => {
         x: nodeJSON.metadata?.positionX ? Number(nodeJSON.metadata?.positionX) : 0,
         y: nodeJSON.metadata?.positionY ? Number(nodeJSON.metadata?.positionY) : 0
       },
-      data: {} as { [key: string]: any }
+      data: {
+        configuration: {} as NodeConfigurationJSON,
+        values: {} as { [key: string]: any }
+      }
     }
 
     nodes.push(node)
+
+    if (nodeJSON.configuration) {
+      for (const [inputKey, input] of Object.entries(nodeJSON.configuration)) {
+        node.data.configuration[inputKey] = input
+      }
+    }
 
     if (nodeJSON.parameters) {
       for (const [inputKey, input] of Object.entries(nodeJSON.parameters)) {
@@ -57,7 +65,7 @@ export const behaveToFlow = (graph: GraphJSON): [Node[], Edge[]] => {
           })
         }
         if ('value' in input) {
-          node.data[inputKey] = input.value
+          node.data.values[inputKey] = input.value
         }
       }
     }

--- a/packages/editor/src/components/graph/ee-flow/transformers/flowToBehave.ts
+++ b/packages/editor/src/components/graph/ee-flow/transformers/flowToBehave.ts
@@ -38,7 +38,6 @@ export const flowToBehave = (nodes: Node[], edges: Edge[], specGenerator: NodeSp
 
     const nodeSpec = specGenerator.getNodeSpec(node.type, node.data.configuration)
     if (nodeSpec === undefined) return
-
     const behaveNode: NodeJSON = {
       id: node.id,
       type: node.type,
@@ -47,22 +46,19 @@ export const flowToBehave = (nodes: Node[], edges: Edge[], specGenerator: NodeSp
         positionY: String(node.position.y)
       }
     }
-    if (node.data.configuration) {
-      Object.entries(node.data.configuration).forEach(([key, value]) => {
-        if (behaveNode.configuration === undefined) {
-          behaveNode.configuration = {}
-        }
-        behaveNode.configuration[key] = value as ValueJSON
-      })
-    }
-    if (node.data.values) {
-      Object.entries(node.data.values).forEach(([key, value]) => {
-        if (behaveNode.parameters === undefined) {
-          behaveNode.parameters = {}
-        }
-        behaveNode.parameters[key] = { value: value as string }
-      })
-    }
+    Object.entries(node.data.configuration).forEach(([key, value]) => {
+      if (behaveNode.configuration === undefined) {
+        behaveNode.configuration = {}
+      }
+      behaveNode.configuration[key] = value as ValueJSON
+    })
+
+    Object.entries(node.data.values).forEach(([key, value]) => {
+      if (behaveNode.parameters === undefined) {
+        behaveNode.parameters = {}
+      }
+      behaveNode.parameters[key] = { value: value as string }
+    })
 
     edges
       .filter((edge) => edge.target === node.id)


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0fdfa21</samp>

This pull request updates the flow editor to use the new `NodeConfigurationJSON` type from `@behave-graph/core`, which improves the consistency and clarity of the node data structure. It also refactors some functions and reduces the debounce time for the graph state update. The main files affected are `behaveToFlow.ts`, `flowToBehave.ts`, `Flow.tsx`, `Node.tsx`, and `useChangeNodeData.ts`.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0fdfa21</samp>

*  Reduced the debounce time for updating the graph state in the flow editor from 2000 ms to 1000 ms to improve responsiveness and performance ([link](https://github.com/EtherealEngine/etherealengine/pull/9089/files?diff=unified&w=0#diff-b588b174a2e443f8ef2ba038e179e41b29f56a3500ea888c8dd8190abcaf8fbbL82-R82))
*  Aligned the data structure for the node configuration and values with the new `NodeConfigurationJSON` type, which separates them into two properties: `data.configuration` and `data.values` ([link](https://github.com/EtherealEngine/etherealengine/pull/9089/files?diff=unified&w=0#diff-8908045e00bb9fde41c03d5807af7d95c4297ee5c1c335c3543d082f5ec545daL97-R97), [link](https://github.com/EtherealEngine/etherealengine/pull/9089/files?diff=unified&w=0#diff-59c0a36bbe52efbdbd6c8dba6d2296ad56c91bf1eb69c8ebbcd89d2f6c2447adL41-R44), [link](https://github.com/EtherealEngine/etherealengine/pull/9089/files?diff=unified&w=0#diff-3c910343ac914ebd40d7ebafd8f17a48960a35351f32039556389bb525e1b295L26-R29), [link](https://github.com/EtherealEngine/etherealengine/pull/9089/files?diff=unified&w=0#diff-3c910343ac914ebd40d7ebafd8f17a48960a35351f32039556389bb525e1b295L43-R55), [link](https://github.com/EtherealEngine/etherealengine/pull/9089/files?diff=unified&w=0#diff-3c910343ac914ebd40d7ebafd8f17a48960a35351f32039556389bb525e1b295L60-R68), [link](https://github.com/EtherealEngine/etherealengine/pull/9089/files?diff=unified&w=0#diff-8649c59b4d540bfced53180f503cf01521d5100dca77bac08873816b02554569L41), [link](https://github.com/EtherealEngine/etherealengine/pull/9089/files?diff=unified&w=0#diff-8649c59b4d540bfced53180f503cf01521d5100dca77bac08873816b02554569L50-R62))
*  Simplified the `flowToBehave` function by removing unnecessary `if` statements and iterating over the node data properties ([link](https://github.com/EtherealEngine/etherealengine/pull/9089/files?diff=unified&w=0#diff-8649c59b4d540bfced53180f503cf01521d5100dca77bac08873816b02554569L41), [link](https://github.com/EtherealEngine/etherealengine/pull/9089/files?diff=unified&w=0#diff-8649c59b4d540bfced53180f503cf01521d5100dca77bac08873816b02554569L50-R62))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0fdfa21</samp>

> _Sing, O Muse, of the swift and skillful changes_
> _That the wise and valiant developers wrought_
> _On the flow editor, the splendid tool of graphs,_
> _That shapes the logic of the noble behave engine._

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
