### PR TITLE
refactor scopes for `cluster` services

### DIFF
--- a/packages/server-core/src/cluster/api-job/api-job.hooks.ts
+++ b/packages/server-core/src/cluster/api-job/api-job.hooks.ts
@@ -48,20 +48,20 @@ export default {
 
   before: {
     all: [
-      iff(isProvider('external'), verifyScope('admin', 'admin')),
+      iff(isProvider('external'), verifyScope('server', 'read')),
       () => schemaHooks.validateQuery(apiJobQueryValidator),
       schemaHooks.resolveQuery(apiJobQueryResolver)
     ],
-    find: [iff(isProvider('external'), verifyScope('admin', 'admin'))],
-    get: [iff(isProvider('external'), verifyScope('admin', 'admin'))],
+    find: [],
+    get: [],
     create: [
-      iff(isProvider('external'), verifyScope('admin', 'admin')),
+      iff(isProvider('external'), verifyScope('server', 'write')),
       () => schemaHooks.validateData(apiJobDataValidator),
       schemaHooks.resolveData(apiJobDataResolver)
     ],
-    update: [iff(isProvider('external'), verifyScope('admin', 'admin'))],
+    update: [],
     patch: [
-      iff(isProvider('external'), verifyScope('admin', 'admin')),
+      iff(isProvider('external'), verifyScope('server', 'write')),
       () => schemaHooks.validateData(apiJobPatchValidator),
       schemaHooks.resolveData(apiJobPatchResolver)
     ],

--- a/packages/server-core/src/cluster/api-job/api-job.hooks.ts
+++ b/packages/server-core/src/cluster/api-job/api-job.hooks.ts
@@ -24,7 +24,7 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { hooks as schemaHooks } from '@feathersjs/schema'
-import { iff, isProvider } from 'feathers-hooks-common'
+import { disallow, iff, isProvider } from 'feathers-hooks-common'
 
 import {
   apiJobDataValidator,
@@ -47,19 +47,15 @@ export default {
   },
 
   before: {
-    all: [
-      iff(isProvider('external'), verifyScope('server', 'read')),
-      () => schemaHooks.validateQuery(apiJobQueryValidator),
-      schemaHooks.resolveQuery(apiJobQueryResolver)
-    ],
-    find: [],
-    get: [],
+    all: [() => schemaHooks.validateQuery(apiJobQueryValidator), schemaHooks.resolveQuery(apiJobQueryResolver)],
+    find: [iff(isProvider('external'), verifyScope('server', 'read'))],
+    get: [iff(isProvider('external'), verifyScope('server', 'read'))],
     create: [
       iff(isProvider('external'), verifyScope('server', 'write')),
       () => schemaHooks.validateData(apiJobDataValidator),
       schemaHooks.resolveData(apiJobDataResolver)
     ],
-    update: [],
+    update: [disallow()],
     patch: [
       iff(isProvider('external'), verifyScope('server', 'write')),
       () => schemaHooks.validateData(apiJobPatchValidator),

--- a/packages/server-core/src/cluster/build-status/build-status.hooks.ts
+++ b/packages/server-core/src/cluster/build-status/build-status.hooks.ts
@@ -24,7 +24,7 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { hooks as schemaHooks } from '@feathersjs/schema'
-import { iff, isProvider } from 'feathers-hooks-common'
+import { disallow, iff, isProvider } from 'feathers-hooks-common'
 
 import {
   buildStatusDataValidator,
@@ -48,18 +48,17 @@ export default {
 
   before: {
     all: [
-      iff(isProvider('external'), verifyScope('server', 'read')),
       () => schemaHooks.validateQuery(buildStatusQueryValidator),
       schemaHooks.resolveQuery(buildStatusQueryResolver)
     ],
-    find: [],
-    get: [],
+    find: [iff(isProvider('external'), verifyScope('server', 'read'))],
+    get: [iff(isProvider('external'), verifyScope('server', 'read'))],
     create: [
       iff(isProvider('external'), verifyScope('server', 'write')),
       () => schemaHooks.validateData(buildStatusDataValidator),
       schemaHooks.resolveData(buildStatusDataResolver)
     ],
-    update: [],
+    update: [disallow()],
     patch: [
       iff(isProvider('external'), verifyScope('server', 'write')),
       () => schemaHooks.validateData(buildStatusPatchValidator),

--- a/packages/server-core/src/cluster/build-status/build-status.hooks.ts
+++ b/packages/server-core/src/cluster/build-status/build-status.hooks.ts
@@ -48,22 +48,24 @@ export default {
 
   before: {
     all: [
-      iff(isProvider('external'), verifyScope('admin', 'admin')),
+      iff(isProvider('external'), verifyScope('server', 'read')),
       () => schemaHooks.validateQuery(buildStatusQueryValidator),
       schemaHooks.resolveQuery(buildStatusQueryResolver)
     ],
     find: [],
     get: [],
     create: [
+      iff(isProvider('external'), verifyScope('server', 'write')),
       () => schemaHooks.validateData(buildStatusDataValidator),
       schemaHooks.resolveData(buildStatusDataResolver)
     ],
     update: [],
     patch: [
+      iff(isProvider('external'), verifyScope('server', 'write')),
       () => schemaHooks.validateData(buildStatusPatchValidator),
       schemaHooks.resolveData(buildStatusPatchResolver)
     ],
-    remove: []
+    remove: [iff(isProvider('external'), verifyScope('server', 'read'))]
   },
 
   after: {

--- a/packages/server-core/src/cluster/pods/pods.hooks.ts
+++ b/packages/server-core/src/cluster/pods/pods.hooks.ts
@@ -23,18 +23,18 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { iff, isProvider } from 'feathers-hooks-common'
+import { disallow, iff, isProvider } from 'feathers-hooks-common'
 
 import verifyScope from '../../hooks/verify-scope'
 
 export default {
   before: {
-    all: [iff(isProvider('external'), verifyScope('server', 'read'))],
-    find: [],
-    get: [],
-    create: [],
-    update: [],
-    patch: [],
+    all: [],
+    find: [iff(isProvider('external'), verifyScope('server', 'read'))],
+    get: [iff(isProvider('external'), verifyScope('server', 'read'))],
+    create: [disallow()],
+    update: [disallow()],
+    patch: [disallow()],
     remove: [iff(isProvider('external'), verifyScope('server', 'write'))]
   },
 

--- a/packages/server-core/src/cluster/pods/pods.hooks.ts
+++ b/packages/server-core/src/cluster/pods/pods.hooks.ts
@@ -29,13 +29,13 @@ import verifyScope from '../../hooks/verify-scope'
 
 export default {
   before: {
-    all: [iff(isProvider('external'), verifyScope('admin', 'admin'))],
+    all: [iff(isProvider('external'), verifyScope('server', 'read'))],
     find: [],
     get: [],
     create: [],
     update: [],
     patch: [],
-    remove: []
+    remove: [iff(isProvider('external'), verifyScope('server', 'write'))]
   },
 
   after: {


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bfcb829</samp>

Improved the security and communication of the cluster services by adjusting the scope and permission hooks for `build-status`, `pods`, and `api-job`. This enables the server to manage the build status and API jobs of the pods without admin rights.

## References
refs #9161

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bfcb829</samp>

*  Changed the service hooks for `api-job`, `build-status`, and `pods` to use the `server` scope instead of the `admin` scope for external requests ([link](https://github.com/EtherealEngine/etherealengine/pull/9184/files?diff=unified&w=0#diff-5ceeb9506973a3be875f0b571285eef40461b1685b48ff862d90473009a32faeL51-R64), [link](https://github.com/EtherealEngine/etherealengine/pull/9184/files?diff=unified&w=0#diff-2a62a24d5c3f6d5fce935a7b0f100ac76af7e2b0e28237238f4b0f8565c6a2e1L51-R51), [link](https://github.com/EtherealEngine/etherealengine/pull/9184/files?diff=unified&w=0#diff-04302298e7bfc9f3dc9a03dc27d3402ca7ff6306352b0597f587f4edf4676031L32-R32)). This allows the server to perform various operations on the cluster without requiring admin privileges.
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bfcb829</samp>

> _We're the crew of the `api-job` ship, we sail the code with skill_
> _We don't need `admin` scope to do our work, we use the `server` scope at will_
> _Heave away, me hearties, heave away_
> _We'll hook the `build-status` and the `pods` with care, and keep them safe and sound_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
