### PR TITLE
Move PeerID to hyperflux store

### DIFF
--- a/packages/client/src/engine.tsx
+++ b/packages/client/src/engine.tsx
@@ -25,12 +25,10 @@ Ethereal Engine. All Rights Reserved.
 
 import React, { createRef, Suspense } from 'react'
 import { useTranslation } from 'react-i18next'
-import { v4 as uuidv4 } from 'uuid'
 
 import { API } from '@etherealengine/client-core/src/API'
 import { FullscreenContainer } from '@etherealengine/client-core/src/components/FullscreenContainer'
 import { LoadingCircle } from '@etherealengine/client-core/src/components/LoadingCircle'
-import { PeerID } from '@etherealengine/common/src/interfaces/PeerID'
 import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { EngineState } from '@etherealengine/engine/src/ecs/classes/EngineState'
 import { initializeBrowser } from '@etherealengine/engine/src/initializeBrowser'
@@ -41,7 +39,6 @@ import { pipeLogs } from '@etherealengine/engine/src/common/functions/logger'
 import { initializei18n } from './util'
 
 createEngine()
-Engine.instance.peerID = uuidv4() as PeerID
 getMutableState(EngineState).publicPath.set(
   // @ts-ignore
   import.meta.env.BASE_URL === '/client/' ? location.origin : import.meta.env.BASE_URL!.slice(0, -1) // remove trailing '/'

--- a/packages/client/src/engine_tw.tsx
+++ b/packages/client/src/engine_tw.tsx
@@ -23,10 +23,7 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { v4 as uuidv4 } from 'uuid'
-
 import { API } from '@etherealengine/client-core/src/API'
-import { PeerID } from '@etherealengine/common/src/interfaces/PeerID'
 import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
 import { EngineState } from '@etherealengine/engine/src/ecs/classes/EngineState'
 import { initializeBrowser } from '@etherealengine/engine/src/initializeBrowser'
@@ -37,7 +34,6 @@ import { pipeLogs } from '@etherealengine/engine/src/common/functions/logger'
 import { initializei18n } from './util'
 
 createEngine()
-Engine.instance.peerID = uuidv4() as PeerID
 getMutableState(EngineState).publicPath.set(
   // @ts-ignore
   import.meta.env.BASE_URL === '/client/' ? location.origin : import.meta.env.BASE_URL!.slice(0, -1) // remove trailing '/'

--- a/packages/engine/src/avatar/functions/moveAvatar.test.ts
+++ b/packages/engine/src/avatar/functions/moveAvatar.test.ts
@@ -27,7 +27,6 @@ import { strictEqual } from 'assert'
 import { Quaternion, Vector3 } from 'three'
 
 import { EntityUUID } from '@etherealengine/common/src/interfaces/EntityUUID'
-import { PeerID } from '@etherealengine/common/src/interfaces/PeerID'
 import { UserID } from '@etherealengine/engine/src/schemas/user/user.schema'
 import {
   applyIncomingActions,
@@ -58,7 +57,6 @@ describe('moveAvatar function tests', () => {
     Engine.instance.store.defaultDispatchDelay = () => 0
     getMutableState(PhysicsState).physicsWorld.set(Physics.createWorld())
     Engine.instance.userID = 'userId' as UserID
-    Engine.instance.peerID = 'peerID' as PeerID
   })
 
   afterEach(() => {

--- a/packages/engine/src/avatar/functions/spawnAvatarReceptor.test.ts
+++ b/packages/engine/src/avatar/functions/spawnAvatarReceptor.test.ts
@@ -27,7 +27,6 @@ import assert, { strictEqual } from 'assert'
 import { Quaternion, Vector3 } from 'three'
 
 import { EntityUUID } from '@etherealengine/common/src/interfaces/EntityUUID'
-import { PeerID } from '@etherealengine/common/src/interfaces/PeerID'
 import { UserID } from '@etherealengine/engine/src/schemas/user/user.schema'
 import {
   applyIncomingActions,
@@ -64,7 +63,6 @@ describe('spawnAvatarReceptor', () => {
     Engine.instance.store.defaultDispatchDelay = () => 0
     getMutableState(PhysicsState).physicsWorld.set(Physics.createWorld())
     Engine.instance.userID = 'user' as UserID
-    Engine.instance.peerID = 'peerID' as PeerID
   })
 
   afterEach(() => {

--- a/packages/engine/src/ecs/classes/Engine.ts
+++ b/packages/engine/src/ecs/classes/Engine.ts
@@ -37,7 +37,6 @@ import type { FeathersApplication } from '@feathersjs/feathers'
 import { Group, Object3D, Scene } from 'three'
 
 import type { ServiceTypes } from '@etherealengine/common/declarations'
-import { PeerID } from '@etherealengine/common/src/interfaces/PeerID'
 
 import { getAllEntities } from 'bitecs'
 import { Timer } from '../../common/functions/Timer'
@@ -57,7 +56,9 @@ export class Engine {
   userID: UserID
 
   /** The peerID of the logged-in user */
-  peerID: PeerID
+  get peerID() {
+    return Engine.instance.store.peerID
+  }
 
   store = createHyperStore({
     forwardIncomingActions: (action) => {

--- a/packages/engine/src/ecs/classes/Engine.ts
+++ b/packages/engine/src/ecs/classes/Engine.ts
@@ -55,7 +55,10 @@ export class Engine {
   /** The uuid of the logged-in user */
   userID: UserID
 
-  /** The peerID of the logged-in user */
+  /**
+   * The peerID of the logged-in user
+   * @deprecated - use Engine.instance.store.peerID instead
+   */
   get peerID() {
     return Engine.instance.store.peerID
   }

--- a/packages/engine/src/interaction/systems/GrabbableSystem.test.ts
+++ b/packages/engine/src/interaction/systems/GrabbableSystem.test.ts
@@ -85,7 +85,7 @@ describe.skip('EquippableSystem Integration Tests', () => {
 
     addComponent(player, NetworkObjectComponent, {
       ownerId: Engine.instance.userID,
-      authorityPeerID: 'peer id' as PeerID,
+      authorityPeerID: Engine.instance.peerID,
       networkId: 0 as NetworkId
     })
     const networkObject = getComponent(player, NetworkObjectComponent)

--- a/packages/engine/src/networking/functions/NetworkPeerFunctions.test.ts
+++ b/packages/engine/src/networking/functions/NetworkPeerFunctions.test.ts
@@ -59,9 +59,8 @@ describe('NetworkPeerFunctions', () => {
   describe('addPeers', () => {
     it('should add peer', () => {
       const userId = 'user id' as UserID
-      const peerID = 'peer id' as PeerID
+      const peerID = Engine.instance.store.peerID
       Engine.instance.userID = 'another user id' as UserID
-      Engine.instance.peerID = peerID
       const userName = 'user name'
       const userIndex = 1
       const peerIndex = 2
@@ -85,9 +84,8 @@ describe('NetworkPeerFunctions', () => {
 
     it('should update peer if it already exists', () => {
       const userId = 'user id' as UserID
-      const peerID = 'peer id' as PeerID
+      const peerID = Engine.instance.store.peerID
       Engine.instance.userID = 'another user id' as UserID
-      Engine.instance.peerID = peerID
       const userName = 'user name'
       const userName2 = 'user name 2'
       const userIndex = 1
@@ -119,7 +117,6 @@ describe('NetworkPeerFunctions', () => {
       const userId = 'user id' as UserID
       const peerID = 'peer id' as PeerID
       Engine.instance.userID = 'another user id' as UserID
-      Engine.instance.peerID = 'another peer id' as PeerID
       const userName = 'user name'
       const userIndex = 1
       const peerIndex = 2
@@ -138,9 +135,8 @@ describe('NetworkPeerFunctions', () => {
 
     it('should not remove self peer', () => {
       const userId = 'user id' as UserID
-      const peerID = 'peer id' as PeerID
+      const peerID = Engine.instance.store.peerID
       Engine.instance.userID = 'another user id' as UserID
-      Engine.instance.peerID = peerID
       const userName = 'user name'
       const userIndex = 1
       const peerIndex = 2
@@ -159,9 +155,8 @@ describe('NetworkPeerFunctions', () => {
 
     it('should remove peer and owned network objects', () => {
       const userId = 'world' as UserID & InstanceID
-      const peerID = 'peer id' as PeerID
+      const anotherPeerID = 'another peer id' as PeerID
       Engine.instance.userID = 'another user id' as UserID
-      Engine.instance.peerID = 'another peer id' as PeerID
       const userName = 'user name'
       const userIndex = 1
       const peerIndex = 5
@@ -169,20 +164,20 @@ describe('NetworkPeerFunctions', () => {
       network.hostId = Engine.instance.userID
       getMutableState(NetworkState).hostIds.world.set(userId)
 
-      NetworkPeerFunctions.createPeer(network, peerID, peerIndex, userId, userIndex, userName)
+      NetworkPeerFunctions.createPeer(network, anotherPeerID, peerIndex, userId, userIndex, userName)
       const networkId = 2 as NetworkId
 
       const entity = createEntity()
       setComponent(entity, NetworkObjectComponent, {
         ownerId: userId,
-        authorityPeerID: peerID,
+        authorityPeerID: anotherPeerID,
         networkId
       })
       setComponent(entity, UUIDComponent, 'entity_uuid' as EntityUUID)
 
       // process remove actions and execute entity removal
       Engine.instance.store.defaultDispatchDelay = () => 0
-      NetworkPeerFunctions.destroyPeer(network, peerID)
+      NetworkPeerFunctions.destroyPeer(network, anotherPeerID)
 
       applyIncomingActions()
       receiveActions(EntityNetworkState)

--- a/packages/engine/src/networking/serialization/DataReader.test.ts
+++ b/packages/engine/src/networking/serialization/DataReader.test.ts
@@ -761,9 +761,8 @@ describe('DataReader', () => {
     const network = NetworkState.worldNetwork as Network
 
     Engine.instance.userID = 'userId' as UserID
-    Engine.instance.peerID = 'peer' as PeerID
     const userId = Engine.instance.userID
-    const peerID = 'peerID' as PeerID
+    const peerID = Engine.instance.store.peerID
     const userIndex = 0
     const peerIndex = 0
     network.userIndexToUserID[userIndex] = userId
@@ -960,8 +959,7 @@ describe('DataReader', () => {
     const network = NetworkState.worldNetwork as Network
     const engineState = getMutableState(EngineState)
     engineState.simulationTime.set(1)
-    const peerID = 'peerID' as PeerID
-    Engine.instance.peerID = peerID
+    const peerID = Engine.instance.store.peerID
 
     const n = 10
     const entities: Entity[] = Array(n)

--- a/packages/engine/src/networking/serialization/DataWriter.test.ts
+++ b/packages/engine/src/networking/serialization/DataWriter.test.ts
@@ -436,8 +436,7 @@ describe('DataWriter', () => {
 
   it('should writeEntities', () => {
     const writeView = createViewCursor()
-    const peerID = 'peerID' as PeerID
-    Engine.instance.peerID = peerID
+    const peerID = Engine.instance.store.peerID
 
     const n = 5
     const entities: Entity[] = Array(n)
@@ -527,8 +526,7 @@ describe('DataWriter', () => {
   })
 
   it('should createDataWriter', () => {
-    const peerID = 'peerID' as PeerID
-    Engine.instance.peerID = peerID
+    const peerID = Engine.instance.store.peerID
 
     const write = createDataWriter()
 

--- a/packages/engine/src/networking/state/EntityNetworkState.test.ts
+++ b/packages/engine/src/networking/state/EntityNetworkState.test.ts
@@ -75,12 +75,11 @@ describe('EntityNetworkState', () => {
     it('should spawn object owned by host', () => {
       const hostUserId = 'world' as UserID
       const userId = 'user id' as UserID
-      const peerID = 'peer id' as PeerID
+      const peerID = Engine.instance.store.peerID
       const peerID2 = 'peer id 2' as PeerID
 
       Engine.instance.userID = userId
       const network = NetworkState.worldNetwork as Network
-      Engine.instance.peerID = peerID
 
       NetworkPeerFunctions.createPeer(network, peerID, 0, hostUserId, 0, 'host')
       NetworkPeerFunctions.createPeer(network, peerID2, 1, userId, 1, 'user name')
@@ -120,12 +119,11 @@ describe('EntityNetworkState', () => {
       const userId = 'user id' as UserID
       const hostId = 'host' as UserID
       const peerID = 'peer id' as PeerID
-      const peerID2 = 'peer id 2' as PeerID
+      const peerID2 = Engine.instance.store.peerID
 
       Engine.instance.userID = userId
 
       const network = NetworkState.worldNetwork as Network
-      Engine.instance.peerID = peerID2
 
       NetworkPeerFunctions.createPeer(network, peerID, 0, hostId, 0, 'host')
       NetworkPeerFunctions.createPeer(network, peerID2, 1, userId, 1, 'user name')
@@ -165,13 +163,12 @@ describe('EntityNetworkState', () => {
       const hostUserId = 'world' as UserID
       const userId = 'user id' as UserID
       const userId2 = 'second user id' as UserID
-      const peerID = 'peer id' as PeerID
+      const peerID = Engine.instance.store.peerID
       const peerID2 = 'peer id 2' as PeerID
       const peerID3 = 'peer id 3' as PeerID
 
       Engine.instance.userID = userId
       const network = NetworkState.worldNetwork as Network
-      Engine.instance.peerID = peerID
 
       NetworkPeerFunctions.createPeer(network, peerID, 0, hostUserId, 0, 'world')
       NetworkPeerFunctions.createPeer(network, peerID2, 1, userId, 1, 'user name')
@@ -209,11 +206,10 @@ describe('EntityNetworkState', () => {
 
     it('should spawn avatar owned by user', async () => {
       const userId = 'user id' as UserID
-      const peerID = 'peer id' as PeerID
+      const peerID = Engine.instance.store.peerID
 
       Engine.instance.userID = userId
       const network = NetworkState.worldNetwork as Network
-      Engine.instance.peerID = peerID
 
       NetworkPeerFunctions.createPeer(network, peerID, 1, userId, 1, 'user name')
 
@@ -244,12 +240,11 @@ describe('EntityNetworkState', () => {
       const hostUserId = 'world' as UserID
       const hostPeerId = 'host peer id' as PeerID
       const userId = 'user id' as UserID
-      const peerID = 'peer id' as PeerID
+      const peerID = Engine.instance.store.peerID
       const peerID2 = 'peer id 2' as PeerID
 
       Engine.instance.userID = userId
       const network = NetworkState.worldNetwork as Network
-      Engine.instance.peerID = peerID
 
       NetworkPeerFunctions.createPeer(network, hostPeerId, 0, hostUserId, 0, 'host')
       NetworkPeerFunctions.createPeer(network, peerID, 0, userId, 1, 'user name')
@@ -318,12 +313,11 @@ describe('EntityNetworkState', () => {
     const hostUserId = 'world' as UserID
     const hostPeerId = 'host peer id' as PeerID
     const userId = 'user id' as UserID
-    const peerID = 'peer id' as PeerID
+    const peerID = Engine.instance.store.peerID
     const peerID2 = 'peer id 2' as PeerID
 
     Engine.instance.userID = userId // user being the action dispatcher
     const network = NetworkState.worldNetwork as Network
-    Engine.instance.peerID = peerID
 
     NetworkPeerFunctions.createPeer(network, hostPeerId, 0, hostUserId, 0, 'host')
     NetworkPeerFunctions.createPeer(network, peerID, 0, userId, 1, 'user name')

--- a/packages/hyperflux/functions/ActionFunctions.ts
+++ b/packages/hyperflux/functions/ActionFunctions.ts
@@ -302,10 +302,10 @@ function defineAction<Shape extends ActionShape<Action>>(actionShape: Shape) {
  */
 const dispatchAction = <A extends Action>(action: A) => {
   const storeId = HyperFlux.store.getDispatchId()
-  const agentId = HyperFlux.store.getPeerId()
+  const agentId = HyperFlux.store.peerID
 
   action.$from = action.$from ?? (storeId as UserID)
-  action.$peer = action.$peer ?? (agentId as PeerID)
+  action.$peer = action.$peer ?? agentId
   action.$to = action.$to ?? 'all'
   action.$time = action.$time ?? HyperFlux.store.getDispatchTime() + HyperFlux.store.defaultDispatchDelay()
   action.$cache = action.$cache ?? false

--- a/packages/hyperflux/functions/StoreFunctions.ts
+++ b/packages/hyperflux/functions/StoreFunctions.ts
@@ -25,7 +25,9 @@ Ethereal Engine. All Rights Reserved.
 
 import { Downgraded, State } from '@hookstate/core'
 import { merge } from 'lodash'
+import { v4 as uuidv4 } from 'uuid'
 
+import { PeerID } from '@etherealengine/common/src/interfaces/PeerID'
 import { ActionQueueDefinition, addOutgoingTopicIfNecessary, ResolvedActionType, Topic } from './ActionFunctions'
 import { ReactorRoot } from './ReactorFunctions'
 
@@ -46,9 +48,9 @@ export interface HyperStore {
    * */
   getDispatchId: () => string
   /**
-   * A function which returns the agent id assigned to actions
+   * The agent id
    */
-  getPeerId: () => string
+  peerID: PeerID
   /**
    * A function which returns the current dispatch time (units are arbitrary)
    */
@@ -120,7 +122,7 @@ export function createHyperStore(options: {
     getDispatchTime: options.getDispatchTime,
     getCurrentReactorRoot: options.getCurrentReactorRoot ?? (() => null),
     defaultDispatchDelay: options.defaultDispatchDelay ?? (() => 0),
-
+    peerID: uuidv4() as PeerID,
     stateMap: {},
     valueMap: {},
     actions: {

--- a/packages/instanceserver/src/channels.ts
+++ b/packages/instanceserver/src/channels.ts
@@ -28,7 +28,6 @@ import { Paginated } from '@feathersjs/feathers/lib'
 import '@feathersjs/transport-commons'
 
 import { decode } from 'jsonwebtoken'
-import { v4 as uuidv4 } from 'uuid'
 
 import { PeerID } from '@etherealengine/common/src/interfaces/PeerID'
 import { Engine } from '@etherealengine/engine/src/ecs/classes/Engine'
@@ -238,7 +237,6 @@ const loadEngine = async (app: Application, sceneId: SceneID) => {
 
   const hostId = instanceServerState.instance.id as UserID & InstanceID
   Engine.instance.userID = hostId
-  Engine.instance.peerID = uuidv4() as PeerID
   const topic = instanceServerState.isMediaInstance ? NetworkTopics.media : NetworkTopics.world
 
   await setupIPs()


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f3d47b</samp>

The pull request refactors the peerID management across the engine, the client, and the instance server by using the HyperFlux store as the single source of truth. This improves the peer-to-peer communication, synchronization, and testing of the engine. It also removes unused and redundant code from several files.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f3d47b</samp>

*  Removed `uuidv4` and `PeerID` imports from several files where they are no longer needed ([link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-e4000a2492a5d9f2ee0e96bbce45988cdae7175b9187ff47e2e8ba17a920c16cL26-R26),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-91fdd12e3a60dcc67e76e429c8f7bdc96e19c8688e1ca759fc3405e91e8ed51eL28-R31),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-fba67caad2e0eb8e816228bee5951411edb2e150f2f899cac806bc120bad2c34L30),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-8b0e5f59151123cb319518abe243d8a2ad95732b0a51e1ddf3764eed6c7962cfL30),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-f5058824fc8b2d07de7b40700a45b4be45ed166e119171595f90bede67eca1c0L40))
*  Renamed `engine_tw.tsx` to `engine.tsx` to avoid confusion with the original file ([link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-e4000a2492a5d9f2ee0e96bbce45988cdae7175b9187ff47e2e8ba17a920c16cL26-R26))
*  Changed `Engine.instance.peerID` from a string to a getter that returns the peerID from the HyperFlux store in `Engine.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-f5058824fc8b2d07de7b40700a45b4be45ed166e119171595f90bede67eca1c0L60-R61))
*  Removed the assignment of `Engine.instance.peerID` to a random UUID from several files where it is no longer necessary ([link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-e4000a2492a5d9f2ee0e96bbce45988cdae7175b9187ff47e2e8ba17a920c16cL40),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-91fdd12e3a60dcc67e76e429c8f7bdc96e19c8688e1ca759fc3405e91e8ed51eL44),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-fba67caad2e0eb8e816228bee5951411edb2e150f2f899cac806bc120bad2c34L61),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-8b0e5f59151123cb319518abe243d8a2ad95732b0a51e1ddf3764eed6c7962cfL67),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-44dbd601e92f66ae516625943903be544d7da898998a678f6e46fd3ca3fcf6bcL122),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-c68a1cd6644d277cf3f9a3c7bbfbdd0cc0184ed015eb8803802e6559988da90eL174),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-f28651f2b131fe962a0070c7d734975c6714a056dc169847ca249fa85167f831L241))
*  Changed the `peerID` variable from a string to `Engine.instance.store.peerID` in several test files where it is used to match the peerID of the HyperFlux store ([link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-44dbd601e92f66ae516625943903be544d7da898998a678f6e46fd3ca3fcf6bcL62-R63),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-44dbd601e92f66ae516625943903be544d7da898998a678f6e46fd3ca3fcf6bcL88-R88),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-44dbd601e92f66ae516625943903be544d7da898998a678f6e46fd3ca3fcf6bcL141-R139),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-44dbd601e92f66ae516625943903be544d7da898998a678f6e46fd3ca3fcf6bcL162-R159),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-9081287a11da0e9998fb56c8645f066a895c2f6587bdf3f1d2b39856f404f8feL764-R765),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-9081287a11da0e9998fb56c8645f066a895c2f6587bdf3f1d2b39856f404f8feL963-R962),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-4918f8fd8190269f8d054629bc9da010778a518680d25117a438b0dbe9b67127L439-R439),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-4918f8fd8190269f8d054629bc9da010778a518680d25117a438b0dbe9b67127L530-R529),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-c68a1cd6644d277cf3f9a3c7bbfbdd0cc0184ed015eb8803802e6559988da90eL78-R82),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-c68a1cd6644d277cf3f9a3c7bbfbdd0cc0184ed015eb8803802e6559988da90eL123-R126),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-c68a1cd6644d277cf3f9a3c7bbfbdd0cc0184ed015eb8803802e6559988da90eL168-R166),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-c68a1cd6644d277cf3f9a3c7bbfbdd0cc0184ed015eb8803802e6559988da90eL212-R212),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-c68a1cd6644d277cf3f9a3c7bbfbdd0cc0184ed015eb8803802e6559988da90eL247-R247),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-c68a1cd6644d277cf3f9a3c7bbfbdd0cc0184ed015eb8803802e6559988da90eL321-R320))
*  Changed the `authorityPeerID` property of the `NetworkObjectComponent` from a string to `Engine.instance.peerID` in `GrabbableSystem.test.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-62b0f9730788861de531f19a53b2a73d2c8444b9da31237349872dd170c22bc3L88-R88))
*  Changed the `peerID` variable from a string to `anotherPeerID` in `NetworkPeerFunctions.test.ts` to avoid confusion with the peerID of the HyperFlux store and the engine instance ([link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-44dbd601e92f66ae516625943903be544d7da898998a678f6e46fd3ca3fcf6bcL172-R167),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-44dbd601e92f66ae516625943903be544d7da898998a678f6e46fd3ca3fcf6bcL178-R173),[link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-44dbd601e92f66ae516625943903be544d7da898998a678f6e46fd3ca3fcf6bcL185-R180))
*  Replaced the `getPeerId` function by the `peerID` property of the HyperFlux store in `ActionFunctions.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-635da5f62dee50a7e0468ec3ad6667222d3ed5f01b747a5cd7aa4e2c23e47104L305-R308))
*  Added `uuidv4` and `PeerID` imports to `StoreFunctions.ts` where they are needed to generate and store the peerID in the HyperFlux store ([link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-2fef5a585a2cda53aaa99a380c3a8640a70ab6f9cfb5fe5421b370ea9b88057fL28-R30))
*  Removed the `getPeerId` function from the `HyperStore` interface and replaced it by the `peerID` property of type `PeerID` in `StoreFunctions.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-2fef5a585a2cda53aaa99a380c3a8640a70ab6f9cfb5fe5421b370ea9b88057fL49-R53))
*  Initialized the `peerID` property to a random UUID in the `createHyperStore` function in `StoreFunctions.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9204/files?diff=unified&w=0#diff-2fef5a585a2cda53aaa99a380c3a8640a70ab6f9cfb5fe5421b370ea9b88057fL123-R125))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1f3d47b</samp>

> _To improve the networking code_
> _We refactored the use of `peerID`_
> _We used HyperFlux store_
> _To handle it more_
> _And removed what was redundant or hid_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
