### PR TITLE
Added optional provisionConstraints on instance provisioning

### DIFF
--- a/packages/client-core/src/common/services/LocationInstanceConnectionService.ts
+++ b/packages/client-core/src/common/services/LocationInstanceConnectionService.ts
@@ -36,7 +36,6 @@ import { instanceProvisionPath } from '@etherealengine/engine/src/schemas/networ
 import { InstanceID, instancePath, InstanceType } from '@etherealengine/engine/src/schemas/networking/instance.schema'
 import { SceneID } from '@etherealengine/engine/src/schemas/projects/scene.schema'
 import { LocationID, RoomCode } from '@etherealengine/engine/src/schemas/social/location.schema'
-import { API } from '../../API'
 import { SocketWebRTCClientNetwork } from '../../transports/SocketWebRTCClientFunctions'
 import { AuthState } from '../../user/services/AuthService'
 
@@ -80,7 +79,7 @@ export const LocationInstanceConnectionService = {
     logger.info({ locationId, instanceId, sceneId }, 'Provision World Server')
     const token = getState(AuthState).authUser.accessToken
     if (instanceId != null) {
-      const instance = (await API.instance.client.service(instancePath).find({
+      const instance = (await Engine.instance.api.service(instancePath).find({
         query: {
           id: instanceId,
           ended: false
@@ -90,7 +89,7 @@ export const LocationInstanceConnectionService = {
         instanceId = null!
       }
     }
-    const provisionResult = await API.instance.client.service(instanceProvisionPath).find({
+    const provisionResult = await Engine.instance.api.service(instanceProvisionPath).find({
       query: {
         locationId,
         instanceId,
@@ -120,7 +119,7 @@ export const LocationInstanceConnectionService = {
   provisionExistingServer: async (locationId: LocationID, instanceId: InstanceID, sceneId: SceneID) => {
     logger.info({ locationId, instanceId, sceneId }, 'Provision Existing World Server')
     const token = getState(AuthState).authUser.accessToken
-    const instance = (await API.instance.client.service(instancePath).find({
+    const instance = (await Engine.instance.api.service(instancePath).find({
       query: {
         id: instanceId,
         ended: false
@@ -136,7 +135,7 @@ export const LocationInstanceConnectionService = {
       }
       return
     }
-    const provisionResult = await API.instance.client.service(instanceProvisionPath).find({
+    const provisionResult = await Engine.instance.api.service(instanceProvisionPath).find({
       query: {
         locationId,
         instanceId,
@@ -161,7 +160,7 @@ export const LocationInstanceConnectionService = {
   provisionExistingServerByRoomCode: async (locationId: LocationID, roomCode: RoomCode, sceneId: SceneID) => {
     logger.info({ locationId, roomCode, sceneId }, 'Provision Existing World Server')
     const token = getState(AuthState).authUser.accessToken
-    const instance = (await API.instance.client.service(instancePath).find({
+    const instance = (await Engine.instance.api.service(instancePath).find({
       query: {
         roomCode,
         ended: false
@@ -177,7 +176,7 @@ export const LocationInstanceConnectionService = {
       }
       return
     }
-    const provisionResult = await API.instance.client.service(instanceProvisionPath).find({
+    const provisionResult = await Engine.instance.api.service(instanceProvisionPath).find({
       query: {
         locationId,
         roomCode,

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -307,7 +307,7 @@ export default defineConfig(async () => {
               ? 'dev-sw.js?dev-sw'
               : 'service-worker.js'
             : '',
-        paymentPointer: coilSetting.paymentPointer || ''
+        paymentPointer: coilSetting?.paymentPointer || ''
       }),
       viteCompression({
         filter: /\.(js|mjs|json|css)$/i,

--- a/packages/engine/src/assets/compression/ModelTransformFunctions.ts
+++ b/packages/engine/src/assets/compression/ModelTransformFunctions.ts
@@ -689,7 +689,7 @@ export async function transformModel(args: ModelTransformParameters) {
         {
           name: fileName,
           byteLength: data.byteLength,
-          
+
         }
       })
     )*/

--- a/scripts/build_docker_desktop.sh
+++ b/scripts/build_docker_desktop.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+set -e
+set -x
+
+if [ -z "$SERVER_HOST" ]
+then
+  SERVER_HOST=localhost
+else
+  SERVER_HOST=$SERVER_HOST
+fi
+
+if [ -z "$SERVER_PORT" ]
+then
+  SERVER_PORT=3030
+else
+  SERVER_PORT=$SERVER_PRT
+fi
+
+if [ -z "$MYSQL_HOST" ]
+then
+  MYSQL_HOST=host.docker.internal
+else
+  MYSQL_HOST=$MYSQL_HOST
+fi
+
+if [ -z "$MYSQL_PORT" ]
+then
+  MYSQL_PORT=3304
+else
+  MYSQL_PORT=$MYSQL_PORT
+fi
+
+if [ -z "$MYSQL_USER" ]
+then
+  MYSQL_USER=server
+else
+  MYSQL_USER=$MYSQL_USER
+fi
+
+if [ -z "$MYSQL_PASSWORD" ]
+then
+  MYSQL_PASSWORD=password
+else
+  MYSQL_PASSWORD=$MYSQL_PASSWORD
+fi
+
+if [ -z "$MYSQL_DATABASE" ]
+then
+  MYSQL_DATABASE=etherealengine
+else
+  MYSQL_DATABASE=$MYSQL_DATABASE
+fi
+
+if [ -z "$VITE_APP_HOST" ]
+then
+  VITE_APP_HOST=local.etherealengine.org
+else
+  VITE_APP_HOST=$VITE_APP_HOST
+fi
+
+if [ -z "$VITE_SERVER_HOST" ]
+then
+  VITE_SERVER_HOST=api-local.etherealengine.org
+else
+  VITE_SERVER_HOST=$VITE_SERVER_HOST
+fi
+
+if [ -z "$VITE_FILE_SERVER" ]
+then
+  VITE_FILE_SERVER=https://localhost:9000/etherealengine-minikube-static-resources
+else
+  VITE_FILE_SERVER=$VITE_FILE_SERVER
+fi
+
+if [ -z "$VITE_MEDIATOR_SERVER" ]
+then
+  VITE_MEDIATOR_SERVER=https://authn.io
+else
+  VITE_MEDIATOR_SERVER=$VITE_MEDIATOR_SERVER
+fi
+
+if [ -z "$VITE_INSTANCESERVER_HOST" ]
+then
+  VITE_INSTANCESERVER_HOST=instanceserver-local.etherealengine.org
+else
+  VITE_INSTANCESERVER_HOST=$VITE_INSTANCESERVER_HOST
+fi
+
+if [ -z "$VITE_LOGIN_WITH_WALLET" ]
+then
+  VITE_LOGIN_WITH_WALLET=false
+else
+  VITE_LOGIN_WITH_WALLET=$VITE_LOGIN_WITH_WALLET
+fi
+
+if [ -z "$VITE_8TH_WALL" ]
+then
+  VITE_8TH_WALL=null
+else
+  VITE_8TH_WALL=$VITE_8TH_WALL
+fi
+
+if [ -z "$NODE_ENV" ]
+then
+  NODE_ENV=development
+else
+  NODE_ENV=$NODE_ENV
+fi
+
+
+# ./generate-certs.sh
+
+docker start etherealengine_minikube_db
+#eval $(minikube docker-env)
+
+mkdir -p ./project-package-jsons/projects/default-project
+cp packages/projects/default-project/package.json ./project-package-jsons/projects/default-project
+find packages/projects/projects/ -name package.json -exec bash -c 'mkdir -p ./project-package-jsons/$(dirname $1) && cp $1 ./project-package-jsons/$(dirname $1)' - '{}' \;
+
+docker buildx build \
+  -t etherealengine \
+  --cache-to type=inline \
+  --build-arg NODE_ENV=$NODE_ENV \
+  --build-arg MYSQL_HOST=$MYSQL_HOST \
+  --build-arg MYSQL_PORT=$MYSQL_PORT \
+  --build-arg MYSQL_PASSWORD=$MYSQL_PASSWORD \
+  --build-arg MYSQL_USER=$MYSQL_USER \
+  --build-arg MYSQL_DATABASE=$MYSQL_DATABASE \
+  --build-arg SERVER_HOST=$SERVER_HOST \
+  --build-arg SERVER_PORT=$SERVER_PORT \
+  --build-arg VITE_APP_HOST=$VITE_APP_HOST \
+  --build-arg VITE_SERVER_HOST=$VITE_SERVER_HOST \
+  --build-arg VITE_FILE_SERVER=$VITE_FILE_SERVER \
+  --build-arg VITE_MEDIATOR_SERVER=$VITE_MEDIATOR_SERVER \
+  --build-arg VITE_INSTANCESERVER_HOST=$VITE_INSTANCESERVER_HOST \
+  --build-arg VITE_READY_PLAYER_ME_URL=$VITE_READY_PLAYER_ME_URL \
+  --build-arg VITE_DISABLE_LOG=$VITE_DISABLE_LOG \
+  --build-arg VITE_8TH_WALL=$VITE_8TH_WALL \
+  --build-arg VITE_LOGIN_WITH_WALLET=$VITE_LOGIN_WITH_WALLET .
+
+#DOCKER_BUILDKIT=1 docker build -t etherealengine-testbot -f ./dockerfiles/testbot/Dockerfile-testbot .


### PR DESCRIPTION
## Summary
Added a new query param 'provisionConstraints' to the instance-provision
service. provisionConstraints is and object where fields on agones pod
can be specified to limit which pods will be used for that provision.
It is of the form

{
  <path.of.field>: {
    <comparator>: 'value'
  }
}

e.g.

{
  'metadata.labels.maxCCU': {
    lte: '40'
  }
}

to limit the provision to pods where metadata.labels.maxCCU is
less than or equal to 40. The sub-field selector must be passed
as a dot-separated string as the key(s) at the top level of the
object.

Use of provisionConstraints will now ignore the existing condition that
the pod's name must contain the release. This is to allow for multiple
instanceserver deployments of varying sizes; if one wanted some
instanceservers on e.g. t3a.smalls and others on t3a.xlarges, they would
need to be separate nodeGroups in AWS, and there would need to be separate
Helm deployments for the different instanceserver sizes with labels
indicating e.g. numCores or maxCCU for each deplyoment. The deployments
must have different names, which would make the name match regex not
match all deployments.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1c4f36</samp>

This pull request introduces several improvements and new features for the etherealengine project, such as:

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e1c4f36</samp>

*  Add a new feature for selecting game servers based on provision constraints ([link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dL72-R73), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dR82), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dL104-R167), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dL150-R206), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dL163-R220), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dR231), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dL254-R312), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dL377-R436), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dR475), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dL424-R485), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dR492), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dL463-R528), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dR604), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dL566-R634), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dL602-R666), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dL738-R802), [link](https://github.com/EtherealEngine/etherealengine/pull/9211/files?diff=unified&w=0#diff-136b40456b368c558fed8a3b7ebb926c30b1d38e987c2d431447560e90b9802dL745-R810)). This feature modifies the `getFreeInstanceserver` and `checkForDuplicatedAssignments` functions in the `instance-provision.class.ts` file, as well as the `find` and `getISInService` methods of the `InstanceProvisionService` class, to accept and parse a `provisionConstraints` parameter that specifies additional conditions for filtering the ready game servers based on their metadata fields. The feature also adds several console log statements for debugging purposes.
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e1c4f36</samp>

> _`vite.config.ts`_
> _Fixes bug with optional chain_
> _Winter of errors_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
