### PR TITLE
Ground Plane Visibility

### DIFF
--- a/packages/client-core/i18n/en/editor.json
+++ b/packages/client-core/i18n/en/editor.json
@@ -295,8 +295,8 @@
       "name": "Ground Plane",
       "description": "A flat ground plane that extends into the distance.",
       "lbl-color": "Color",
-      "lbl-receiveShadow": "Receive Shadow",
-      "lbl-generateNavmesh": "Generate Navmesh"
+      "lbl-visible": "Visible",
+      "info-visible": "Toggle the visibility of the ground plane. Setting to false will still allow shadows to be received, rather than setting the entity visibility."
     },
     "loopAnimation": {
       "title": "Loop Animation",

--- a/packages/editor/src/components/properties/GroundPlaneNodeEditor.tsx
+++ b/packages/editor/src/components/properties/GroundPlaneNodeEditor.tsx
@@ -31,6 +31,7 @@ import { GroundPlaneComponent } from '@etherealengine/engine/src/scene/component
 
 import SquareIcon from '@mui/icons-material/Square'
 
+import BooleanInput from '../inputs/BooleanInput'
 import ColorInput from '../inputs/ColorInput'
 import InputGroup from '../inputs/InputGroup'
 import NodeEditor from './NodeEditor'
@@ -53,6 +54,16 @@ export const GroundPlaneNodeEditor: EditorComponentType = (props) => {
           value={groundPlaneComponent.color.value}
           onChange={updateProperty(GroundPlaneComponent, 'color')}
           onRelease={commitProperty(GroundPlaneComponent, 'color')}
+        />
+      </InputGroup>
+      <InputGroup
+        name="Visible"
+        label={t('editor:properties.groundPlane.lbl-visible')}
+        info={t('editor:properties.groundPlane.info-visible')}
+      >
+        <BooleanInput
+          value={groundPlaneComponent.visible.value}
+          onChange={commitProperty(GroundPlaneComponent, 'visible')}
         />
       </InputGroup>
       <ShadowProperties entity={props.entity} />


### PR DESCRIPTION
## Summary

Somehow the `visible` input on the ground plane editor was removed. This is a nice feature, especially for AR to allow shadows to be cast on the ground without the ground being visible.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d6de7c3</samp>

Added a UI option to toggle the visibility of the ground plane component in the editor. Updated the localization file to reflect the new and removed properties of the component.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d6de7c3</samp>

*  Added `visible` property to ground plane component and editor ([link](https://github.com/EtherealEngine/etherealengine/pull/9096/files?diff=unified&w=0#diff-1090d26e3ba03bd91f8a7965975be8e551268e83a819edb17c58d78b4ef51ffeR34), [link](https://github.com/EtherealEngine/etherealengine/pull/9096/files?diff=unified&w=0#diff-1090d26e3ba03bd91f8a7965975be8e551268e83a819edb17c58d78b4ef51ffeR59-R68), [link](https://github.com/EtherealEngine/etherealengine/pull/9096/files?diff=unified&w=0#diff-827e8c4336f8ab1c715c553a8028695e3cfe0fa1b3af6432139850e34eb078fdL298-R299))
* Removed `receiveShadow` and `generateNavmesh` properties from ground plane component and editor ([link](https://github.com/EtherealEngine/etherealengine/pull/9096/files?diff=unified&w=0#diff-827e8c4336f8ab1c715c553a8028695e3cfe0fa1b3af6432139850e34eb078fdL298-R299))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d6de7c3</samp>

> _The ground plane is hidden from our sight_
> _We edit its labels and info with might_
> _We don't need shadows or navmeshes here_
> _We are the masters of the `GroundPlaneComponent`_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
