### PR TITLE
Refactor onquery node and add defaults and asserts

### DIFF
--- a/packages/engine/src/behave-graph/nodes/Profiles/Engine/Events/onQuery.ts
+++ b/packages/engine/src/behave-graph/nodes/Profiles/Engine/Events/onQuery.ts
@@ -31,6 +31,7 @@ import {
   defineQuery,
   removeQuery
 } from '../../../../../ecs/functions/ComponentFunctions'
+import { InputSystemGroup } from '../../../../../ecs/functions/EngineFunctions'
 import {
   SystemDefinitions,
   SystemUUID,
@@ -38,6 +39,7 @@ import {
   disableSystem,
   startSystem
 } from '../../../../../ecs/functions/SystemFunctions'
+import { TransformComponent } from '../../../../../transform/components/TransformComponent'
 
 let systemCounter = 0
 
@@ -66,20 +68,20 @@ export const OnQuery = makeEventNodeDefinition({
 
     const componentName = (index) => {
       const choices = Array.from(ComponentMap.keys()).sort()
-      choices.unshift('none')
       return {
         key: `componentName${index}`,
         valueType: 'string',
-        choices: choices
+        choices: choices,
+        defaultValue: TransformComponent.name
       }
     }
     const type = () => {
-      const choices = ['entry', 'exit']
-      choices.unshift('none')
+      const choices = ['enter', 'exit']
       return {
         key: 'type',
         valueType: 'string',
-        choices: choices
+        choices: choices,
+        defaultValue: choices[0]
       }
     }
 
@@ -88,11 +90,11 @@ export const OnQuery = makeEventNodeDefinition({
       const groups = systemDefinitions.filter((key) => key.includes('group')).sort()
       const nonGroups = systemDefinitions.filter((key) => !key.includes('group')).sort()
       const choices = [...groups, ...nonGroups]
-      choices.unshift('none')
       return {
         key: 'system',
         valueType: 'string',
-        choices: choices
+        choices: choices,
+        defaultValue: InputSystemGroup
       }
     }
     // unsure how to get all system groups
@@ -120,43 +122,28 @@ export const OnQuery = makeEventNodeDefinition({
       const component = ComponentMap.get(componentName)!
       queryComponents.push(component)
     }
-    const query = defineQuery(queryComponents)
+    const query = defineQuery(queryComponents)[type]
     let prevQueryResult = []
     let newQueryResult = []
-    let queryType
-    switch (type) {
-      case 'entry': {
-        queryType = query.enter
-        break
-      }
-      case 'exit': {
-        queryType = query.exit
-        break
-      }
-      case 'none': {
-        queryType = query
-        break
-      }
-    }
     const systemUUID = defineSystem({
       uuid: 'behave-graph-onQuery-' + systemCounter++,
       execute: () => {
-        newQueryResult = queryType()
+        newQueryResult = query()
         if (newQueryResult.length === 0) return
         if (prevQueryResult === newQueryResult) return
         const tempResult = newQueryResult
-        function delayedLoop(i) {
+        function delayedIteration(i) {
           if (i < tempResult.length) {
-            const eid = tempResult[i]
-            write('entity', eid)
+            write('entity', tempResult[i])
             commit('flow')
             setTimeout(() => {
-              prevQueryResult = tempResult
-              delayedLoop(i + 1)
-            }, 50) //milliseconds, to prevent write from skipping over entities
+              delayedIteration(i + 1)
+            }, 50)
           }
         }
-        delayedLoop(0)
+        // Start the delayed iteration
+        delayedIteration(0)
+        prevQueryResult = tempResult
       }
     })
     startSystem(systemUUID, { with: system })

--- a/packages/engine/src/behave-graph/nodes/Profiles/Engine/Events/onQuery.ts
+++ b/packages/engine/src/behave-graph/nodes/Profiles/Engine/Events/onQuery.ts
@@ -135,10 +135,9 @@ export const OnQuery = makeEventNodeDefinition({
         function delayedIteration(i) {
           if (i < tempResult.length) {
             write('entity', tempResult[i])
-            commit('flow')
-            setTimeout(() => {
+            commit('flow', () => {
               delayedIteration(i + 1)
-            }, 50)
+            })
           }
         }
         // Start the delayed iteration

--- a/packages/engine/src/behave-graph/nodes/Profiles/Engine/Values/CustomNodes.ts
+++ b/packages/engine/src/behave-graph/nodes/Profiles/Engine/Values/CustomNodes.ts
@@ -76,21 +76,19 @@ export const playVideo = makeFlowNodeDefinition({
         text: key,
         value: PlayMode[key as keyof typeof PlayMode]
       }))
+
       return {
         valueType: 'string',
-        choices: choices
+        choices: choices,
+        defaultValue: choices[0]
       }
     },
     videoFit: (_, graphApi) => {
-      const choices = [
-        { text: 'cover', value: 'cover' },
-        { text: 'contain', value: 'contain' },
-        { text: 'vertical', value: 'vertical' },
-        { text: 'horizontal', value: 'horizontal' }
-      ]
+      const choices = ['cover', 'contain', 'vertical', 'horizontal']
       return {
         valueType: 'string',
-        choices: choices
+        choices: choices,
+        defaultValue: choices[0]
       }
     }
   },
@@ -143,7 +141,8 @@ export const playAudio = makeFlowNodeDefinition({
       }))
       return {
         valueType: 'string',
-        choices: choices
+        choices: choices,
+        defaultValue: choices[0]
       }
     }
   },
