### PR TITLE
Enabled use of client pagination in FeathersHook useFind

### DIFF
--- a/packages/engine/src/common/functions/FeathersHooks.tsx
+++ b/packages/engine/src/common/functions/FeathersHooks.tsx
@@ -168,13 +168,25 @@ export type PaginationQuery = Partial<PaginationProps> & Query
 export const useFind = <S extends keyof ServiceTypes>(serviceName: S, params: Params<PaginationQuery> = {}) => {
   const paginate = usePaginate(params.query)
 
-  const response = useService(serviceName, 'find', {
-    ...params,
-    query: {
-      ...params.query,
-      ...paginate.query
+  let requestParams
+  if (params.query?.paginate === false || params.query?.$paginate === false) {
+    requestParams = {
+      ...params,
+      query: {
+        ...params.query
+      }
     }
-  })
+  } else {
+    requestParams = {
+      ...params,
+      query: {
+        ...params.query,
+        ...paginate.query
+      }
+    }
+  }
+
+  const response = useService(serviceName, 'find', requestParams)
 
   const data = response?.data
     ? Array.isArray(response.data)


### PR DESCRIPTION
## Summary

Since we can enable `paginate:false` for certain services using `enableClientPagination` hook on server end. But there was an issue in FeathersHook on client as it was appending those pagination limit, step, etc variables which was overriding the request to not handle `paginate: false`.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ebdd973</samp>

Modified `useFind` hook to support non-paginated queries. The hook now checks the query parameters for `paginate` or `$paginate` flags and passes them to the `useService` hook accordingly.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ebdd973</samp>

*  Modify `useFind` hook to handle non-paginated queries ([link](https://github.com/EtherealEngine/etherealengine/pull/9128/files?diff=unified&w=0#diff-da1ecdb323d21a3091d85b185650c122616fbbe5f470baa3096ef8dec0f1540fL171-R190))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ebdd973</samp>

> _`useFind` respects_
> _`paginate` query option_
> _no more wasted calls_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
