### PR TITLE
Changes to use context.params instead of arguments

### DIFF
--- a/packages/server-core/src/social/invite-code-lookup/invite-code-lookup.resolvers.ts
+++ b/packages/server-core/src/social/invite-code-lookup/invite-code-lookup.resolvers.ts
@@ -38,7 +38,7 @@ import type { HookContext } from '@etherealengine/server-core/declarations'
 
 export const inviteCodeLookupResolver = resolve<InviteCodeLookupType, HookContext>({
   instanceAttendance: virtual(async (inviteCodeLookup, context) => {
-    if (context.params.user?.id === context.arguments[0])
+    if (context.params.user?.id === context.id)
       return (await context.app.service(instanceAttendancePath).find({
         query: {
           userId: inviteCodeLookup.id,

--- a/packages/server-core/src/user/avatar/avatar.resolvers.ts
+++ b/packages/server-core/src/user/avatar/avatar.resolvers.ts
@@ -41,7 +41,7 @@ export const avatarResolver = resolve<AvatarType, HookContext>({
 
 export const avatarExternalResolver = resolve<AvatarType, HookContext>({
   user: virtual(async (avatar, context) => {
-    if (context.arguments && context.arguments.length > 0 && context.arguments[1]?.actualQuery?.skipUser) return {}
+    if (context.params?.actualQuery?.skipUser) return {}
     if (avatar.userId) {
       try {
         return await context.app.service(userPath).get(avatar.userId, { query: { skipAvatar: true } })

--- a/packages/server-core/src/user/user/user.resolvers.ts
+++ b/packages/server-core/src/user/user/user.resolvers.ts
@@ -95,7 +95,7 @@ export const userResolver = resolve<UserType, HookContext>({
 
 export const userExternalResolver = resolve<UserType, HookContext>({
   avatar: virtual(async (user, context) => {
-    if (context.arguments && context.arguments.length > 0 && context.arguments[1]?.actualQuery?.skipAvatar) return {}
+    if (context.params?.actualQuery?.skipAvatar) return {}
     if (context.event !== 'removed' && user.avatarId)
       try {
         return await context.app.service(avatarPath).get(user.avatarId, { query: { skipUser: true } })


### PR DESCRIPTION
## Summary

Replaced `context.arguments` with `context.params` as `context.arguments[]`, etc can represent different things (id, data, params) based on methods. For reading purpose as done in the modified code, `context.params`, `context.id` is better to use. Though for writing to id, arguments can be used as we faced an issue previously.
https://github.com/EtherealEngine/etherealengine/pull/9178
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f63cf95</samp>

This pull request fixes a bug in the `invite-code-lookup.resolvers.ts` file that caused an error when querying the instance attendance of the current user, and optimizes the `avatar.resolvers.ts` and `user.resolvers.ts` files by using a more efficient way to check if some data should be skipped.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f63cf95</samp>

* Fix bug in `inviteCodeLookupResolver` that caused error when querying instance attendance of current user ([link](https://github.com/EtherealEngine/etherealengine/pull/9181/files?diff=unified&w=0#diff-73242032c6d82a224a0cfd5535dc75c06e5c6c60de511ca2ec705fdf9cd0e3c8L41-R41))
* Optimize `avatarExternalResolver` and `userExternalResolver` by using `context.params.actualQuery` to check if user or avatar data should be skipped, instead of parsing `context.arguments[1].actualQuery` ([link](https://github.com/EtherealEngine/etherealengine/pull/9181/files?diff=unified&w=0#diff-4fc3166d2e818a31e3644b5f6bc62a29dedc4471d891217be755a5b39765d156L44-R44), [link](https://github.com/EtherealEngine/etherealengine/pull/9181/files?diff=unified&w=0#diff-ae5e320d761134086ef0fb3a57124ad983c9c89985de39838ad1f4ab9259e765L98-R98))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f63cf95</samp>

> _`inviteCode` bug_
> _fixed with proper context_
> _autumn leaves no trace_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
