### PR TITLE
Immersive AR Fixes

### DIFF
--- a/packages/client-core/src/systems/WidgetUISystem.ts
+++ b/packages/client-core/src/systems/WidgetUISystem.ts
@@ -213,6 +213,7 @@ const execute = () => {
 
 const reactor = () => {
   const xrState = useHookstate(getMutableState(XRState))
+
   useEffect(() => {
     if (!xrState.sessionActive.value) {
       WidgetAppService.closeWidgets()
@@ -220,6 +221,7 @@ const reactor = () => {
       dispatchAction(WidgetAppActions.showWidgetMenu({ shown: false, handedness: widgetState.handedness }))
     }
   }, [xrState.sessionActive])
+
   useEffect(() => {
     createWidgetMenus()
     return () => {
@@ -227,6 +229,7 @@ const reactor = () => {
       removeEntity(widgetMenuUI.entity)
     }
   }, [])
+
   return null
 }
 

--- a/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
+++ b/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
@@ -393,7 +393,7 @@ const reactor = () => {
   }, [isCameraAttachedToAvatar, session])
 
   useEffect(() => {
-    setTrackingSpace()
+    if (userReady.value) setTrackingSpace()
   }, [userReady])
 
   return null

--- a/packages/engine/src/input/systems/ClientInputSystem.ts
+++ b/packages/engine/src/input/systems/ClientInputSystem.ts
@@ -376,12 +376,12 @@ export function updateGamepadInput(eid: Entity) {
   const buttons = inputSource.buttons as ButtonStateMap
 
   // log buttons
-  if (source.gamepad) {
-    for (let i = 0; i < source.gamepad.buttons.length; i++) {
-      const button = source.gamepad.buttons[i]
-      if (button.pressed) console.log('button ' + i + ' pressed: ' + button.pressed)
-    }
-  }
+  // if (source.gamepad) {
+  //   for (let i = 0; i < source.gamepad.buttons.length; i++) {
+  //     const button = source.gamepad.buttons[i]
+  //     if (button.pressed) console.log('button ' + i + ' pressed: ' + button.pressed)
+  //   }
+  // }
 
   if (!source.gamepad) return
   const gamepadButtons = source.gamepad.buttons

--- a/packages/engine/src/xrui/WidgetAppService.ts
+++ b/packages/engine/src/xrui/WidgetAppService.ts
@@ -85,6 +85,8 @@ export const WidgetAppService = {
   }
 }
 
+/** @todo convert to functions */
+
 export class WidgetAppActions {
   static showWidgetMenu = defineAction({
     type: 'xre.xrui.WidgetAppActions.SHOW_WIDGET_MENU' as const,


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b91e35</samp>

This pull request improves the immersive AR mode and the widget UI system, refactors some code modules to use better types and hooks, and fixes some import and code style issues. It also adds a shader plugin for scene placement, a condition for avatar animation, and a comment for future refactoring. The main files affected are `createAnchorWidget.tsx`, `WidgetUISystem.ts`, `OnBeforeCompilePlugin.ts`, `XRAnchorSystem.ts`, `XRScenePlacementShaderSystem.tsx`, `AvatarAnimationSystem.ts`, `ClientInputSystem.ts`, and `WidgetAppService.ts`.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5b91e35</samp>

*  Update the logic and functionality of the `createAnchorWidget` function to handle the immersive AR controller placement, scene rotation and scaling, and scene scale auto mode ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-0212d90229033b0b2ef9c3f916051ba7685e1345e1053289d37793835bd0f99dL51-R100),[link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-0212d90229033b0b2ef9c3f916051ba7685e1345e1053289d37793835bd0f99dL77-R122))
*  Update the import statements in `WidgetUISystem.ts` and `createAnchorWidget.tsx` to reflect the file name and location changes ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-0212d90229033b0b2ef9c3f916051ba7685e1345e1053289d37793835bd0f99dL26-R45),[link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-8857d34b990b36947793b517ab000b55de5305fc4cab4f138ccc1eaa33996b5aR216))
*  Remove some unused variables and comments from the `createAnchorWidget` function ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-0212d90229033b0b2ef9c3f916051ba7685e1345e1053289d37793835bd0f99dL40-R56))
*  Add a condition to the `useEffect` hook in the `reactor` function in `AvatarAnimationSystem.ts` to only call the `setTrackingSpace` function if the `userReady` state is true ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-e0a011e84a40926910be0273bb512c563d8c83d4becd2e1ac35f7075e5a33e20L396-R396))
*  Remove the type declaration and the unnecessary casting for the `CustomMaterial` type in `OnBeforeCompilePlugin.ts`, and add a module declaration to extend the `Material` type with the plugin-related properties ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-4f875af1ce2d1ac5b3dcfa7be7ff39e5328216882f8cf800ad22a882835dbf64L59-L66),[link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-4f875af1ce2d1ac5b3dcfa7be7ff39e5328216882f8cf800ad22a882835dbf64L73-R74),[link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-4f875af1ce2d1ac5b3dcfa7be7ff39e5328216882f8cf800ad22a882835dbf64L107-R97),[link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-4f875af1ce2d1ac5b3dcfa7be7ff39e5328216882f8cf800ad22a882835dbf64L128-R118),[link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-4f875af1ce2d1ac5b3dcfa7be7ff39e5328216882f8cf800ad22a882835dbf64L185-R177),[link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-4f875af1ce2d1ac5b3dcfa7be7ff39e5328216882f8cf800ad22a882835dbf64L194-R184),[link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-4f875af1ce2d1ac5b3dcfa7be7ff39e5328216882f8cf800ad22a882835dbf64R196-R204))
*  Comment out the code that logs the gamepad button inputs in the `updateGamepadInput` function in `ClientInputSystem.ts`, as it is not needed for production and may cause performance issues ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-c571e0581e50f0f02775dfb1f8f87a957bba1c070183faf431075bc3dd45dbecL379-R384))
*  Update the import statements in `XRAnchorSystem.ts` and `XRScenePlacementShaderSystem.tsx` to use the `useHookstate` hook and the `useQuery` function from the `hyperflux` module, and add the `InputSourceComponent` and the `OnBeforeCompilePlugin` modules as needed ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-7d6e18b3544f2b765abb7e2b1f79f37db7904302e41ff7dc0273931d8e640ac2L41-R43),[link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-429583ae13e9b950626db40f6002d78730e66019db30fb6b914bc1a728b1f6c9L31-R34),[link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-7d6e18b3544f2b765abb7e2b1f79f37db7904302e41ff7dc0273931d8e640ac2L54-R56))
*  Add a return statement to the `updateHitTest` function in `XRAnchorSystem.ts` to exit early if the `hitTest.source.value` is falsy ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-7d6e18b3544f2b765abb7e2b1f79f37db7904302e41ff7dc0273931d8e640ac2R62))
*  Simplify the code and remove some unnecessary variables and checks from the `updateHitTest` function in `XRAnchorSystem.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-7d6e18b3544f2b765abb7e2b1f79f37db7904302e41ff7dc0273931d8e640ac2L70-R88))
*  Use the `useHookstate` hook instead of the `useState` hook for accessing the `xrState.session` and `xrState.scenePlacementMode` states in the `reactor` function in `XRAnchorSystem.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-7d6e18b3544f2b765abb7e2b1f79f37db7904302e41ff7dc0273931d8e640ac2L283-R291))
*  Add a new `useEffect` hook to the `reactor` function in `XRAnchorSystem.ts` to handle the immersive AR controller placement logic, by setting the `XRHitTestComponent` on the `scenePlacementEntity` with the appropriate `space` and `entityTypes` properties ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-7d6e18b3544f2b765abb7e2b1f79f37db7904302e41ff7dc0273931d8e640ac2R366-R393))
*  Add a new constant `ShaderID` to store the unique identifier for the shader plugin that modifies the opacity of the scene objects during the scene placement mode, and a new constant `XRScenePlacementShaderPlugin` to store the plugin object that defines the `compile` function and the `scenePlacementOpacity` uniform in `XRScenePlacementShaderSystem.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-429583ae13e9b950626db40f6002d78730e66019db30fb6b914bc1a728b1f6c9R47-R64))
*  Use the `addOBCPlugin` function to add the `XRScenePlacementShaderPlugin` to the material's `plugins` array, instead of directly modifying the material's `transparent` and `opacity` properties, in the `addShaderToObject` function in `XRScenePlacementShaderSystem.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-429583ae13e9b950626db40f6002d78730e66019db30fb6b914bc1a728b1f6c9L50-R73))
*  Set the `scenePlacementOpacity` uniform value to 1, and force the material to update and use a custom program cache key, instead of restoring the material's `transparent` and `opacity` properties, in the `removeShaderFromObject` function in `XRScenePlacementShaderSystem.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-429583ae13e9b950626db40f6002d78730e66019db30fb6b914bc1a728b1f6c9L65-R87))
*  Add the `SceneObjectComponent` to the list of components that are used for querying the scene objects that need to have the shader plugin applied or removed, as the `VisibleComponent` alone is not sufficient, in the `reactor` function in `XRScenePlacementShaderSystem.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-429583ae13e9b950626db40f6002d78730e66019db30fb6b914bc1a728b1f6c9L98-R122))
*  Add a comment to the `WidgetAppService.ts` module, to indicate that the module should be converted to use functions instead of classes, as part of the code refactoring and improvement process ([link](https://github.com/EtherealEngine/etherealengine/pull/9139/files?diff=unified&w=0#diff-014292787843514ffba064b94a019a573388f19585663762a1da24f44bdc4b77R88-R89))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5b91e35</samp>

> _`useEffect` checks_
> _refactoring and fixing_
> _autumn of code_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
