### PR TITLE
Fixed server-side meshopt_decoder Worker call.

### DIFF
--- a/packages/engine/src/assets/loaders/gltf/meshopt_decoder.module.js
+++ b/packages/engine/src/assets/loaders/gltf/meshopt_decoder.module.js
@@ -97,7 +97,7 @@ var MeshoptDecoder = (function() {
 
 	function initWorkers(count) {
 		var source =
-			"data:application/javascript,var instance; var ready = WebAssembly.instantiate(new Uint8Array([" + new Uint8Array(unpack(wasm)) + "]), {})" +
+			"data:text/javascript,var instance; var ready = WebAssembly.instantiate(new Uint8Array([" + new Uint8Array(unpack(wasm)) + "]), {})" +
 			".then(function(result) { instance = result.instance; instance.exports.__wasm_call_ctors(); });" +
 			"self.onmessage = workerProcess;" + 
 			`function decode(fun, target, count, size, source, filter) {

--- a/packages/engine/src/assets/loaders/gltf/meshopt_decoder.module.js
+++ b/packages/engine/src/assets/loaders/gltf/meshopt_decoder.module.js
@@ -1,5 +1,6 @@
 // This file is part of meshoptimizer library and is distributed under the terms of MIT License.
 // Copyright (C) 2016-2022, by Arseny Kapoulkine (arseny.kapoulkine@gmail.com)
+import Worker from 'web-worker'
 var MeshoptDecoder = (function() {
 	"use strict";
 
@@ -96,7 +97,7 @@ var MeshoptDecoder = (function() {
 
 	function initWorkers(count) {
 		var source =
-			"var instance; var ready = WebAssembly.instantiate(new Uint8Array([" + new Uint8Array(unpack(wasm)) + "]), {})" +
+			"data:application/javascript,var instance; var ready = WebAssembly.instantiate(new Uint8Array([" + new Uint8Array(unpack(wasm)) + "]), {})" +
 			".then(function(result) { instance = result.instance; instance.exports.__wasm_call_ctors(); });" +
 			"self.onmessage = workerProcess;" + 
 			`function decode(fun, target, count, size, source, filter) {
@@ -129,14 +130,9 @@ var MeshoptDecoder = (function() {
 			});
 		}`;
 
-		var blob = new Blob([source], {type: 'text/javascript'});
-		var url = URL.createObjectURL(blob);
-
 		for (var i = 0; i < count; ++i) {
-			workers[i] = createWorker(url);
+			workers[i] = createWorker(source);
 		}
-
-		URL.revokeObjectURL(url);
 	}
 
 	function decodeWorker(count, size, source, mode, filter) {

--- a/packages/instanceserver/src/NetworkFunctions.ts
+++ b/packages/instanceserver/src/NetworkFunctions.ts
@@ -324,7 +324,8 @@ export async function handleDisconnect(network: SocketWebRTCServerNetwork, peerI
         {
           instanceId: instanceServerState.instance.id,
           text: `${userName} left`,
-          isNotification: true
+          isNotification: true,
+          senderId: userId
         },
         {
           [identityProviderPath]: {

--- a/packages/server-core/src/social/message/message.ts
+++ b/packages/server-core/src/social/message/message.ts
@@ -60,7 +60,7 @@ export default (app: Application): void => {
   const onCRUD =
     (app: Application) =>
     async (data: MessageType): Promise<any> => {
-      if (!data.sender) {
+      if (!data.sender && data.senderId) {
         data.sender = await app.service(userPath).get(data.senderId)
       }
       const channelUsers = (await app.service(channelUserPath).find({


### PR DESCRIPTION
## Summary
Backend running of meshopt_decoder was failing because of lack of Worker in node. now polyfilling it with web-worker like we do with other uses of Worker. Had to change meshopt_decoder Blob URL to Data URL since web-worker does not appear to work with Blob URLs despite the documentation saying it does.

Added senderId to 'user left instance' message to avoid a bug. Message onCRUD expects a senderId if sender is not present. Added a check for senderId in onCRUD just in case it isn't.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c7de3ae</samp>

This pull request improves the performance and reliability of `gltf` asset loading, network communication, and message handling. It simplifies the web worker creation for meshopt decoding, adds the senderId to the disconnect message, and checks the senderId before fetching the sender data.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c7de3ae</samp>

*  Enable creating web workers from data URLs instead of blobs in `meshopt_decoder.module.js` ([link](https://github.com/EtherealEngine/etherealengine/pull/9187/files?diff=unified&w=0#diff-a919baeba37a7716a7ffafc5134b5484e107fd5c0811a1813e17672b7770f264R3), [link](https://github.com/EtherealEngine/etherealengine/pull/9187/files?diff=unified&w=0#diff-a919baeba37a7716a7ffafc5134b5484e107fd5c0811a1813e17672b7770f264L99-R100), [link](https://github.com/EtherealEngine/etherealengine/pull/9187/files?diff=unified&w=0#diff-a919baeba37a7716a7ffafc5134b5484e107fd5c0811a1813e17672b7770f264L132-R135))
*  Add senderId property to the disconnect message in `NetworkFunctions.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9187/files?diff=unified&w=0#diff-4b6d0fcf01661321157ffc938c90143772b61022c88eba2140824700b046bdc6L327-R328))
*  Check for senderId existence before fetching sender data in `message.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9187/files?diff=unified&w=0#diff-e9e6f7c790f2601f9f907ec882e9ff93948ccbe47319d7436d6bd6052a25ff44L63-R63))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c7de3ae</samp>

> _`senderId` added_
> _to disconnect messages_
> _who left the instance?_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
