### PR TITLE
refactor scopes for `client-setting` service

### DIFF
--- a/packages/server-core/src/scope/scope-type/scope-type.seed.ts
+++ b/packages/server-core/src/scope/scope-type/scope-type.seed.ts
@@ -113,6 +113,12 @@ export const scopeTypeSeed = [
     type: 'settings:write'
   },
   {
+    type: 'settings_client:read'
+  },
+  {
+    type: 'settings_client:write'
+  },
+  {
     type: 'server:read'
   },
   {

--- a/packages/server-core/src/setting/client-setting/client-setting.hooks.ts
+++ b/packages/server-core/src/setting/client-setting/client-setting.hooks.ts
@@ -133,18 +133,18 @@ export default {
     find: [],
     get: [],
     create: [
-      iff(isProvider('external'), verifyScope('admin', 'admin'), verifyScope('settings', 'write')),
+      iff(isProvider('external'), verifyScope('settings_client', 'write')),
       () => schemaHooks.validateData(clientSettingDataValidator),
       schemaHooks.resolveData(clientSettingDataResolver)
     ],
-    update: [iff(isProvider('external'), verifyScope('admin', 'admin'), verifyScope('settings', 'write'))],
+    update: [iff(isProvider('external'), verifyScope('settings_client', 'write'))],
     patch: [
-      iff(isProvider('external'), verifyScope('admin', 'admin'), verifyScope('settings', 'write')),
+      iff(isProvider('external'), verifyScope('settings_client', 'write')),
       () => schemaHooks.validateData(clientSettingPatchValidator),
       schemaHooks.resolveData(clientSettingPatchResolver),
       updateWebManifest
     ],
-    remove: [iff(isProvider('external'), verifyScope('admin', 'admin'), verifyScope('settings', 'write'))]
+    remove: [iff(isProvider('external'), verifyScope('settings_client', 'write'))]
   },
 
   after: {


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 86e8f97</samp>

This pull request introduces new scope types for the client settings service, which handles the web app manifest and other client-side settings. The new scope types `settings_client:read` and `settings_client:write` are added to the file `scope-type.seed.ts` and used in the file `client-setting.hooks.ts` to replace the previous scope verification.

## References
refs #9161

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 86e8f97</samp>

*  Add new scope types for client settings ([link](https://github.com/EtherealEngine/etherealengine/pull/9183/files?diff=unified&w=0#diff-f4030fcae8458c587a53780bc67624af731ed7e2a59f22faec2999ec6043561cR116-R121))
*  Update scope verification for client settings service ([link](https://github.com/EtherealEngine/etherealengine/pull/9183/files?diff=unified&w=0#diff-927aa9f1a46cc67f38c8daaa2bc4907ad115b2e6f605696526d8d90206c15c97L136-R147))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 86e8f97</samp>

> _New scope types added_
> _`settings_client` controls_
> _Web app in autumn_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
