### PR TITLE
Fix issue where instanceserver was breaking on dev

### DIFF
--- a/packages/engine/src/scene/components/LinkComponent.ts
+++ b/packages/engine/src/scene/components/LinkComponent.ts
@@ -72,6 +72,7 @@ const linkLogic = (linkComponent, xrState) => {
 }
 
 const vec3 = new Vector3()
+const interactMessage = 'Click to follow'
 const onLinkInteractUpdate = (entity: Entity, xrui: ReturnType<typeof createInteractUI>) => {
   const transform = getComponent(xrui.entity, TransformComponent)
   if (!transform || !hasComponent(Engine.instance.localClientEntity, TransformComponent)) return
@@ -187,7 +188,7 @@ export const LinkComponent = defineComponent({
       setComponent(entity, BoundingBoxComponent)
       setComponent(entity, InputComponent, { highlight: true, grow: true })
       if (!getState(EngineState).isEditor) {
-        addInteractableUI(entity, createNonInteractUI(entity, 'Click to follow'), onLinkInteractUpdate)
+        addInteractableUI(entity, createNonInteractUI(entity, interactMessage), onLinkInteractUpdate)
       }
     }, [])
 

--- a/packages/engine/src/scene/components/LinkComponent.ts
+++ b/packages/engine/src/scene/components/LinkComponent.ts
@@ -25,7 +25,6 @@ Ethereal Engine. All Rights Reserved.
 
 import { defineState, getMutableState, getState } from '@etherealengine/hyperflux'
 import { useEffect } from 'react'
-import { useTranslation } from 'react-i18next'
 import { MathUtils, MeshBasicMaterial, Vector3 } from 'three'
 import { getAvatarBoneWorldPosition } from '../../avatar/functions/avatarFunctions'
 import { matches } from '../../common/functions/MatchesUtils'
@@ -161,7 +160,6 @@ export const LinkComponent = defineComponent({
     const entity = useEntityContext()
     const link = useComponent(entity, LinkComponent)
     const input = useOptionalComponent(entity, InputComponent)
-    const { t } = useTranslation()
 
     useEffect(() => {
       if (getState(EngineState).isEditor || !input) return
@@ -189,7 +187,7 @@ export const LinkComponent = defineComponent({
       setComponent(entity, BoundingBoxComponent)
       setComponent(entity, InputComponent, { highlight: true, grow: true })
       if (!getState(EngineState).isEditor) {
-        addInteractableUI(entity, createNonInteractUI(entity, t('common:interactables.link')), onLinkInteractUpdate)
+        addInteractableUI(entity, createNonInteractUI(entity, 'Click to follow'), onLinkInteractUpdate)
       }
     }, [])
 


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 71e0bce</samp>

Removed translation logic from `LinkComponent` to fix rendering bugs. Simplified the UI text for the link component.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 71e0bce</samp>

*  Simplified the UI text for the link component and removed the dependency on the translation function ([link](https://github.com/EtherealEngine/etherealengine/pull/9192/files?diff=unified&w=0#diff-158aff3a00178c22e020894b7350b017587e0349bfd5365a51365aad3ba6b6e6L28), [link](https://github.com/EtherealEngine/etherealengine/pull/9192/files?diff=unified&w=0#diff-158aff3a00178c22e020894b7350b017587e0349bfd5365a51365aad3ba6b6e6L164), [link](https://github.com/EtherealEngine/etherealengine/pull/9192/files?diff=unified&w=0#diff-158aff3a00178c22e020894b7350b017587e0349bfd5365a51365aad3ba6b6e6L192-R190))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 71e0bce</samp>

> _Sing, O Muse, of the skillful coder who removed_
> _The troublesome hook and the function of speech_
> _From the file of the link, and made the text plain_
> _To fix the display and the logic of the page._

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
