### PR TITLE
Converted meshopt decoder from backticked strings to concatenated double quotes

### DIFF
--- a/packages/engine/src/assets/loaders/gltf/meshopt_decoder.module.js
+++ b/packages/engine/src/assets/loaders/gltf/meshopt_decoder.module.js
@@ -100,35 +100,35 @@ var MeshoptDecoder = (function() {
 			"data:text/javascript,var instance; var ready = WebAssembly.instantiate(new Uint8Array([" + new Uint8Array(unpack(wasm)) + "]), {})" +
 			".then(function(result) { instance = result.instance; instance.exports.__wasm_call_ctors(); });" +
 			"self.onmessage = workerProcess;" + 
-			`function decode(fun, target, count, size, source, filter) {
-				var sbrk = instance.exports.sbrk;
-				var count4 = (count + 3) & ~3;
-				var tp = sbrk(count4 * size);
-				var sp = sbrk(source.length);
-				var heap = new Uint8Array(instance.exports.memory.buffer);
-				heap.set(source, sp);
-				var res = fun(tp, count, size, sp, source.length);
-				if (res == 0 && filter) {
-					filter(tp, count4, size);
-				}
-				target.set(heap.subarray(tp, tp + count * size));
-				sbrk(tp - sbrk(0));
-				if (res != 0) {
-					throw new Error("Malformed buffer data: " + res);
-				}
-			}` +
-		`function workerProcess(event) {
-			ready.then(function() {
-				var data = event.data;
-				try {
-					var target = new Uint8Array(data.count * data.size);
-					decode(instance.exports[data.mode], target, data.count, data.size, data.source, instance.exports[data.filter]);
-					self.postMessage({ id: data.id, count: data.count, action: "resolve", value: target }, [ target.buffer ]);
-				} catch (error) {
-					self.postMessage({ id: data.id, count: data.count, action: "reject", value: error });
-				}
-			});
-		}`;
+			"function decode(fun, target, count, size, source, filter) {" +
+				"var sbrk = instance.exports.sbrk;" +
+				"var count4 = (count + 3) & ~3;" +
+				"var tp = sbrk(count4 * size);" +
+				"var sp = sbrk(source.length);" +
+				"var heap = new Uint8Array(instance.exports.memory.buffer);" +
+				"heap.set(source, sp);" +
+				"var res = fun(tp, count, size, sp, source.length);" +
+				"if (res == 0 && filter) {" +
+					"filter(tp, count4, size);" +
+				"}" +
+				"target.set(heap.subarray(tp, tp + count * size));" +
+				"sbrk(tp - sbrk(0));" +
+				"if (res != 0) {" +
+					"throw new Error('Malformed buffer data: ' + res);" +
+				"}" +
+			"}" +
+			"function workerProcess(event) {" +
+				"ready.then(function() {" +
+					"var data = event.data;" +
+					"try {" +
+						"var target = new Uint8Array(data.count * data.size);" +
+						"decode(instance.exports[data.mode], target, data.count, data.size, data.source, instance.exports[data.filter]);" +
+						"self.postMessage({ id: data.id, count: data.count, action: 'resolve', value: target }, [ target.buffer ]);" +
+					"} catch (error) {" +
+						"self.postMessage({ id: data.id, count: data.count, action: 'reject', value: error });" +
+					"}" +
+				"});" +
+			"}";
 
 		for (var i = 0; i < count; ++i) {
 			workers[i] = createWorker(source);


### PR DESCRIPTION
## Summary
Concatenated version was resulting in an invalid Data URL. It might have had to do with the tabs that that was resulting in.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 42f3989</samp>

Reformatted code in `meshopt_decoder.module.js` to follow ESLint rules and improve readability. No functional changes.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 42f3989</samp>

*  Reformatted code in `initWorkers` function to use consistent indentation, spacing, and single quotes ([link](https://github.com/EtherealEngine/etherealengine/pull/9212/files?diff=unified&w=0#diff-a919baeba37a7716a7ffafc5134b5484e107fd5c0811a1813e17672b7770f264L103-R131))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 42f3989</samp>

> _`initWorkers` code_
> _Reformatted for clarity_
> _A fresh spring cleaning_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
