### PR TITLE
Fix instance-provision responsiveness check

### DIFF
--- a/packages/server-core/src/networking/instance-provision/instance-provision.class.ts
+++ b/packages/server-core/src/networking/instance-provision/instance-provision.class.ts
@@ -320,14 +320,15 @@ export async function checkForDuplicatedAssignments({
   // it assumes the pod is unresponsive. Locally, it just waits half a second and tries again - if the local
   // instanceservers are rebooting after the last person left, we just need to wait a bit for them to start.
   // In production, it attempts to delete that pod via the K8s API client and tries again.
+  let retry = true
   const responsivenessCheck = await Promise.race([
     new Promise<boolean>((resolve) => {
       setTimeout(() => {
-        logger.warn(`Instanceserver at ${ipAddress} too long to respond, assuming it is unresponsive and killing`)
+        retry = false
         resolve(false)
       }, config.server.instanceserverUnreachableTimeoutSeconds * 1000) // timeout after 2 seconds
     }),
-    new Promise<boolean>((resolve) => {
+    new Promise<boolean>(async (resolve) => {
       const options = {} as any
       let protocol = 'http://'
       if (!config.kubernetes.enabled) {
@@ -337,17 +338,21 @@ export async function checkForDuplicatedAssignments({
         })
       }
 
-      fetch(protocol + ipAddress, options)
-        .then((result) => {
+      // try fetching several times until it works, or timeout
+      while (retry) {
+        try {
+          await fetch(protocol + ipAddress, options)
           resolve(true)
-        })
-        .catch((err) => {
-          logger.error(err)
-          resolve(false)
-        })
+        } catch (e) {
+          // wait and try again
+          await new Promise((resolve) => setTimeout(() => resolve(null), 500))
+        }
+      }
     })
   ])
+
   if (!responsivenessCheck) {
+    logger.warn(`Instanceserver at ${ipAddress} too long to respond, assuming it is unresponsive and killing`)
     await app.service(instancePath).remove(assignResult.id)
     const k8DefaultClient = getState(ServerState).k8DefaultClient
     if (config.kubernetes.enabled)


### PR DESCRIPTION
## Summary
Responsiveness check often gets stuck in restart loops in local dev, because the fetch until timeout logic was incorrect. This fixes the problem. 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c92a203</samp>

This pull request refactors the instance server status fetching logic in `instance-provision.class.ts` to use a retry mechanism with `await`. This simplifies the code and reduces warnings.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c92a203</samp>

*  Add a `retry` variable to control the fetch loop of instance server status ([link](https://github.com/EtherealEngine/etherealengine/pull/9196/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dL323-R331))
*  Replace the `fetch` call with a `while` loop that uses `await` and checks the `retry` variable ([link](https://github.com/EtherealEngine/etherealengine/pull/9196/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dL340-R355))
*  Move the warning log message to the end of the `instance-provision.class.ts` file, where the unresponsive instance server is removed ([link](https://github.com/EtherealEngine/etherealengine/pull/9196/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dL340-R355))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c92a203</samp>

> _To fetch the server status with grace_
> _We use a `retry` variable in place_
> _With a `while` loop we wait_
> _And avoid warnings we hate_
> _Making the code more readable and clear in this case_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
