### PR TITLE
refactor scopes for `bot` services

### DIFF
--- a/packages/server-core/src/bot/bot-command/bot-command.hooks.ts
+++ b/packages/server-core/src/bot/bot-command/bot-command.hooks.ts
@@ -44,13 +44,9 @@ export default {
   },
 
   before: {
-    all: [
-      iff(isProvider('external'), verifyScope('bot', 'read')),
-      () => schemaHooks.validateQuery(botCommandQueryValidator),
-      schemaHooks.resolveQuery(botCommandQueryResolver)
-    ],
-    find: [],
-    get: [],
+    all: [() => schemaHooks.validateQuery(botCommandQueryValidator), schemaHooks.resolveQuery(botCommandQueryResolver)],
+    find: [iff(isProvider('external'), verifyScope('bot', 'read'))],
+    get: [iff(isProvider('external'), verifyScope('bot', 'read'))],
     create: [
       iff(isProvider('external'), verifyScope('bot', 'write')),
       () => schemaHooks.validateData(botCommandDataValidator),

--- a/packages/server-core/src/bot/bot-command/bot-command.hooks.ts
+++ b/packages/server-core/src/bot/bot-command/bot-command.hooks.ts
@@ -28,14 +28,12 @@ import { disallow, iff, isProvider } from 'feathers-hooks-common'
 
 import {
   botCommandDataValidator,
-  botCommandPatchValidator,
   botCommandQueryValidator
 } from '@etherealengine/engine/src/schemas/bot/bot-command.schema'
 import verifyScope from '../../hooks/verify-scope'
 import {
   botCommandDataResolver,
   botCommandExternalResolver,
-  botCommandPatchResolver,
   botCommandQueryResolver,
   botCommandResolver
 } from './bot-command.resolvers'
@@ -47,20 +45,20 @@ export default {
 
   before: {
     all: [
-      iff(isProvider('external'), verifyScope('admin', 'admin')),
+      iff(isProvider('external'), verifyScope('bot', 'read')),
       () => schemaHooks.validateQuery(botCommandQueryValidator),
       schemaHooks.resolveQuery(botCommandQueryResolver)
     ],
     find: [],
     get: [],
-    create: [() => schemaHooks.validateData(botCommandDataValidator), schemaHooks.resolveData(botCommandDataResolver)],
-    update: [disallow()],
-    patch: [
-      disallow(),
-      () => schemaHooks.validateData(botCommandPatchValidator),
-      schemaHooks.resolveData(botCommandPatchResolver)
+    create: [
+      iff(isProvider('external'), verifyScope('bot', 'write')),
+      () => schemaHooks.validateData(botCommandDataValidator),
+      schemaHooks.resolveData(botCommandDataResolver)
     ],
-    remove: []
+    update: [disallow()],
+    patch: [disallow()],
+    remove: [iff(isProvider('external'), verifyScope('bot', 'write'))]
   },
 
   after: {

--- a/packages/server-core/src/bot/bot/bot.hooks.ts
+++ b/packages/server-core/src/bot/bot/bot.hooks.ts
@@ -75,13 +75,9 @@ export default {
   },
 
   before: {
-    all: [
-      iff(isProvider('external'), verifyScope('bot', 'read')),
-      () => schemaHooks.validateQuery(botQueryValidator),
-      schemaHooks.resolveQuery(botQueryResolver)
-    ],
-    find: [],
-    get: [],
+    all: [() => schemaHooks.validateQuery(botQueryValidator), schemaHooks.resolveQuery(botQueryResolver)],
+    find: [iff(isProvider('external'), verifyScope('bot', 'read'))],
+    get: [iff(isProvider('external'), verifyScope('bot', 'read'))],
     create: [
       iff(isProvider('external'), verifyScope('bot', 'write')),
       () => schemaHooks.validateData(botDataValidator),

--- a/packages/server-core/src/bot/bot/bot.hooks.ts
+++ b/packages/server-core/src/bot/bot/bot.hooks.ts
@@ -76,21 +76,26 @@ export default {
 
   before: {
     all: [
-      iff(isProvider('external'), verifyScope('admin', 'admin')),
+      iff(isProvider('external'), verifyScope('bot', 'read')),
       () => schemaHooks.validateQuery(botQueryValidator),
       schemaHooks.resolveQuery(botQueryResolver)
     ],
     find: [],
     get: [],
     create: [
+      iff(isProvider('external'), verifyScope('bot', 'write')),
       () => schemaHooks.validateData(botDataValidator),
       schemaHooks.resolveData(botDataResolver),
       persistData,
       discard('botCommands')
     ],
     update: [disallow()],
-    patch: [() => schemaHooks.validateData(botPatchValidator), schemaHooks.resolveData(botPatchResolver)],
-    remove: []
+    patch: [
+      iff(isProvider('external'), verifyScope('bot', 'write')),
+      () => schemaHooks.validateData(botPatchValidator),
+      schemaHooks.resolveData(botPatchResolver)
+    ],
+    remove: [iff(isProvider('external'), verifyScope('bot', 'write'))]
   },
 
   after: {


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58f9da4</samp>

The pull request improves the security and validation of the `bot` and `bot-command` services by using the `verifyScope` hook and disabling or restricting some methods. It requires the `bot` scope with different permissions for different actions on the bots and their commands.

## References
refs #9161 

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 58f9da4</samp>

*  Changed the authorization scope for accessing and modifying bots and bot commands ([link](https://github.com/EtherealEngine/etherealengine/pull/9154/files?diff=unified&w=0#diff-46f43795814297462f05b8b944b22b029f4c9aff87c2aa4d23bad0d49c51d546L50-R48), [link](https://github.com/EtherealEngine/etherealengine/pull/9154/files?diff=unified&w=0#diff-46f43795814297462f05b8b944b22b029f4c9aff87c2aa4d23bad0d49c51d546L56-R61), [link](https://github.com/EtherealEngine/etherealengine/pull/9154/files?diff=unified&w=0#diff-4f03bcb3045374de73c000b5ec0044840604abf499bbf76473c2a49f2f63b293L79-R79), [link](https://github.com/EtherealEngine/etherealengine/pull/9154/files?diff=unified&w=0#diff-4f03bcb3045374de73c000b5ec0044840604abf499bbf76473c2a49f2f63b293R86), [link](https://github.com/EtherealEngine/etherealengine/pull/9154/files?diff=unified&w=0#diff-4f03bcb3045374de73c000b5ec0044840604abf499bbf76473c2a49f2f63b293L92-R98))
* Removed unnecessary hooks for validating and resolving data for the `patch` method of the `bot-command` service ([link](https://github.com/EtherealEngine/etherealengine/pull/9154/files?diff=unified&w=0#diff-46f43795814297462f05b8b944b22b029f4c9aff87c2aa4d23bad0d49c51d546L31), [link](https://github.com/EtherealEngine/etherealengine/pull/9154/files?diff=unified&w=0#diff-46f43795814297462f05b8b944b22b029f4c9aff87c2aa4d23bad0d49c51d546L38))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 58f9da4</samp>

> _Sing, O Muse, of the code that was changed by the skillful developer_
> _Who removed the redundant hooks and the patch method from `bot-command`_
> _And who added the `verifyScope` hook to the `bot` service with care_
> _To require the proper scope and permission for each action_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
