### PR TITLE
Fixed infinite recursion in avatar & user resolvers.

### DIFF
--- a/packages/engine/src/schemas/user/avatar.schema.ts
+++ b/packages/engine/src/schemas/user/avatar.schema.ts
@@ -65,7 +65,7 @@ export const avatarSchema = Type.Object(
 )
 export type AvatarType = Static<typeof avatarSchema>
 
-export type AvatarDatabaseType = Omit<AvatarType, 'user' | 'modelResource' | 'thumbnailResource'>
+export type AvatarDatabaseType = Omit<AvatarType, 'modelResource' | 'thumbnailResource'>
 
 // Schema for creating new entries
 // export const avatarDataSchema = Type.Pick(
@@ -105,7 +105,10 @@ export const avatarQuerySchema = Type.Intersect(
       }
     }),
     // Add additional query properties here
-    Type.Object({ action: Type.Optional(Type.String()) }, { additionalProperties: false })
+    Type.Object(
+      { action: Type.Optional(Type.String()), skipUser: Type.Optional(Type.Boolean()) },
+      { additionalProperties: false }
+    )
   ],
   { additionalProperties: false }
 )

--- a/packages/engine/src/schemas/user/user.schema.ts
+++ b/packages/engine/src/schemas/user/user.schema.ts
@@ -113,7 +113,8 @@ export const userQuerySchema = Type.Intersect(
     // Add additional query properties here
     Type.Object(
       {
-        search: Type.Optional(Type.String())
+        search: Type.Optional(Type.String()),
+        skipAvatar: Type.Optional(Type.Boolean())
       },
       { additionalProperties: false }
     )

--- a/packages/server-core/src/scope/scope/scope.hooks.ts
+++ b/packages/server-core/src/scope/scope/scope.hooks.ts
@@ -39,14 +39,14 @@ import { HookContext } from '../../../declarations'
 import enableClientPagination from '../../hooks/enable-client-pagination'
 import verifyScope from '../../hooks/verify-scope'
 import verifyScopeAllowingSelf from '../../hooks/verify-scope-allowing-self'
+import { ScopeService } from './scope.class'
 import {
   scopeDataResolver,
   scopeExternalResolver,
   scopePatchResolver,
   scopeQueryResolver,
   scopeResolver
-} from '../../scope/scope/scope.resolvers'
-import { ScopeService } from './scope.class'
+} from './scope.resolvers'
 
 /**
  * Check and maintain existing scopes

--- a/packages/server-core/src/user/avatar/avatar.hooks.ts
+++ b/packages/server-core/src/user/avatar/avatar.hooks.ts
@@ -41,6 +41,7 @@ import { userPath } from '@etherealengine/engine/src/schemas/user/user.schema'
 import { HookContext } from '../../../declarations'
 import disallowNonId from '../../hooks/disallow-non-id'
 import isAction from '../../hooks/is-action'
+import persistQuery from '../../hooks/persist-query'
 import verifyScope from '../../hooks/verify-scope'
 import { AvatarService } from './avatar.class'
 import {
@@ -179,10 +180,12 @@ export default {
     all: [() => schemaHooks.validateQuery(avatarQueryValidator), schemaHooks.resolveQuery(avatarQueryResolver)],
     find: [
       iffElse(isAction('admin'), verifyScope('admin', 'admin'), ensureUserAccessibleAvatars),
+      persistQuery,
       discardQuery('action'),
+      discardQuery('skipUser'),
       sortByUserName
     ],
-    get: [],
+    get: [persistQuery, discardQuery('skipUser')],
     create: [
       () => schemaHooks.validateData(avatarDataValidator),
       schemaHooks.resolveData(avatarDataResolver),

--- a/packages/server-core/src/user/avatar/avatar.resolvers.ts
+++ b/packages/server-core/src/user/avatar/avatar.resolvers.ts
@@ -41,8 +41,13 @@ export const avatarResolver = resolve<AvatarType, HookContext>({
 
 export const avatarExternalResolver = resolve<AvatarType, HookContext>({
   user: virtual(async (avatar, context) => {
+    if (context.arguments && context.arguments.length > 0 && context.arguments[1]?.actualQuery?.skipUser) return {}
     if (avatar.userId) {
-      return context.app.service(userPath).get(avatar.userId)
+      try {
+        return await context.app.service(userPath).get(avatar.userId, { query: { skipAvatar: true } })
+      } catch (err) {
+        return {}
+      }
     }
   }),
   modelResource: virtual(async (avatar, context) => {

--- a/packages/server-core/src/user/user/user.hooks.ts
+++ b/packages/server-core/src/user/user/user.hooks.ts
@@ -46,6 +46,7 @@ import { HookContext } from '../../../declarations'
 import { createSkippableHooks } from '../../hooks/createSkippableHooks'
 import disallowNonId from '../../hooks/disallow-non-id'
 import persistData from '../../hooks/persist-data'
+import persistQuery from '../../hooks/persist-query'
 import verifyScope from '../../hooks/verify-scope'
 import getFreeInviteCode from '../../util/get-free-invite-code'
 import { UserService } from './user.class'
@@ -267,9 +268,11 @@ export default createSkippableHooks(
       all: [() => schemaHooks.validateQuery(userQueryValidator), schemaHooks.resolveQuery(userQueryResolver)],
       find: [
         iff(isProvider('external'), verifyScope('admin', 'admin'), verifyScope('user', 'read'), handleUserSearch),
-        iff(isProvider('external'), discardQuery('search', '$sort.accountIdentifier') as any)
+        iff(isProvider('external'), discardQuery('search', '$sort.accountIdentifier') as any),
+        persistQuery,
+        discardQuery('skipAvatar')
       ],
-      get: [],
+      get: [persistQuery, discardQuery('skipAvatar')],
       create: [
         iff(isProvider('external'), verifyScope('admin', 'admin'), verifyScope('user', 'write')),
         () => schemaHooks.validateData(userDataValidator),

--- a/packages/server-core/src/user/user/user.resolvers.ts
+++ b/packages/server-core/src/user/user/user.resolvers.ts
@@ -95,7 +95,13 @@ export const userResolver = resolve<UserType, HookContext>({
 
 export const userExternalResolver = resolve<UserType, HookContext>({
   avatar: virtual(async (user, context) => {
-    if (context.event !== 'removed' && user.avatarId) return await context.app.service(avatarPath).get(user.avatarId)
+    if (context.arguments && context.arguments.length > 0 && context.arguments[1]?.actualQuery?.skipAvatar) return {}
+    if (context.event !== 'removed' && user.avatarId)
+      try {
+        return await context.app.service(avatarPath).get(user.avatarId, { query: { skipUser: true } })
+      } catch (err) {
+        return {}
+      }
   }),
   userSetting: virtual(async (user, context) => {
     const userSetting = (await context.app.service(userSettingPath).find({


### PR DESCRIPTION
## Summary
PR 9073 introduced an infinite recursion bug. If a user had a custom avatar that they had uploaded, the user resolver would fetch their avatar, which would now fetch the user that owned that avatar, which would fetch the avatar, ad infinitum. Added some query params to skip the population of the user or avatar if instructed to do so by internal resolver fetches.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2063c3a</samp>

Refactored the user and avatar services and schemas to optimize the data fetching and avoid circular dependencies. Added `skipUser` and `skipAvatar` query parameters to optionally exclude the user or avatar data from the service responses. Simplified the scope service file structure and the hook code for consistency and readability.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2063c3a</samp>

*  Omit the `user` property from the `AvatarDatabaseType` type, since it is not stored in the database but resolved externally ([link](https://github.com/EtherealEngine/etherealengine/pull/9178/files?diff=unified&w=0#diff-81108cdb5690aa587b75b4f0dee4a7d94eeb31bc2c15c72e7ac2bd64c30a18acL68-R68))
* Add optional `skipUser` and `skipAvatar` properties to the `avatarQuerySchema` and `userQuerySchema` schemas, respectively, which allow the queries to exclude the user or avatar data from the response ([link](https://github.com/EtherealEngine/etherealengine/pull/9178/files?diff=unified&w=0#diff-81108cdb5690aa587b75b4f0dee4a7d94eeb31bc2c15c72e7ac2bd64c30a18acL108-R111), [link](https://github.com/EtherealEngine/etherealengine/pull/9178/files?diff=unified&w=0#diff-b9987a914e7ba539f5a09749f28c140b05120d8e35b581cfd669b6ac34974b02L116-R117))
* Import the `ScopeService` class, the `scopeQueryResolver` and `scopeResolver` functions from the same file `scope.hooks.ts`, since they were moved from another file in a previous commit ([link](https://github.com/EtherealEngine/etherealengine/pull/9178/files?diff=unified&w=0#diff-51a56de3ce2fc5f1eab0db395d40caae6e265781c2aae44e10039ed7f0a328e4R42), [link](https://github.com/EtherealEngine/etherealengine/pull/9178/files?diff=unified&w=0#diff-51a56de3ce2fc5f1eab0db395d40caae6e265781c2aae44e10039ed7f0a328e4L48-R49))
* Import and use the `persistQuery` hook from the `hooks` folder in the `find` and `get` hooks for the `avatar` and `user` services, which stores the original query in the `actualQuery` property of the context, and discards the irrelevant query parameters for the database query ([link](https://github.com/EtherealEngine/etherealengine/pull/9178/files?diff=unified&w=0#diff-5d8f220f6a127251c7b3c898887efb63a8dff4dfd9d9daab035d926c1ecb48d0R44), [link](https://github.com/EtherealEngine/etherealengine/pull/9178/files?diff=unified&w=0#diff-5d8f220f6a127251c7b3c898887efb63a8dff4dfd9d9daab035d926c1ecb48d0L182-R188), [link](https://github.com/EtherealEngine/etherealengine/pull/9178/files?diff=unified&w=0#diff-080bb3bb2b4fa4e65acf1e18bab6ca65a9ac29000851ee951af06614eda29039R49), [link](https://github.com/EtherealEngine/etherealengine/pull/9178/files?diff=unified&w=0#diff-080bb3bb2b4fa4e65acf1e18bab6ca65a9ac29000851ee951af06614eda29039L270-R275))
* Modify the `user` resolver for the `avatar` service and the `avatar` resolver for the `user` service to check the `skipUser` and `skipAvatar` query parameters, respectively, and return an empty object instead of fetching the data if they are set, to prevent circular dependencies between the services. Also, pass the corresponding query parameters to the `get` calls for the other service ([link](https://github.com/EtherealEngine/etherealengine/pull/9178/files?diff=unified&w=0#diff-4fc3166d2e818a31e3644b5f6bc62a29dedc4471d891217be755a5b39765d156L44-R46), [link](https://github.com/EtherealEngine/etherealengine/pull/9178/files?diff=unified&w=0#diff-ae5e320d761134086ef0fb3a57124ad983c9c89985de39838ad1f4ab9259e765L98-R100))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2063c3a</samp>

> _`skipAvatar` query_
> _optimizes user service_
> _spring cleaning the code_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
