### PR TITLE
Fix s3 types (that are causing CI/CD errors)

### DIFF
--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -28,6 +28,7 @@ import {
   CreateFunctionCommand,
   CreateInvalidationCommand,
   DescribeFunctionCommand,
+  FunctionRuntime,
   FunctionSummary,
   GetDistributionCommand,
   ListFunctionsCommand,
@@ -46,6 +47,7 @@ import {
   GetObjectCommand,
   HeadObjectCommand,
   ListObjectsV2Command,
+  ObjectCannedACL,
   ObjectIdentifier,
   PutObjectCommand,
   S3Client,
@@ -173,7 +175,7 @@ export class S3Provider implements StorageProviderInterface {
   private blob: typeof S3BlobStore = new S3BlobStore({
     client: this.provider,
     bucket: config.aws.s3.staticResourceBucket,
-    ACL: 'public-read'
+    ACL: ObjectCannedACL.public_read
   })
 
   private cloudfront: CloudFrontClient = new CloudFrontClient({
@@ -301,14 +303,14 @@ export class S3Provider implements StorageProviderInterface {
 
     const args = params.isDirectory
       ? {
-          ACL: 'public-read',
+          ACL: ObjectCannedACL.public_read,
           Body: Buffer.alloc(0),
           Bucket: this.bucket,
           ContentType: 'application/x-empty',
           Key: key + '/'
         }
       : {
-          ACL: 'public-read',
+          ACL: ObjectCannedACL.public_read,
           Body: data.Body,
           Bucket: this.bucket,
           ContentType: data.ContentType,
@@ -337,7 +339,7 @@ export class S3Provider implements StorageProviderInterface {
       return response
     } else if (data.Body?.length > MULTIPART_CUTOFF_SIZE) {
       const multiPartStartArgs = {
-        ACL: 'public-read',
+        ACL: ObjectCannedACL.public_read,
         Bucket: this.bucket,
         Key: key,
         ContentType: data.ContentType
@@ -499,7 +501,7 @@ export class S3Provider implements StorageProviderInterface {
       FunctionCode: new TextEncoder().encode(code),
       FunctionConfig: {
         Comment: 'Function to handle routing of Ethereal Engine client',
-        Runtime: 'cloudfront-js-1.0'
+        Runtime: FunctionRuntime.cloudfront_js_1_0
       }
     }
     const command = new CreateFunctionCommand(params)
@@ -568,7 +570,7 @@ export class S3Provider implements StorageProviderInterface {
       FunctionCode: new TextEncoder().encode(code),
       FunctionConfig: {
         Comment: 'Function to handle routing of Ethereal Engine client',
-        Runtime: 'cloudfront-js-1.0'
+        Runtime: FunctionRuntime.cloudfront_js_1_0
       }
     }
     const command = new UpdateFunctionCommand(params)
@@ -709,7 +711,7 @@ export class S3Provider implements StorageProviderInterface {
     const result = await Promise.all([
       ...listResponse.Contents.map(async (file) => {
         const input = {
-          ACL: 'public-read',
+          ACL: ObjectCannedACL.public_read,
           Bucket: this.bucket,
           CopySource: `/${this.bucket}/${file.Key}`,
           Key: path.join(newFilePath, file.Key.replace(oldFilePath, ''))


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9c345e</samp>

Refactor S3 and CloudFront code in `s3.storage.ts` using AWS SDK enums.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c9c345e</samp>

*  Import enums from AWS SDK for runtime and ACL values ([link](https://github.com/EtherealEngine/etherealengine/pull/9130/files?diff=unified&w=0#diff-8355cc6812ded09068b1c27fb6c745d20017ce5fe28ee5235d676e5399fea10eR31), [link](https://github.com/EtherealEngine/etherealengine/pull/9130/files?diff=unified&w=0#diff-8355cc6812ded09068b1c27fb6c745d20017ce5fe28ee5235d676e5399fea10eR50))
*  Use `ObjectCannedACL.public_read` instead of `'public-read'` for S3 object ACLs in `s3.storage.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9130/files?diff=unified&w=0#diff-8355cc6812ded09068b1c27fb6c745d20017ce5fe28ee5235d676e5399fea10eL176-R178), [link](https://github.com/EtherealEngine/etherealengine/pull/9130/files?diff=unified&w=0#diff-8355cc6812ded09068b1c27fb6c745d20017ce5fe28ee5235d676e5399fea10eL304-R306), [link](https://github.com/EtherealEngine/etherealengine/pull/9130/files?diff=unified&w=0#diff-8355cc6812ded09068b1c27fb6c745d20017ce5fe28ee5235d676e5399fea10eL311-R313), [link](https://github.com/EtherealEngine/etherealengine/pull/9130/files?diff=unified&w=0#diff-8355cc6812ded09068b1c27fb6c745d20017ce5fe28ee5235d676e5399fea10eL340-R342))
*  Use `FunctionRuntime.cloudfront_js_1_0` instead of `'cloudfront-js-1.0'` for CloudFront function runtime in `s3.storage.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9130/files?diff=unified&w=0#diff-8355cc6812ded09068b1c27fb6c745d20017ce5fe28ee5235d676e5399fea10eL502-R504), [link](https://github.com/EtherealEngine/etherealengine/pull/9130/files?diff=unified&w=0#diff-8355cc6812ded09068b1c27fb6c745d20017ce5fe28ee5235d676e5399fea10eL571-R573), [link](https://github.com/EtherealEngine/etherealengine/pull/9130/files?diff=unified&w=0#diff-8355cc6812ded09068b1c27fb6c745d20017ce5fe28ee5235d676e5399fea10eL712-R714))
*  Copy S3 object to another location using the same ACL value ([link](https://github.com/EtherealEngine/etherealengine/pull/9130/files?diff=unified&w=0#diff-8355cc6812ded09068b1c27fb6c745d20017ce5fe28ee5235d676e5399fea10eL712-R714))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c9c345e</samp>

> _No more strings of doom, we use the enum_
> _We refactor and improve, we make the code assume_
> _The power of the SDK, we unleash the beast_
> _We upload, copy, create, we are the S3 priests_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
