### PR TITLE
add default arguement to add media node func

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@types/cli": "0.11.21",
     "@types/mocha": "10.0.1",
     "@types/primus": "^7.3.6",
+    "@types/three": "0.157.0",
     "@typescript-eslint/eslint-plugin": "5.56.0",
     "@typescript-eslint/parser": "5.56.0",
     "concurrently": "7.6.0",

--- a/packages/editor/src/components/properties/ParticleSystemNodeEditor.tsx
+++ b/packages/editor/src/components/properties/ParticleSystemNodeEditor.tsx
@@ -251,7 +251,7 @@ const ParticleSystemNodeEditor: EditorComponentType = (props) => {
                 value={burst.probability.value}
                 onChange={onSetState(burst.probability)}
               />
-              <Button onClick={onRemoveBurst(burst)}>Remove Burst</Button>
+              <Button onClick={onRemoveBurst(burst as any)}>Remove Burst</Button>
             </div>
           )
         }}
@@ -329,7 +329,7 @@ const ParticleSystemNodeEditor: EditorComponentType = (props) => {
             <ValueGenerator
               value={particleSystem.systemParameters.rendererEmitterSettings.startLength as ValueGeneratorJSON}
               scope={
-                particleSystemState.systemParameters.rendererEmitterSettings
+                (particleSystemState.systemParameters.rendererEmitterSettings as any)
                   .startLength as unknown as State<ValueGeneratorJSON>
               }
               onChange={onSetState}

--- a/packages/editor/src/functions/addMediaNode.ts
+++ b/packages/editor/src/functions/addMediaNode.ts
@@ -46,7 +46,7 @@ import { EditorControlFunctions } from './EditorControlFunctions'
  */
 export async function addMediaNode(
   url: string,
-  parent: Entity = getState(SceneState).sceneEntity,
+  parent: Entity | null = getState(SceneState).sceneEntity,
   before: Entity | null = null,
   extraComponentJson: ComponentJson[] = []
 ) {

--- a/packages/editor/src/functions/addMediaNode.ts
+++ b/packages/editor/src/functions/addMediaNode.ts
@@ -33,6 +33,8 @@ import { VideoComponent } from '@etherealengine/engine/src/scene/components/Vide
 import { VolumetricComponent } from '@etherealengine/engine/src/scene/components/VolumetricComponent'
 
 import { ComponentJson } from '@etherealengine/common/src/interfaces/SceneInterface'
+import { SceneState } from '@etherealengine/engine/src/ecs/classes/Scene'
+import { getState } from '@etherealengine/hyperflux'
 import { EditorControlFunctions } from './EditorControlFunctions'
 
 /**
@@ -44,7 +46,7 @@ import { EditorControlFunctions } from './EditorControlFunctions'
  */
 export async function addMediaNode(
   url: string,
-  parent: Entity | null = null,
+  parent: Entity = getState(SceneState).sceneEntity,
   before: Entity | null = null,
   extraComponentJson: ComponentJson[] = []
 ) {

--- a/packages/editor/src/lightmapper/AutoUV2.tsx
+++ b/packages/editor/src/lightmapper/AutoUV2.tsx
@@ -85,7 +85,7 @@ function convertGeometryToIndexed(buffer: THREE.BufferGeometry) {
     groupIndexArray.fill(group.materialIndex, group.start, Math.min(posVertexCount, group.start + group.count))
   }
 
-  const indexAttr = new THREE.Uint16BufferAttribute(faceCount * 3, 3)
+  const indexAttr = new THREE.Uint16BufferAttribute(faceCount * 3, 3) // should item siz not be one? internallly (array.length/ itemsize) =count
   indexAttr.count = faceCount * 3 // @todo without this the mesh does not show all faces
 
   for (let faceIndex = 0; faceIndex < faceCount; faceIndex += 1) {


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8d85715</samp>

Updated `addMediaNode` function to use scene state and default parent. This improves the usability and consistency of the function when adding media nodes to the scene.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8d85715</samp>

*  Import `SceneState` and `getState` modules to access scene entity and state ([link](https://github.com/EtherealEngine/etherealengine/pull/9150/files?diff=unified&w=0#diff-9b0967ffe73db7e4adda8d2b1b41c9ffe09aa4d44096d1e6729cec1059c35913R36-R37))
*  Change default value of `parent` parameter in `addMediaNode` function to be scene entity ([link](https://github.com/EtherealEngine/etherealengine/pull/9150/files?diff=unified&w=0#diff-9b0967ffe73db7e4adda8d2b1b41c9ffe09aa4d44096d1e6729cec1059c35913L47-R49))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8d85715</samp>

> _No more orphans in the scene, we give them a home_
> _We import the modules that let us access the dome_
> _We set the default parent with the state of the art_
> _We simplify the function, we make it smart_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
