### PR TITLE
add export for material plugin parameter and id

### DIFF
--- a/packages/engine/src/assets/exporters/gltf/extensions/EEMaterialExporterExtension.ts
+++ b/packages/engine/src/assets/exporters/gltf/extensions/EEMaterialExporterExtension.ts
@@ -109,6 +109,7 @@ export default class EEMaterialExporterExtension extends ExporterExtension {
       name: material.name,
       prototype: materialEntry?.prototype ?? material.userData.type ?? material.type,
       plugins: materialEntry?.plugins ?? material.userData.plugins ?? [],
+      pluginstest: getState(MaterialLibraryState).plugins[materialEntry?.plugins[0]].plugin,
       args: result
     }
     this.writer.extensionsUsed[this.name] = true


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6af61cf</samp>

Added a new property `pluginstest` to the glTF extension for Ethereal Engine materials. This property is used to test the export of custom material plugins as glTF extensions.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6af61cf</samp>

*  Add a new property `pluginstest` to the exported material extension ([link](https://github.com/EtherealEngine/etherealengine/pull/9093/files?diff=unified&w=0#diff-afb00943433039343d67ba9fe303ab3ef50fd1a797763afd3b2bb020498a9639R112))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6af61cf</samp>

> _`material` has_
> _`pluginstest` extension_
> _cutting edge in spring_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
