### PR TITLE
do not show empty brackets when no asset resource is selected

### DIFF
--- a/packages/editor/src/components/assets/AssetsPreviewPanel.tsx
+++ b/packages/editor/src/components/assets/AssetsPreviewPanel.tsx
@@ -160,11 +160,15 @@ export const AssetsPreviewPanel = React.forwardRef(({ hideHeading }: Props, ref)
     }
   }
 
+  console.log('debug1 the preview panel resource props', previewPanel.resourceProps)
+
   return (
     <>
       {!hideHeading && (
         <div style={assetHeadingStyles as React.CSSProperties}>
-          {`${previewPanel.resourceProps.name} (${previewPanel.resourceProps.size})`}{' '}
+          {previewPanel.resourceProps.name &&
+            previewPanel.resourceProps.size &&
+            `${previewPanel.resourceProps.name} (${previewPanel.resourceProps.size})`}
         </div>
       )}
       {previewPanel.PreviewSource && <previewPanel.PreviewSource resourceProps={previewPanel.resourceProps} />}

--- a/packages/editor/src/components/assets/AssetsPreviewPanel.tsx
+++ b/packages/editor/src/components/assets/AssetsPreviewPanel.tsx
@@ -160,8 +160,6 @@ export const AssetsPreviewPanel = React.forwardRef(({ hideHeading }: Props, ref)
     }
   }
 
-  console.log('debug1 the preview panel resource props', previewPanel.resourceProps)
-
   return (
     <>
       {!hideHeading && (


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d5f6ec0</samp>

Added debugging and error handling to `AssetsPreviewPanel.tsx` to fix a bug with missing asset previews.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d5f6ec0</samp>

*  Added a console log and a conditional check to fix the preview panel bug ([link](https://github.com/EtherealEngine/etherealengine/pull/9186/files?diff=unified&w=0#diff-d6f3837d733aa181bf834ec146bff20f596b2c73dff6f256ce24be0408f40ae0L163-R171))
*  Prevented rendering the asset name and size if they are undefined or null ([link](https://github.com/EtherealEngine/etherealengine/pull/9186/files?diff=unified&w=0#diff-d6f3837d733aa181bf834ec146bff20f596b2c73dff6f256ce24be0408f40ae0L163-R171))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d5f6ec0</samp>

> _`console.log` helps_
> _debug preview panel props_
> _avoid null errors_

## QA Steps

**Before**

![ffd3778ec176094a9e00da4b448ff3a1](https://github.com/EtherealEngine/etherealengine/assets/55396651/48002c50-0863-49b6-ab84-ac9619f064df)

![406f0eb21163267330d72dfb436411ef](https://github.com/EtherealEngine/etherealengine/assets/55396651/390fe47d-3813-43f2-806f-615a3e68ebe9)

**After**

![image](https://github.com/EtherealEngine/etherealengine/assets/55396651/6154bdc6-549a-460d-b353-1017c95ae180)

![image](https://github.com/EtherealEngine/etherealengine/assets/55396651/a47b1bd2-64d2-481c-8ac4-ef78efa7cfee)



## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
