### PR TITLE
Remove pending tag if there's no renderer instance

### DIFF
--- a/packages/engine/src/scene/components/ModelComponent.ts
+++ b/packages/engine/src/scene/components/ModelComponent.ts
@@ -212,9 +212,11 @@ function ModelReactor() {
       EngineRenderer.instance.renderer
         .compileAsync(scene, getComponent(Engine.instance.cameraEntity, CameraComponent), Engine.instance.scene)
         .then(() => {
+          console.log('finished ', entity)
           if (hasComponent(entity, SceneAssetPendingTagComponent))
             removeComponent(entity, SceneAssetPendingTagComponent)
         })
+    else if (hasComponent(entity, SceneAssetPendingTagComponent)) removeComponent(entity, SceneAssetPendingTagComponent)
 
     if (groupComponent?.value?.find((group: any) => group === scene)) return
 

--- a/packages/engine/src/scene/components/ModelComponent.ts
+++ b/packages/engine/src/scene/components/ModelComponent.ts
@@ -212,7 +212,6 @@ function ModelReactor() {
       EngineRenderer.instance.renderer
         .compileAsync(scene, getComponent(Engine.instance.cameraEntity, CameraComponent), Engine.instance.scene)
         .then(() => {
-          console.log('finished ', entity)
           if (hasComponent(entity, SceneAssetPendingTagComponent))
             removeComponent(entity, SceneAssetPendingTagComponent)
         })


### PR DESCRIPTION
## Summary
One liner, title describes all. Remove the scene pending tag if there's no renderer instance. Created to fix capture page hanging on scenes with model components.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e9dbd4</samp>

* Fix a bug where some entities would not render properly after loading a scene ([link](https://github.com/EtherealEngine/etherealengine/pull/9215/files?diff=unified&w=0#diff-daae2524b717be2ba24820c9515621d8714efd6e8d8bed8493853a425dc305cdR218))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0e9dbd4</samp>

> _`SceneAssetPendingTag`_
> _Cut from entity, now free_
> _Scene assets ready_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
