### PR TITLE
Changes to add server logger for all hooks

### DIFF
--- a/packages/server-core/src/createApp.ts
+++ b/packages/server-core/src/createApp.ts
@@ -51,6 +51,7 @@ import { logger } from './ServerLogger'
 import { ServerMode, ServerState, ServerTypeMode } from './ServerState'
 import { default as appConfig, default as config } from './appconfig'
 import authenticate from './hooks/authenticate'
+import { logError } from './hooks/log-error'
 import persistHeaders from './hooks/persist-headers'
 import { createDefaultStorageProvider, createIPFSStorageProvider } from './media/storageprovider/storageprovider'
 import mysql from './mysql'
@@ -238,7 +239,9 @@ export const createFeathersKoaApp = (
 
   // Store headers across internal service calls
   app.hooks({
-    around: [authenticate, persistHeaders]
+    around: {
+      all: [logError, authenticate, persistHeaders]
+    }
   })
 
   pipeLogs(Engine.instance.api)

--- a/packages/server-core/src/hooks/log-error.ts
+++ b/packages/server-core/src/hooks/log-error.ts
@@ -40,10 +40,10 @@ export const logError = async (context: HookContext, next: NextFunction) => {
     await next()
   } catch (error) {
     logger.error(
-      `Error in ${context.path}, ${context.type}, ${context.method} method. ${structuredClone(
-        context.error
-      )}, stacktrace: ${context.error.stack}`,
-      context.error
+      `Error in ${context.path} service, ${context.type} hook, ${context.method} method. ${structuredClone(
+        error
+      )}, stacktrace: ${error.stack}`,
+      error
     )
 
     throw error

--- a/packages/server-core/src/hooks/log-error.ts
+++ b/packages/server-core/src/hooks/log-error.ts
@@ -1,0 +1,51 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import multiLogger from '@etherealengine/engine/src/common/functions/logger'
+import { NextFunction } from '@feathersjs/feathers'
+import type { HookContext } from '../../declarations'
+
+const logger = multiLogger.child({ component: 'server-core:log-error' })
+
+/**
+ * A logger to log errors in hooks to server logger
+ * Reference: https://github.com/feathersjs/feathers-chat/blob/dove/feathers-chat-ts/src/hooks/log-error.ts
+ * @param context
+ * @param next
+ */
+export const logError = async (context: HookContext, next: NextFunction) => {
+  try {
+    await next()
+  } catch (error) {
+    logger.error(
+      `Error in ${context.path}, ${context.type}, ${context.method} method. ${structuredClone(
+        context.error
+      )}, stacktrace: ${context.error.stack}`,
+      context.error
+    )
+
+    throw error
+  }
+}


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 54905fa</samp>

This pull request adds a new `logError` hook to the server core module, which logs errors in hooks to the server logger. This enhances the error handling and debugging capabilities of the server core module and other services that use it.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 54905fa</samp>

*  Implement and apply `logError` hook to log errors in hooks to the server logger ([link](https://github.com/EtherealEngine/etherealengine/pull/9162/files?diff=unified&w=0#diff-68b84eeaf71f49de58369ee519660b86d0469693cee4c988a576d8430269045fR54), [link](https://github.com/EtherealEngine/etherealengine/pull/9162/files?diff=unified&w=0#diff-68b84eeaf71f49de58369ee519660b86d0469693cee4c988a576d8430269045fL241-R244), [link](https://github.com/EtherealEngine/etherealengine/pull/9162/files?diff=unified&w=0#diff-ac3d31e8b206e18249dd80d0c91f563fb0bdfb29f3594bf372eba4a443567fe5R1-R51))
  * Import `logError` hook from `./hooks/log-error.ts` in `createApp.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9162/files?diff=unified&w=0#diff-68b84eeaf71f49de58369ee519660b86d0469693cee4c988a576d8430269045fR54))
  * Add `logError` hook to the `around` hook object of the `createFeathersKoaApp` function in `createApp.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9162/files?diff=unified&w=0#diff-68b84eeaf71f49de58369ee519660b86d0469693cee4c988a576d8430269045fL241-R244))
  * Define and export `logError` hook in `./hooks/log-error.ts` with file comment, license header, and logger initialization ([link](https://github.com/EtherealEngine/etherealengine/pull/9162/files?diff=unified&w=0#diff-ac3d31e8b206e18249dd80d0c91f563fb0bdfb29f3594bf372eba4a443567fe5R1-R51))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 54905fa</samp>

> _`logError` is the hook of doom_
> _It catches all the failures in the core_
> _No error can escape its wrath_
> _It writes them all to the server lore_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
