### PR TITLE
Compile Async for Model Component

### DIFF
--- a/packages/engine/src/scene/components/ModelComponent.ts
+++ b/packages/engine/src/scene/components/ModelComponent.ts
@@ -176,8 +176,6 @@ function ModelReactor() {
               if (fileExtension == 'vrm') (model.asset as any).userData = { flipped: true }
               model.scene && removeObjectFromGroup(entity, model.scene)
               modelComponent.scene.set(loadedAsset.scene)
-              if (!hasComponent(entity, SceneAssetPendingTagComponent)) return
-              removeComponent(entity, SceneAssetPendingTagComponent)
             },
             (onprogress) => {
               if (!hasComponent(entity, SceneAssetPendingTagComponent)) return

--- a/packages/engine/src/scene/components/ModelComponent.ts
+++ b/packages/engine/src/scene/components/ModelComponent.ts
@@ -32,6 +32,8 @@ import { VRM } from '@pixiv/three-vrm'
 import { AssetLoader } from '../../assets/classes/AssetLoader'
 import { GLTF } from '../../assets/loaders/gltf/GLTFLoader'
 import { LoopAnimationComponent } from '../../avatar/components/LoopAnimationComponent'
+import { CameraComponent } from '../../camera/components/CameraComponent'
+import { Engine } from '../../ecs/classes/Engine'
 import { EngineState } from '../../ecs/classes/EngineState'
 import {
   ComponentType,
@@ -47,6 +49,7 @@ import {
 import { entityExists, useEntityContext } from '../../ecs/functions/EntityFunctions'
 import { removeEntityNodeRecursively } from '../../ecs/functions/EntityTree'
 import { BoundingBoxComponent } from '../../interaction/components/BoundingBoxComponents'
+import { EngineRenderer } from '../../renderer/WebGLRendererSystem'
 import { SourceType } from '../../renderer/materials/components/MaterialSource'
 import { removeMaterialSource } from '../../renderer/materials/functions/MaterialLibraryFunctions'
 import { FrustumCullCameraComponent } from '../../transform/components/DistanceComponents'
@@ -206,6 +209,12 @@ function ModelReactor() {
 
     if (!scene) return
     addObjectToGroup(entity, scene)
+
+    EngineRenderer.instance.renderer
+      .compileAsync(scene, getComponent(Engine.instance.cameraEntity, CameraComponent), Engine.instance.scene)
+      .then(() => {
+        if (hasComponent(entity, SceneAssetPendingTagComponent)) removeComponent(entity, SceneAssetPendingTagComponent)
+      })
 
     if (groupComponent?.value?.find((group: any) => group === scene)) return
 


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc10169</samp>

Improved model loading performance and readiness detection by pre-compiling scenes and cameras for `ModelComponent` entities and removing `SceneAssetPendingTagComponent`.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fc10169</samp>

* Import camera and engine modules to access scene and camera entities ([link](https://github.com/EtherealEngine/etherealengine/pull/9203/files?diff=unified&w=0#diff-daae2524b717be2ba24820c9515621d8714efd6e8d8bed8493853a425dc305cdR35-R36))
* Import renderer module to access renderer system ([link](https://github.com/EtherealEngine/etherealengine/pull/9203/files?diff=unified&w=0#diff-daae2524b717be2ba24820c9515621d8714efd6e8d8bed8493853a425dc305cdR52))
* Call renderer's compileAsync method to improve model loading performance and remove pending tag ([link](https://github.com/EtherealEngine/etherealengine/pull/9203/files?diff=unified&w=0#diff-daae2524b717be2ba24820c9515621d8714efd6e8d8bed8493853a425dc305cdR213-R218))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fc10169</samp>

> _We'll load the models faster than before_
> _By pre-compiling the scene and camera_
> _Heave away, me hearties, heave away_
> _And remove the `SceneAssetPendingTagComponent` when we're done_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
