### PR TITLE
Fixed issue with first user not being made admin

### DIFF
--- a/packages/server-core/src/user/identity-provider/identity-provider.hooks.ts
+++ b/packages/server-core/src/user/identity-provider/identity-provider.hooks.ts
@@ -130,7 +130,7 @@ async function addIdentityProviderType(context: HookContext<IdentityProviderServ
     context.params!.provider &&
     !['password', 'email', 'sms'].includes((context!.data as IdentityProviderData).type)
   ) {
-    ;(context.data as IdentityProviderData).type = 'guest'
+    ;(context.data as IdentityProviderData).type = 'guest' //Non-password/magiclink create requests must always be for guests
   }
 
   const adminScopes = await context.app.service(scopePath).find({
@@ -139,7 +139,7 @@ async function addIdentityProviderType(context: HookContext<IdentityProviderServ
     }
   })
 
-  if (adminScopes.total === 0 && isDev && (context.data as IdentityProviderData).type !== 'guest') {
+  if (adminScopes.total === 0 && (isDev || (context.data as IdentityProviderData).type !== 'guest')) {
     ;(context.data as IdentityProviderData).type = 'admin'
   }
 }


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b137218</samp>

Improved documentation and development mode support for identity providers in `server-core`. Added a comment to explain the guest-only logic and changed the admin type assignment to work with any identity provider type.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b137218</samp>

*  Prevent unauthorized account creation with non-password/magiclink identity providers by requiring guest type for those requests ([link](https://github.com/EtherealEngine/etherealengine/pull/9120/files?diff=unified&w=0#diff-01bc270bd43dde684382c7a71b5497010092c79bc6520db1d7ef7b0702f5c3bfL133-R133))
*  Allow developers to create admin accounts with any identity provider type in development mode by checking both mode and type conditions ([link](https://github.com/EtherealEngine/etherealengine/pull/9120/files?diff=unified&w=0#diff-01bc270bd43dde684382c7a71b5497010092c79bc6520db1d7ef7b0702f5c3bfL142-R142))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b137218</samp>

> _`guest-only` rule_
> _clarified for identities_
> _admin type varies_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
