### PR TITLE
remove unwanted `0` in the debug panel

### DIFF
--- a/packages/client-core/src/components/Debug/index.tsx
+++ b/packages/client-core/src/components/Debug/index.tsx
@@ -43,7 +43,6 @@ import { RootSystemGroup, SimulationSystemGroup } from '@etherealengine/engine/s
 import { entityExists } from '@etherealengine/engine/src/ecs/functions/EntityFunctions'
 import { EntityTreeComponent } from '@etherealengine/engine/src/ecs/functions/EntityTree'
 import { System, SystemDefinitions, SystemUUID } from '@etherealengine/engine/src/ecs/functions/SystemFunctions'
-import { NetworkState } from '@etherealengine/engine/src/networking/NetworkState'
 import { RendererState } from '@etherealengine/engine/src/renderer/RendererState'
 import { NameComponent } from '@etherealengine/engine/src/scene/components/NameComponent'
 import { UUIDComponent } from '@etherealengine/engine/src/scene/components/UUIDComponent'
@@ -115,11 +114,9 @@ export const Debug = ({ showingStateRef }: { showingStateRef: React.MutableRefOb
 
   const { t } = useTranslation()
   const hasActiveControlledAvatar =
-    Engine.instance.localClientEntity &&
+    !!Engine.instance.localClientEntity &&
     engineState.connectedWorld.value &&
     hasComponent(Engine.instance.localClientEntity, AvatarControllerComponent)
-
-  const networks = getMutableState(NetworkState).networks
 
   const onClickRespawn = (): void => {
     Engine.instance.localClientEntity && respawnAvatar(Engine.instance.localClientEntity)


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb95119</samp>

Fixed circular dependency and cleaned up code in `Debug` component. This component provides a UI for debugging various aspects of the engine.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cb95119</samp>

*  Simplified the condition for rendering the debug panel by using the `!!` operator on the `localClientEntity` value ([link](https://github.com/EtherealEngine/etherealengine/pull/9208/files?diff=unified&w=0#diff-e7c3ea17cd35c689bea85b17184731bd08283c5328b6e4c709e2904452c9c932L118-R120))
* Removed unused import of `NetworkState` to avoid circular dependency error ([link](https://github.com/EtherealEngine/etherealengine/pull/9208/files?diff=unified&w=0#diff-e7c3ea17cd35c689bea85b17184731bd08283c5328b6e4c709e2904452c9c932L46))
* Deleted unused `networks` variable from `Debug` component ([link](https://github.com/EtherealEngine/etherealengine/pull/9208/files?diff=unified&w=0#diff-e7c3ea17cd35c689bea85b17184731bd08283c5328b6e4c709e2904452c9c932L118-R120))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cb95119</samp>

> _The `Debug` component was a mess_
> _With unused code and excess_
> _The logic was simplified_
> _The circular error defied_
> _Now the code is easier to assess_

## QA Steps

**Earlier**

![image](https://github.com/EtherealEngine/etherealengine/assets/55396651/97caee42-497e-4cd1-a80f-8b084eaba241)

**Now**

![image](https://github.com/EtherealEngine/etherealengine/assets/55396651/1ec8d7b7-0d9f-4152-9560-3554c2d6367f)


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
