### PR TITLE
set userReady to false upon new avatar load

### DIFF
--- a/packages/engine/src/avatar/functions/avatarFunctions.ts
+++ b/packages/engine/src/avatar/functions/avatarFunctions.ts
@@ -125,6 +125,8 @@ export const loadAvatarForUser = async (
     }
   }
 
+  if (entity === Engine.instance.localClientEntity) getMutableState(EngineState).userReady.set(false)
+
   setComponent(entity, AvatarPendingComponent, { url: avatarURL })
   const parent = (await loadAvatarModelAsset(avatarURL)) as VRM
 


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 758103a</samp>

Fix a bug that prevented user interaction after avatar switching. Update `userReady` state in `avatarFunctions.ts` when loading the local avatar.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 758103a</samp>

* Fix a bug that caused the user to be stuck in the loading screen when switching avatars by setting the userReady state to false when loading the avatar for the local client entity ([link](https://github.com/EtherealEngine/etherealengine/pull/9097/files?diff=unified&w=0#diff-ae0c696fdcb759ddeda5f76ab4b6722ad7279c8c65438f5008fd6fadfb9535a9R128-R129))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 758103a</samp>

> _`userReady` false_
> _Loading avatar, fix bug_
> _Winter of waiting_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
