### PR TITLE
service scoping on the client

### DIFF
--- a/packages/client-core/src/admin/components/Project/ProjectTable.tsx
+++ b/packages/client-core/src/admin/components/Project/ProjectTable.tsx
@@ -39,7 +39,7 @@ import { ProjectType, projectPath } from '@etherealengine/engine/src/schemas/pro
 import { NotificationService } from '../../../common/services/NotificationService'
 import { ProjectService } from '../../../common/services/ProjectService'
 import { AuthState } from '../../../user/services/AuthService'
-import { userIsAdmin } from '../../../user/userHasAccess'
+import { useUserHasAccessHook } from '../../../user/userHasAccess'
 import TableComponent from '../../common/Table'
 import { projectsColumns } from '../../common/variables/projects'
 import styles from '../../styles/admin.module.scss'
@@ -222,7 +222,7 @@ const ProjectTable = ({ className }: Props) => {
     })
   }
 
-  const isAdmin = user.scopes?.value?.find((scope) => scope.type === 'admin:admin')
+  const hasProjectWritePermission = useUserHasAccessHook('projects:write')
 
   const createData = (el: ProjectType, name: string) => {
     const commitSHA = el.commitSHA
@@ -270,7 +270,7 @@ const ProjectTable = ({ className }: Props) => {
       ),
       update: (
         <>
-          {isAdmin && name !== 'default-project' && (
+          {hasProjectWritePermission && name !== 'default-project' && (
             <IconButton
               className={styles.iconButton}
               name="update"
@@ -279,7 +279,7 @@ const ProjectTable = ({ className }: Props) => {
               icon={<Icon type="Refresh" />}
             />
           )}
-          {isAdmin && name === 'default-project' && (
+          {hasProjectWritePermission && name === 'default-project' && (
             <Tooltip title={t('admin:components.project.defaultProjectUpdateTooltip')} arrow>
               <IconButton className={styles.iconButton} name="update" disabled={true} icon={<Icon type="Refresh" />} />
             </Tooltip>
@@ -288,11 +288,11 @@ const ProjectTable = ({ className }: Props) => {
       ),
       push: (
         <>
-          {isAdmin && (
+          {hasProjectWritePermission && (
             <IconButton
               className={styles.iconButton}
               name="update"
-              disabled={(!el.hasWriteAccess && !userIsAdmin()) || !el.repositoryPath}
+              disabled={!el.hasWriteAccess || !el.repositoryPath}
               onClick={() => openPushConfirmation(el)}
               icon={<Icon type="Upload" />}
             />
@@ -312,7 +312,7 @@ const ProjectTable = ({ className }: Props) => {
       ),
       projectPermissions: (
         <>
-          {isAdmin && (
+          {hasProjectWritePermission && (
             <IconButton
               className={styles.iconButton}
               name="editProjectPermissions"
@@ -324,7 +324,7 @@ const ProjectTable = ({ className }: Props) => {
       ),
       invalidate: (
         <>
-          {isAdmin && (
+          {hasProjectWritePermission && (
             <IconButton
               className={styles.iconButton}
               name="invalidate"
@@ -336,7 +336,7 @@ const ProjectTable = ({ className }: Props) => {
       ),
       view: (
         <>
-          {isAdmin && (
+          {hasProjectWritePermission && (
             <IconButton
               className={styles.iconButton}
               name="view"
@@ -348,7 +348,7 @@ const ProjectTable = ({ className }: Props) => {
       ),
       action: (
         <>
-          {isAdmin && (
+          {hasProjectWritePermission && (
             <IconButton
               className={styles.iconButton}
               name="remove"

--- a/packages/client-core/src/admin/components/Project/ProjectTable.tsx
+++ b/packages/client-core/src/admin/components/Project/ProjectTable.tsx
@@ -28,7 +28,6 @@ import { useTranslation } from 'react-i18next'
 
 import ConfirmDialog from '@etherealengine/client-core/src/common/components/ConfirmDialog'
 import multiLogger from '@etherealengine/engine/src/common/functions/logger'
-import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
 import Box from '@etherealengine/ui/src/primitives/mui/Box'
 import Icon from '@etherealengine/ui/src/primitives/mui/Icon'
 import IconButton from '@etherealengine/ui/src/primitives/mui/IconButton'
@@ -38,7 +37,6 @@ import { useFind } from '@etherealengine/engine/src/common/functions/FeathersHoo
 import { ProjectType, projectPath } from '@etherealengine/engine/src/schemas/projects/project.schema'
 import { NotificationService } from '../../../common/services/NotificationService'
 import { ProjectService } from '../../../common/services/ProjectService'
-import { AuthState } from '../../../user/services/AuthService'
 import { useUserHasAccessHook } from '../../../user/userHasAccess'
 import TableComponent from '../../common/Table'
 import { projectsColumns } from '../../common/variables/projects'
@@ -88,9 +86,6 @@ const ProjectTable = ({ className }: Props) => {
   })
 
   const projectsData = projects.data as ProjectType[]
-
-  const authState = useHookstate(getMutableState(AuthState))
-  const user = authState.user
 
   const projectRef = useRef(project)
 
@@ -301,13 +296,15 @@ const ProjectTable = ({ className }: Props) => {
       ),
       link: (
         <>
-          <IconButton
-            className={styles.iconButton}
-            name="update"
-            disabled={name === 'default-project'}
-            onClick={() => handleOpenProjectDrawer(el, true)}
-            icon={<Icon type={!el.repositoryPath ? 'LinkOff' : 'Link'} />}
-          />
+          {hasProjectWritePermission && (
+            <IconButton
+              className={styles.iconButton}
+              name="update"
+              disabled={name === 'default-project'}
+              onClick={() => handleOpenProjectDrawer(el, true)}
+              icon={<Icon type={!el.repositoryPath ? 'LinkOff' : 'Link'} />}
+            />
+          )}
         </>
       ),
       projectPermissions: (

--- a/packages/client-core/src/admin/components/Project/UserPermissionDrawer.tsx
+++ b/packages/client-core/src/admin/components/Project/UserPermissionDrawer.tsx
@@ -45,6 +45,7 @@ import { ProjectType } from '@etherealengine/engine/src/schemas/projects/project
 import { NotificationService } from '../../../common/services/NotificationService'
 import { ProjectService } from '../../../common/services/ProjectService'
 import { AuthState } from '../../../user/services/AuthService'
+import { userHasAccess } from '../../../user/userHasAccess'
 import DrawerView from '../../common/DrawerView'
 import styles from '../../styles/admin.module.scss'
 
@@ -61,7 +62,7 @@ const UserPermissionDrawer = ({ open, project, onClose }: Props) => {
   const selfUser = useHookstate(getMutableState(AuthState)).user
   const selfUserPermission =
     project?.projectPermissions?.find((permission) => permission.userId === selfUser.id.value)?.type === 'owner' ||
-    selfUser.scopes?.value?.find((scope) => scope.type === 'admin:admin')
+    userHasAccess('projects:write')
       ? 'owner'
       : 'user'
 

--- a/packages/client-core/src/admin/components/Project/UserPermissionDrawer.tsx
+++ b/packages/client-core/src/admin/components/Project/UserPermissionDrawer.tsx
@@ -62,7 +62,7 @@ const UserPermissionDrawer = ({ open, project, onClose }: Props) => {
   const selfUser = useHookstate(getMutableState(AuthState)).user
   const selfUserPermission =
     project?.projectPermissions?.find((permission) => permission.userId === selfUser.id.value)?.type === 'owner' ||
-    userHasAccess('projects:write')
+    userHasAccess('admin:admin')
       ? 'owner'
       : 'user'
 

--- a/packages/client-core/src/admin/components/Setting/index.tsx
+++ b/packages/client-core/src/admin/components/Setting/index.tsx
@@ -40,6 +40,7 @@ import ListItemAvatar from '@etherealengine/ui/src/primitives/mui/ListItemAvatar
 import ListItemText from '@etherealengine/ui/src/primitives/mui/ListItemText'
 import Typography from '@etherealengine/ui/src/primitives/mui/Typography'
 
+import { userHasAccess } from '../../../user/userHasAccess'
 import styles from '../../styles/settings.module.scss'
 import Authentication from './Authentication'
 import Aws from './Aws'
@@ -78,7 +79,8 @@ const settingItems = [
     name: 'client',
     title: 'Client',
     icon: <Icon type="ViewCompact" sx={{ color: 'orange' }} />,
-    content: <Client />
+    content: <Client />,
+    scope: 'settings_client:read'
   },
   {
     name: 'clientTheme',
@@ -144,21 +146,23 @@ interface SidebarProps {
 const Sidebar = ({ selected, onChange }: SidebarProps) => {
   return (
     <List>
-      {settingItems.map((item) => (
-        <Fragment key={item.name}>
-          <ListItem
-            button
-            onClick={() => onChange(item.name)}
-            className={selected === item.name ? `${styles.focused}` : `${styles.notFocused}`}
-          >
-            <ListItemAvatar>
-              <Avatar style={{ background: '#5e5a4d' }}>{item.icon}</Avatar>
-            </ListItemAvatar>
-            <ListItemText primary={item.title} />
-          </ListItem>
-          <Divider variant="inset" component="li" sx={{ marginLeft: '0px' }} />
-        </Fragment>
-      ))}
+      {settingItems
+        .filter((item) => (item.scope ? userHasAccess(item.scope) : true))
+        .map((item) => (
+          <Fragment key={item.name}>
+            <ListItem
+              button
+              onClick={() => onChange(item.name)}
+              className={selected === item.name ? `${styles.focused}` : `${styles.notFocused}`}
+            >
+              <ListItemAvatar>
+                <Avatar style={{ background: '#5e5a4d' }}>{item.icon}</Avatar>
+              </ListItemAvatar>
+              <ListItemText primary={item.title} />
+            </ListItem>
+            <Divider variant="inset" component="li" sx={{ marginLeft: '0px' }} />
+          </Fragment>
+        ))}
     </List>
   )
 }

--- a/packages/client-core/src/components/MediaIconsBox/index.tsx
+++ b/packages/client-core/src/components/MediaIconsBox/index.tsx
@@ -57,13 +57,11 @@ import { useTranslation } from 'react-i18next'
 import { VrIcon } from '../../common/components/Icons/VrIcon'
 import { RecordingUIState } from '../../systems/ui/RecordingsWidgetUI'
 import { MediaStreamService, MediaStreamState } from '../../transports/MediaStreams'
-import { useUserHasAccessHook } from '../../user/userHasAccess'
 import { useShelfStyles } from '../Shelves/useShelfStyles'
 import styles from './index.module.scss'
 
 export const MediaIconsBox = () => {
   const { t } = useTranslation()
-  const recordScopes = useUserHasAccessHook('record')
   const playbackState = useHookstate(getMutableState(PlaybackState))
   const recordingState = useHookstate(getMutableState(RecordingState))
 

--- a/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/ProfileMenu.tsx
@@ -55,6 +55,7 @@ import { initialAuthState, initialOAuthConnectedState } from '../../../../common
 import { NotificationService } from '../../../../common/services/NotificationService'
 import { useUserAvatarThumbnail } from '../../../functions/useUserAvatarThumbnail'
 import { AuthService, AuthState } from '../../../services/AuthService'
+import { useUserHasAccessHook } from '../../../userHasAccess'
 import { UserMenus } from '../../../UserUISystem'
 import styles from '../index.module.scss'
 import { PopupMenuServices } from '../PopupMenuService'
@@ -90,8 +91,7 @@ const ProfileMenu = ({ hideLogin, onClose, isPopover }: Props): JSX.Element => {
   const apiKey = selfUser.apiKey?.token?.value
   const isGuest = selfUser.isGuest.value
 
-  const hasAdminAccess =
-    selfUser?.id?.value?.length > 0 && selfUser?.scopes?.value?.find((scope) => scope.type === 'admin:admin')
+  const hasAdminAccess = useUserHasAccessHook('admin:admin')
   const avatarThumbnail = useUserAvatarThumbnail(userId)
 
   useEffect(() => {

--- a/packages/client-core/src/user/components/UserMenu/menus/SettingMenu.tsx
+++ b/packages/client-core/src/user/components/UserMenu/menus/SettingMenu.tsx
@@ -109,8 +109,7 @@ const SettingMenu = ({ isPopover }: Props): JSX.Element => {
   const [clientSetting] = clientSettingState?.client?.value || []
   const userSettings = selfUser.userSetting.value
 
-  const hasAdminAccess =
-    selfUser?.id?.value?.length > 0 && selfUser?.scopes?.value?.find((scope) => scope.type === 'admin:admin')
+  const hasAdminAccess = userHasAccess('admin:admin')
   const hasEditorAccess = userHasAccess('editor:write')
   const themeSettings = { ...defaultThemeSettings, ...clientSetting.themeSettings }
   const themeModes = {

--- a/packages/client-core/src/user/userHasAccess.ts
+++ b/packages/client-core/src/user/userHasAccess.ts
@@ -30,19 +30,11 @@ import { AuthState } from './services/AuthService'
 export const useUserHasAccessHook = (scope: string) => {
   const authState = useHookstate(getMutableState(AuthState))
   const hasScope = authState.value.user?.scopes?.find((r) => r.type === scope)
-  const isAdmin = authState.value.user?.scopes?.find((r) => r.type === 'admin:admin')
-  return Boolean(hasScope || isAdmin)
+  return Boolean(hasScope)
 }
 
 export const userHasAccess = (scope: string) => {
   const authState = getState(AuthState)
   const hasScope = authState.user?.scopes?.find((r) => r.type === scope)
-  const isAdmin = authState.user?.scopes?.find((r) => r.type === 'admin:admin')
-  return Boolean(hasScope || isAdmin)
-}
-
-export const userIsAdmin = () => {
-  const authState = getState(AuthState)
-  const isAdmin = authState.user?.scopes?.find((r) => r.type === 'admin:admin')
-  return Boolean(isAdmin)
+  return Boolean(hasScope)
 }

--- a/packages/editor/src/components/projects/ProjectsPage.tsx
+++ b/packages/editor/src/components/projects/ProjectsPage.tsx
@@ -182,7 +182,7 @@ const ProjectsPage = () => {
   const projectDrawerOpen = useHookstate(false)
   const changeDestination = useHookstate(false)
 
-  const hasWriteAccess = activeProject.value?.hasWriteAccess || userHasAccess('editor:write')
+  const hasWriteAccess = activeProject.value?.hasWriteAccess || userHasAccess('admin:admin')
 
   const authState = useHookstate(getMutableState(AuthState))
   const projectState = useHookstate(getMutableState(ProjectState))

--- a/packages/editor/src/components/projects/ProjectsPage.tsx
+++ b/packages/editor/src/components/projects/ProjectsPage.tsx
@@ -62,7 +62,7 @@ import {
   Paper
 } from '@mui/material'
 
-import { userIsAdmin } from '@etherealengine/client-core/src/user/userHasAccess'
+import { userHasAccess } from '@etherealengine/client-core/src/user/userHasAccess'
 import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { projectPath, ProjectType } from '@etherealengine/engine/src/schemas/projects/project.schema'
 import { getProjects } from '../../functions/projectFunctions'
@@ -182,8 +182,7 @@ const ProjectsPage = () => {
   const projectDrawerOpen = useHookstate(false)
   const changeDestination = useHookstate(false)
 
-  const isAdmin = userIsAdmin()
-  const hasProjectWriteAccess = activeProject.value?.hasWriteAccess || isAdmin
+  const hasWriteAccess = activeProject.value?.hasWriteAccess || userHasAccess('editor:write')
 
   const authState = useHookstate(getMutableState(AuthState))
   const projectState = useHookstate(getMutableState(ProjectState))
@@ -580,7 +579,7 @@ const ProjectsPage = () => {
           {activeProject.value &&
             isInstalled(activeProject.value) &&
             hasRepo(activeProject.value) &&
-            hasProjectWriteAccess && (
+            hasWriteAccess && (
               <MenuItem classes={{ root: styles.filterMenuItem }} onClick={() => handleOpenProjectDrawer(false)}>
                 <Download />
                 {t(`editor.projects.updateFromGithub`)}
@@ -589,7 +588,7 @@ const ProjectsPage = () => {
           {activeProject.value &&
             isInstalled(activeProject.value) &&
             !hasRepo(activeProject.value) &&
-            hasProjectWriteAccess && (
+            hasWriteAccess && (
               <MenuItem classes={{ root: styles.filterMenuItem }} onClick={() => handleOpenProjectDrawer(true)}>
                 <Link />
                 {t(`editor.projects.link`)}
@@ -598,13 +597,13 @@ const ProjectsPage = () => {
           {activeProject.value &&
             isInstalled(activeProject.value) &&
             hasRepo(activeProject.value) &&
-            hasProjectWriteAccess && (
+            hasWriteAccess && (
               <MenuItem classes={{ root: styles.filterMenuItem }} onClick={() => handleOpenProjectDrawer(true)}>
                 <LinkOff />
                 {t(`editor.projects.unlink`)}
               </MenuItem>
             )}
-          {hasProjectWriteAccess && hasRepo(activeProject.value) && (
+          {hasWriteAccess && hasRepo(activeProject.value) && (
             <MenuItem
               classes={{ root: styles.filterMenuItem }}
               onClick={() => activeProject?.value?.id && pushProject(activeProject.value.id)}
@@ -613,7 +612,7 @@ const ProjectsPage = () => {
               {t(`editor.projects.pushToGithub`)}
             </MenuItem>
           )}
-          {isInstalled(activeProject.value) && hasProjectWriteAccess && (
+          {isInstalled(activeProject.value) && hasWriteAccess && (
             <MenuItem classes={{ root: styles.filterMenuItem }} onClick={openDeleteConfirm}>
               {updatingProject.value ? <CircularProgress size={15} className={styles.progressbar} /> : <Delete />}
               {t(`editor.projects.uninstall`)}

--- a/packages/editor/src/components/projects/ProjectsPage.tsx
+++ b/packages/editor/src/components/projects/ProjectsPage.tsx
@@ -182,7 +182,8 @@ const ProjectsPage = () => {
   const projectDrawerOpen = useHookstate(false)
   const changeDestination = useHookstate(false)
 
-  const hasWriteAccess = activeProject.value?.hasWriteAccess || userHasAccess('admin:admin')
+  const hasWriteAccess =
+    activeProject.value?.hasWriteAccess || (userHasAccess('admin:admin') && userHasAccess('projects:write'))
 
   const authState = useHookstate(getMutableState(AuthState))
   const projectState = useHookstate(getMutableState(ProjectState))


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 73ca242</samp>

Refactored the codebase to use the `userHasAccess` function and the `useUserHasAccessHook` hook for checking user permissions based on scopes. This improved the code consistency, flexibility, and readability across various components and files, such as `ProjectTable.tsx`, `UserPermissionDrawer.tsx`, `ProfileMenu.tsx`, `ProjectsPage.tsx`, and `SettingMenu.tsx`. Removed unused or redundant code, such as `userIsAdmin` and `hasProjectWriteAccess`.

## References
refs #9161 

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 73ca242</samp>

*  Refactored the code to use `useUserHasAccessHook` and `userHasAccess` functions to check user permissions based on scopes instead of hard-coded admin roles ([link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-0483cc24b36b60ade3c425269eab2064b7e1d52551ddc6fb4c4eeb6e4b5c2e3dL42-R42), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-a1bf6466372563263b5f30e1697e31af8ea42629d4d0139f2b2e5bef6fd0fb45R48), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-d9ca3cf4f32c9b65ea32012e17bb9870dfa779d981ac2114d56b5189fc3d4a55R58), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-e72b39314a2646b9f88906ef4aab898aac5c9167816cd1ce2192f0ede2adffddL65-R65))
*  Replaced the variable `isAdmin` with `hasProjectWritePermission` in `ProjectTable.tsx`, using the scope `projects:write` for project-related actions such as update, push, invalidate, view, and delete ([link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-0483cc24b36b60ade3c425269eab2064b7e1d52551ddc6fb4c4eeb6e4b5c2e3dL225-R225), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-0483cc24b36b60ade3c425269eab2064b7e1d52551ddc6fb4c4eeb6e4b5c2e3dL273-R273), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-0483cc24b36b60ade3c425269eab2064b7e1d52551ddc6fb4c4eeb6e4b5c2e3dL282-R282), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-0483cc24b36b60ade3c425269eab2064b7e1d52551ddc6fb4c4eeb6e4b5c2e3dL291-R295), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-0483cc24b36b60ade3c425269eab2064b7e1d52551ddc6fb4c4eeb6e4b5c2e3dL315-R315), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-0483cc24b36b60ade3c425269eab2064b7e1d52551ddc6fb4c4eeb6e4b5c2e3dL327-R327), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-0483cc24b36b60ade3c425269eab2064b7e1d52551ddc6fb4c4eeb6e4b5c2e3dL339-R339), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-0483cc24b36b60ade3c425269eab2064b7e1d52551ddc6fb4c4eeb6e4b5c2e3dL351-R351))
*  Changed the variable `selfUserPermission` to use `userHasAccess` with the scope `projects:write` instead of `admin:admin` in `UserPermissionDrawer.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-a1bf6466372563263b5f30e1697e31af8ea42629d4d0139f2b2e5bef6fd0fb45L64-R65))
*  Removed unused imports and variables from `MediaIconsBox/index.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-c1d2de24ab81116538728402fa3ecc78961b7e0c0e8a326a3731d67b51e3f5afL60), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-c1d2de24ab81116538728402fa3ecc78961b7e0c0e8a326a3731d67b51e3f5afL66))
*  Changed the variable `hasAdminAccess` to use `useUserHasAccessHook` with the scope `admin:admin` in `ProfileMenu.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-d9ca3cf4f32c9b65ea32012e17bb9870dfa779d981ac2114d56b5189fc3d4a55L93-R94))
*  Changed the variables `hasAdminAccess` and `hasEditorAccess` to use `userHasAccess` with the scopes `admin:admin` and `editor:write` in `SettingMenu.tsx` ([link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-6832c07b4c6df373746dc8459f04bd37b8ec079b7a664dc8bae84d659b6f6544L114-R114))
*  Changed the functions `useUserHasAccessHook` and `userHasAccess` to return only the result of checking for the given scope, without checking for `admin:admin` as well, in `userHasAccess.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-540c860e0ee3a8ab49b8374ecab2467e98bd5caba8a2f1dc2bc89516332b946bL33-R33), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-540c860e0ee3a8ab49b8374ecab2467e98bd5caba8a2f1dc2bc89516332b946bL40-R40))
*  Removed the unused function `userIsAdmin` from `userHasAccess.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-540c860e0ee3a8ab49b8374ecab2467e98bd5caba8a2f1dc2bc89516332b946bL40-R40))
*  Replaced the variable `isAdmin` with `hasWriteAccess` in `ProjectsPage.tsx`, using the scope `editor:write` for editor-related actions such as download, link, unlink, pull, and delete projects ([link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-e72b39314a2646b9f88906ef4aab898aac5c9167816cd1ce2192f0ede2adffddL184-R184), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-e72b39314a2646b9f88906ef4aab898aac5c9167816cd1ce2192f0ede2adffddL578-R577), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-e72b39314a2646b9f88906ef4aab898aac5c9167816cd1ce2192f0ede2adffddL587-R586), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-e72b39314a2646b9f88906ef4aab898aac5c9167816cd1ce2192f0ede2adffddL596-R595), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-e72b39314a2646b9f88906ef4aab898aac5c9167816cd1ce2192f0ede2adffddL602-R601), [link](https://github.com/EtherealEngine/etherealengine/pull/9185/files?diff=unified&w=0#diff-e72b39314a2646b9f88906ef4aab898aac5c9167816cd1ce2192f0ede2adffddL611-R610))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 73ca242</samp>

> _`userHasAccess`_
> _checks scopes for permissions_
> _refactoring code_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
