### PR TITLE
wip: Fashion Design Configurator

### DIFF
--- a/packages/editor/src/components/element/ElementList.tsx
+++ b/packages/editor/src/components/element/ElementList.tsx
@@ -35,6 +35,7 @@ import { AmbientLightComponent } from '@etherealengine/engine/src/scene/componen
 import { ColliderComponent } from '@etherealengine/engine/src/scene/components/ColliderComponent'
 import { DirectionalLightComponent } from '@etherealengine/engine/src/scene/components/DirectionalLightComponent'
 import { EnvMapBakeComponent } from '@etherealengine/engine/src/scene/components/EnvMapBakeComponent'
+import { FashionDesignComponent } from '@etherealengine/engine/src/scene/components/FashionDesignComponent'
 import { GroundPlaneComponent } from '@etherealengine/engine/src/scene/components/GroundPlaneComponent'
 import { GroupComponent } from '@etherealengine/engine/src/scene/components/GroupComponent'
 import { HemisphereLightComponent } from '@etherealengine/engine/src/scene/components/HemisphereLightComponent'
@@ -92,7 +93,14 @@ type SceneElementListItemType = {
 }
 
 export const ComponentShelfCategories: Record<string, Component[]> = {
-  Files: [ModelComponent, VolumetricComponent, PositionalAudioComponent, VideoComponent, ImageComponent],
+  Files: [
+    ModelComponent,
+    VolumetricComponent,
+    FashionDesignComponent,
+    PositionalAudioComponent,
+    VideoComponent,
+    ImageComponent
+  ],
   'Scene Composition': [
     PrimitiveGeometryComponent,
     GroundPlaneComponent,

--- a/packages/editor/src/components/properties/FashionDesignNodeEditor.tsx
+++ b/packages/editor/src/components/properties/FashionDesignNodeEditor.tsx
@@ -1,0 +1,78 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and
+provide for limited attribution for the Original Developer. In addition,
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023
+Ethereal Engine. All Rights Reserved.
+*/
+
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useComponent } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
+import { FashionDesignComponent } from '@etherealengine/engine/src/scene/components/FashionDesignComponent'
+
+import VideocamIcon from '@mui/icons-material/Videocam'
+import FolderInput from '../inputs/FolderInput'
+import InputGroup from '../inputs/InputGroup'
+import NodeEditor from './NodeEditor'
+import { EditorComponentType, commitProperties } from './Util'
+
+const FashionNodeEditor: EditorComponentType = (props) => {
+  // console.log('DBGG FashionNodeEditor props', props)
+  const { t } = useTranslation()
+
+  const fashion = useComponent(props.entity, FashionDesignComponent)
+
+  const setPerformerPath = (value: string) => {
+    // updateProperty(FashionDesignComponent, 'performerPath')
+    commitProperties(FashionDesignComponent, {
+      performerPath: value
+    })
+  }
+
+  const setOutfitPath = (value: string) => {
+    // updateProperty(FashionDesignComponent, 'outfitPath')
+    commitProperties(FashionDesignComponent, {
+      outfitPath: value
+    })
+  }
+
+  return (
+    <NodeEditor
+      {...props}
+      name={t('editor:properties.volumetric.name')}
+      description={t('editor:properties.volumetric.description')}
+    >
+      <InputGroup name="Performer" label="Performer">
+        <FolderInput value={fashion.performerPath.value} onChange={setPerformerPath} />
+      </InputGroup>
+
+      <InputGroup name="Outfit" label="Outfit">
+        <FolderInput value={fashion.outfitPath.value} onChange={setOutfitPath} />
+      </InputGroup>
+    </NodeEditor>
+  )
+}
+
+//setting iconComponent with icon name
+FashionNodeEditor.iconComponent = VideocamIcon
+
+export default FashionNodeEditor

--- a/packages/editor/src/functions/ComponentEditors.tsx
+++ b/packages/editor/src/functions/ComponentEditors.tsx
@@ -80,7 +80,9 @@ import BehaveGraphNodeEditor from '../components/properties/BehaveGraphNodeEdito
 import { LinkComponent } from '@etherealengine/engine/src/scene/components/LinkComponent'
 import { ShadowComponent } from '@etherealengine/engine/src/scene/components/ShadowComponent'
 
+import { FashionDesignComponent } from '@etherealengine/engine/src/scene/components/FashionDesignComponent'
 import { PrimitiveGeometryComponent } from '@etherealengine/engine/src/scene/components/PrimitiveGeometryComponent'
+import FashionNodeEditor from '../components/properties/FashionDesignNodeEditor'
 import LinkNodeEditor from '../components/properties/LinkNodeEditor'
 import LoopAnimationNodeEditor from '../components/properties/LoopAnimationNodeEditor'
 import MediaNodeEditor from '../components/properties/MediaNodeEditor'
@@ -140,6 +142,7 @@ EntityNodeEditor.set(ImageComponent, ImageNodeEditor)
 EntityNodeEditor.set(PositionalAudioComponent, PositionalAudioNodeEditor)
 EntityNodeEditor.set(VideoComponent, VideoNodeEditor)
 EntityNodeEditor.set(VolumetricComponent, VolumetricNodeEditor)
+EntityNodeEditor.set(FashionDesignComponent, FashionNodeEditor)
 // EntityNodeEditor.set(CloudComponent, CloudsNodeEditor)
 // EntityNodeEditor.set(OceanComponent, OceanNodeEditor)
 // EntityNodeEditor.set(WaterComponent, WaterNodeEditor)

--- a/packages/engine/src/scene/components/FashionDesignComponent.tsx
+++ b/packages/engine/src/scene/components/FashionDesignComponent.tsx
@@ -24,7 +24,7 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { useEffect } from 'react'
-import { Entity } from '../../ecs/classes/Entity'
+import { Entity, UndefinedEntity } from '../../ecs/classes/Entity'
 import {
   defineComponent,
   hasComponent,
@@ -43,8 +43,8 @@ export const FashionDesignComponent = defineComponent({
 
   onInit: (entity) => {
     return {
-      performerEntity: -1,
-      outfitEntity: -1,
+      performerEntity: UndefinedEntity,
+      outfitEntity: UndefinedEntity,
       performerPath: 'https://localhost:8642/projects/default-project/rai.json',
       outfitPath: 'https://localhost:8642/projects/default-project/rai-outfit.json'
     }
@@ -72,7 +72,7 @@ function FashionDesignReactor() {
   const entity = useEntityContext()
   const fashion = useComponent(entity, FashionDesignComponent)
   const performer = useOptionalComponent(entity, VolumetricComponent)
-  const outfit = useOptionalComponent(fashion.outfitEntity.value as Entity, VolumetricComponent)
+  const outfit = useOptionalComponent(fashion.outfitEntity.value, VolumetricComponent)
 
   console.log('DBGG fashion design reactor', performer, outfit)
 
@@ -97,11 +97,11 @@ function FashionDesignReactor() {
   useEffect(() => {
     console.log('DBGG fashion design component init')
 
-    if (fashion.performerEntity.value === -1) {
+    if (!fashion.performerEntity.value) {
       setupVolumetricEntity(entity, fashion.performerPath.value)
     }
 
-    if (fashion.outfitEntity.value === -1) {
+    if (!fashion.outfitEntity.value) {
       const outfitEntity = createEntity()
       fashion.outfitEntity.set(outfitEntity)
       setupVolumetricEntity(outfitEntity, fashion.outfitPath.value)

--- a/packages/engine/src/scene/components/FashionDesignComponent.tsx
+++ b/packages/engine/src/scene/components/FashionDesignComponent.tsx
@@ -1,0 +1,126 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import { useEffect } from 'react'
+import { Entity } from '../../ecs/classes/Entity'
+import {
+  defineComponent,
+  hasComponent,
+  setComponent,
+  useComponent,
+  useOptionalComponent
+} from '../../ecs/functions/ComponentFunctions'
+import { createEntity, useEntityContext } from '../../ecs/functions/EntityFunctions'
+import { LocalTransformComponent, TransformComponent } from '../../transform/components/TransformComponent'
+import { VisibleComponent } from './VisibleComponent'
+import { VolumetricComponent } from './VolumetricComponent'
+
+export const FashionDesignComponent = defineComponent({
+  name: 'EE_fashion',
+  jsonID: 'fashion',
+
+  onInit: (entity) => {
+    return {
+      performerEntity: -1,
+      outfitEntity: -1,
+      performerPath: 'https://localhost:8642/projects/default-project/rai.json',
+      outfitPath: 'https://localhost:8642/projects/default-project/rai-outfit.json'
+    }
+  },
+
+  toJSON: (entity, component) => ({
+    performerPath: component.performerPath.value,
+    outfitPath: component.outfitPath.value
+  }),
+
+  onSet: (entity, component, json) => {
+    if (!json) return
+    if (json.performerPath) {
+      component.performerPath.set(json.performerPath)
+    }
+    if (json.outfitPath) {
+      component.outfitPath.set(json.outfitPath)
+    }
+  },
+
+  reactor: FashionDesignReactor
+})
+
+function FashionDesignReactor() {
+  const entity = useEntityContext()
+  const fashion = useComponent(entity, FashionDesignComponent)
+  const performer = useOptionalComponent(entity, VolumetricComponent)
+  const outfit = useOptionalComponent(fashion.outfitEntity.value as Entity, VolumetricComponent)
+
+  console.log('DBGG fashion design reactor', performer, outfit)
+
+  const setupVolumetricEntity = (_entity: Entity, path: string) => {
+    setComponent(_entity, VolumetricComponent, {
+      paths: [path],
+      autoplay: false
+    })
+    if (!hasComponent(_entity, VisibleComponent)) {
+      setComponent(_entity, VisibleComponent)
+    }
+
+    if (!hasComponent(_entity, TransformComponent)) {
+      setComponent(_entity, TransformComponent)
+    }
+    if (!hasComponent(_entity, LocalTransformComponent)) {
+      setComponent(_entity, LocalTransformComponent)
+    }
+    return _entity
+  }
+
+  useEffect(() => {
+    console.log('DBGG fashion design component init')
+
+    if (fashion.performerEntity.value === -1) {
+      setupVolumetricEntity(entity, fashion.performerPath.value)
+    }
+
+    if (fashion.outfitEntity.value === -1) {
+      const outfitEntity = createEntity()
+      fashion.outfitEntity.set(outfitEntity)
+      setupVolumetricEntity(outfitEntity, fashion.outfitPath.value)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!fashion.performerPath.value || !fashion.outfitPath.value) return
+    if (!performer || !outfit) return
+    performer.paths.set([fashion.performerPath.value])
+    outfit.paths.set([fashion.outfitPath.value])
+  }, [fashion.performerPath, fashion.outfitPath])
+
+  useEffect(() => {
+    if (!performer || !outfit) return
+    if (!performer.initialBuffersLoaded || !outfit.initialBuffersLoaded) return
+    performer.paused.set(false)
+    outfit.paused.set(false)
+  }, [performer?.initialBuffersLoaded, outfit?.initialBuffersLoaded])
+
+  return null
+}

--- a/packages/engine/src/scene/components/UVOL2Component.ts
+++ b/packages/engine/src/scene/components/UVOL2Component.ts
@@ -291,7 +291,7 @@ function UVOL2Reactor() {
 
   const material = useMemo(() => {
     if (manifest.current.type === UVOL_TYPE.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE) {
-      return new ShaderMaterial({
+      const _material = new ShaderMaterial({
         vertexShader: uniformSolveVertexShader,
         fragmentShader: uniformSolveFragmentShader,
         uniforms: {
@@ -309,6 +309,15 @@ function UVOL2Reactor() {
           }
         }
       })
+      const depthDelta = 10
+      if (manifest.current.texture.baseColor.path.includes('outfit')) {
+        _material.polygonOffset = true
+        _material.polygonOffsetFactor = depthDelta
+      } else {
+        _material.polygonOffset = true
+        _material.polygonOffsetFactor = -depthDelta
+      }
+      return _material
     }
     return new MeshBasicMaterial({ color: 0xffffff })
   }, [])
@@ -984,6 +993,9 @@ function UVOL2Reactor() {
       volumetric.ended.set(true)
       return
     }
+    console.log(
+      `Entity ${entity}, UVOL2, mesh.material.polygonOffset = ${mesh.material.polygonOffset}, polygonFactor = ${mesh.material.polygonOffsetFactor}, polygonUnits = ${mesh.material.polygonOffsetUnits}`
+    )
 
     updateGeometry(currentTime.current)
     updateTexture(currentTime.current)


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e4a7249</samp>

This pull request adds a new feature to the editor and the engine that enables fashion design using volumetric assets. It introduces a new `FashionDesignComponent` that can load and manipulate performer and outfit models in the scene. It also adds a custom node editor component for the `FashionDesignComponent` that allows editing its properties in the editor's properties panel. It updates the `UVOL2Component` to fix a rendering issue with volumetric assets.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e4a7249</samp>

*  Add a new component `FashionDesignComponent` to the engine package, which allows loading and rendering volumetric performers and outfits ([link](https://github.com/EtherealEngine/etherealengine/pull/9213/files?diff=unified&w=0#diff-45ddd42f4ef7f9509c51c2a8067de6c50a1c57cd37e2e1b7927327935a3e3531R1-R126))
*  Import the `FashionDesignComponent` to the editor package, and add it to the component shelf in the Files category ([link](https://github.com/EtherealEngine/etherealengine/pull/9213/files?diff=unified&w=0#diff-435f3e4520184ba61cf93bc5f868a907509e3bddafbf502da800742a3f59e88cR38), [link](https://github.com/EtherealEngine/etherealengine/pull/9213/files?diff=unified&w=0#diff-435f3e4520184ba61cf93bc5f868a907509e3bddafbf502da800742a3f59e88cL95-R103))
*  Define a custom node editor component `FashionNodeEditor` for the `FashionDesignComponent`, which allows editing the performerPath and outfitPath properties in the properties panel ([link](https://github.com/EtherealEngine/etherealengine/pull/9213/files?diff=unified&w=0#diff-435810bfff2c3a44c86998530aa30b64b0e6e78d7bea30221694417489d7926fR1-R78))
*  Register the `FashionNodeEditor` as the node editor for the `FashionDesignComponent` in the `ComponentEditors.tsx` file ([link](https://github.com/EtherealEngine/etherealengine/pull/9213/files?diff=unified&w=0#diff-3063c1f3aea782ebcd44360d5c8288cda436913150bdd01fef587616cdfdd88cL83-R85), [link](https://github.com/EtherealEngine/etherealengine/pull/9213/files?diff=unified&w=0#diff-3063c1f3aea782ebcd44360d5c8288cda436913150bdd01fef587616cdfdd88cR145))
*  Modify the `UVOL2Reactor` function in the `UVOL2Component.ts` file, which handles the rendering of volumetric assets, to set the polygonOffset and polygonOffsetFactor properties of the material, based on whether the asset is an outfit or not, to avoid z-fighting issues ([link](https://github.com/EtherealEngine/etherealengine/pull/9213/files?diff=unified&w=0#diff-69502afe0a0481347a5cad8fbc00d44c0f8392a7e6f58a46c679da131861355eL294-R294), [link](https://github.com/EtherealEngine/etherealengine/pull/9213/files?diff=unified&w=0#diff-69502afe0a0481347a5cad8fbc00d44c0f8392a7e6f58a46c679da131861355eR312-R320))
*  Add a console log statement to the `UVOL2Reactor` function for debugging purposes ([link](https://github.com/EtherealEngine/etherealengine/pull/9213/files?diff=unified&w=0#diff-69502afe0a0481347a5cad8fbc00d44c0f8392a7e6f58a46c679da131861355eR996-R998))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e4a7249</samp>

> _We are the fashion designers of doom_
> _We load and manipulate the volumetric gloom_
> _We edit the nodes and adjust the materials_
> _We are the fashion designers of doom_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