@@ -223,8 +222,8 @@ export const makeRaycast = makeFlowNodeDefinition({
   }
 })*/
 
-export const getAvatarAnimations = makeFunctionNodeDefinition({
-  typeName: 'engine/media/getAvatarAnimations',
+export const getAnimationPack = makeFunctionNodeDefinition({
+  typeName: 'engine/media/getAnimationPack',
   category: NodeCategory.Query,
   label: 'Get Avatar Animations',
   in: {
@@ -238,10 +237,10 @@ export const getAvatarAnimations = makeFunctionNodeDefinition({
       }
     }
   },
-  out: { animationName: 'string' },
+  out: { animationPack: 'string' },
   exec: ({ read, write, graph }) => {
-    const animationName: string = read('animationName')
-    write('animationName', animationName)
+    const animationPack: string = read('animationName')
+    write('animationPack', animationPack)
   }
 })
 
@@ -295,7 +294,8 @@ export const setAnimationAction = makeFlowNodeDefinition({
       ]
       return {
         valueType: 'number',
-        choices: choices
+        choices: choices,
+        defaultValue: choices[0]
       }
     },
     loopMode: (_, graphApi) => {
@@ -306,7 +306,8 @@ export const setAnimationAction = makeFlowNodeDefinition({
       ]
       return {
         valueType: 'number',
-        choices: choices
+        choices: choices,
+        defaultValue: choices[0]
       }
     },
     weight: 'float',
@@ -362,9 +363,11 @@ export const loadAsset = makeAsyncNodeDefinition({
       const entity = await loadAsset()
       write('entity', entity)
       commit('loadEnd', () => {
+        write('entity', entity)
         finished?.()
       })
     })
+
     return null
   },
   dispose: ({ state, graph: { getDependency } }) => {
@@ -422,7 +425,8 @@ export const startXRSession = makeFlowNodeDefinition({
       const choices = ['inline', 'immersive-ar', 'immersive-vr']
       return {
         valueType: 'string',
-        choices: choices
+        choices: choices,
+        defaultValue: choices[0]
       }
     }
   },
@@ -456,7 +460,7 @@ export const switchScene = makeFlowNodeDefinition({
   label: 'Switch Scene',
   in: {
     flow: 'flow',
-    projectName: 'string',
+    projectName: 'string', // i wish i could access the ProjectState
     sceneName: 'string'
   },
   out: {},

--- a/packages/engine/src/behave-graph/nodes/Profiles/Engine/Values/EntityNodes.ts
+++ b/packages/engine/src/behave-graph/nodes/Profiles/Engine/Values/EntityNodes.ts
@@ -31,9 +31,11 @@ import {
 } from '@behave-graph/core'
 import { toQuat, toVector3 } from '@behave-graph/scene'
 import { EntityUUID } from '@etherealengine/common/src/interfaces/EntityUUID'
+import { getState } from '@etherealengine/hyperflux'
 import { teleportAvatar } from '../../../../../avatar/functions/moveAvatar'
 import { Engine } from '../../../../../ecs/classes/Engine'
 import { Entity } from '../../../../../ecs/classes/Entity'
+import { SceneState } from '../../../../../ecs/classes/Scene'
 import {
   ComponentMap,
   defineQuery,
@@ -61,10 +63,10 @@ export const getEntity = makeFunctionNodeDefinition({
         text: getComponent(entity, NameComponent),
         value: getComponent(entity, UUIDComponent) as string
       }))
-      choices.unshift({ text: 'none', value: '' })
       return {
         valueType: 'string',
-        choices: choices
+        choices: choices,
+        defaultValue: getComponent(SceneState.getRootEntity(getState(SceneState).activeScene!), UUIDComponent)
       }
     }
   },
@@ -129,21 +131,21 @@ export const addEntity = makeFlowNodeDefinition({
         text: getComponent(entity, NameComponent),
         value: getComponent(entity, UUIDComponent) as string
       }))
-      choices.unshift({ text: 'none', value: '' as string })
       return {
         valueType: 'string',
-        choices: choices
+        choices: choices,
+        defaultValue: getComponent(SceneState.getRootEntity(getState(SceneState).activeScene!), UUIDComponent)
       }
     },
-    component: (_, graphApi) => {
+    componentName: (_, graphApi) => {
       const choices = Array.from(ComponentMap.entries())
         .filter(([, component]) => !!component.jsonID)
         .map(([name]) => name)
         .sort()
-      choices.unshift('none')
       return {
         valueType: 'string',
-        choices: choices
+        choices: choices,
+        defaultValue: TransformComponent.name
       }
     },
     entityName: 'string'
@@ -153,7 +155,7 @@ export const addEntity = makeFlowNodeDefinition({
   triggered: ({ read, write, commit, graph: { getDependency } }) => {
     const parentEntityUUID = read<string>('parentEntity')
     const parentEntity: Entity = parentEntityUUID == '' ? null : UUIDComponent.entitiesByUUID[parentEntityUUID]
-    const componentName = read<string>('component')
+    const componentName = read<string>('componentName')
     const entity = addEntityToScene([{ name: ComponentMap.get(componentName)?.jsonID! }], parentEntity)
     const entityName = read<string>('entityName')
     if (entityName.length > 0) setComponent(entity, NameComponent, entityName)
@@ -168,7 +170,17 @@ export const deleteEntity = makeFlowNodeDefinition({
   label: 'Delete entity',
   in: {
     flow: 'flow',
-    entity: 'entity'
+    entity: (_, graphApi) => {
+      const choices = sceneQuery().map((entity) => ({
+        text: getComponent(entity, NameComponent),
+        value: getComponent(entity, UUIDComponent) as string
+      }))
+      choices.unshift({ text: 'none', value: '' })
+      return {
+        valueType: 'string',
+        choices: choices // no default beacause we dont want to acciedently delete the default, none is safer
+      }
+    }
   },
   out: { flow: 'flow' },
   initialState: undefined,

--- a/packages/engine/src/behave-graph/nodes/Profiles/Engine/Values/SplineNodes.ts
+++ b/packages/engine/src/behave-graph/nodes/Profiles/Engine/Values/SplineNodes.ts
@@ -23,7 +23,7 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { NodeCategory, makeAsyncNodeDefinition, makeFunctionNodeDefinition } from '@behave-graph/core'
+import { Assert, NodeCategory, makeAsyncNodeDefinition, makeFunctionNodeDefinition } from '@behave-graph/core'
 import { EntityUUID } from '@etherealengine/common/src/interfaces/EntityUUID'
 import { Entity } from '../../../../../ecs/classes/Entity'
 import {
@@ -61,6 +61,7 @@ export const getSpline = makeFunctionNodeDefinition({
   out: { entity: 'entity' },
   exec: ({ read, write }) => {
     const splineEntityUUID = read<string>('spline')
+    Assert.mustBeTrue(splineEntityUUID !== '', 'Please select spline entity')
     const splineEntity = UUIDComponent.entitiesByUUID[splineEntityUUID]
     write('entity', splineEntity)
   }


### PR DESCRIPTION
This pull request simplifies the onquery node, adds defaults and asserts for nodes, and improves onquery iteration. The changes include:

- Added Assert to getSpline node to ensure a spline entity is selected

- Added default values to videoFit and audioMode nodes

- Renamed getAvatarAnimations to getAnimationPack

- Added default values to setAnimationAction node

- Added default values to addEntity node for componentName and parentEntity

- Improved deleteEntity node by adding a dropdown menu for entity selection

No issues were fixed in this pull request.