### PR TITLE
Refactored onButton event node for sync fiber execution

### DIFF
--- a/packages/engine/src/behave-graph/nodes/Profiles/Engine/Events/onQuery.ts
+++ b/packages/engine/src/behave-graph/nodes/Profiles/Engine/Events/onQuery.ts
@@ -123,26 +123,14 @@ export const OnQuery = makeEventNodeDefinition({
       queryComponents.push(component)
     }
     const query = defineQuery(queryComponents)[type]
-    let prevQueryResult = []
-    let newQueryResult = []
+
     const systemUUID = defineSystem({
       uuid: 'behave-graph-onQuery-' + systemCounter++,
       execute: () => {
-        newQueryResult = query()
-        if (newQueryResult.length === 0) return
-        if (prevQueryResult === newQueryResult) return
-        const tempResult = newQueryResult
-        function delayedIteration(i) {
-          if (i < tempResult.length) {
-            write('entity', tempResult[i])
-            commit('flow', () => {
-              delayedIteration(i + 1)
-            })
-          }
+        for (const eid of query()) {
+          write('entity', eid)
+          commit('flow')
         }
-        // Start the delayed iteration
-        delayedIteration(0)
-        prevQueryResult = tempResult
       }
     })
     startSystem(systemUUID, { with: system })

--- a/packages/engine/src/behave-graph/nodes/Profiles/Engine/registerEngineProfile.ts
+++ b/packages/engine/src/behave-graph/nodes/Profiles/Engine/registerEngineProfile.ts
@@ -33,7 +33,7 @@ import {
   memo
 } from '@behave-graph/core'
 import { GetSceneProperty, SetSceneProperty } from '@behave-graph/scene'
-import { OnButtonState } from './Events/onButtonState'
+import { OnButton } from './Events/onButton'
 import { OnQuery } from './Events/onQuery'
 import * as ComponentNodes from './Values/ComponentNodes'
 import * as CustomNodes from './Values/CustomNodes'
@@ -74,7 +74,7 @@ export const getEngineNodesMap = memo<Record<string, NodeDefinition>>(() => {
     // actions
 
     // events
-    OnButtonState, // click included
+    OnButton.Description,
     OnQuery,
     // async
     //switchScene.Description,


### PR DESCRIPTION
The important piece here is:
```ts
              engine.commitToNewFiber(this, state)
              engine.executeAllSync(1)
```

Unfortunately, accessing the engine instance requires refactoring to the lower-level behave-graph class-based API, rather than the JSON-based factory function. 

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e03f3a8</samp>

This pull request refactors and improves the event nodes for the engine profile of the behave-graph system. It renames and rewrites the `OnButtonState` node as a `OnButton` class that uses the latest features and APIs of the `@behave-graph/core` package. It also simplifies the `OnQuery` node logic by replacing a recursive function with a loop. These changes aim to enhance the consistency, readability, and performance of the node system.

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e03f3a8</samp>

*  Refactor the `OnButtonState` function into a `OnButton` class that extends the `EventNode2` class and improves the performance and concurrency of the event node execution ([link](https://github.com/EtherealEngine/etherealengine/pull/9233/files?diff=unified&w=0#diff-7b01c310473b413cf41500e288814f49617ef005dfb97d676d1ddd389084cf5cL26-R36), [link](https://github.com/EtherealEngine/etherealengine/pull/9233/files?diff=unified&w=0#diff-7b01c310473b413cf41500e288814f49617ef005dfb97d676d1ddd389084cf5cL52-R110), [link](https://github.com/EtherealEngine/etherealengine/pull/9233/files?diff=unified&w=0#diff-7b01c310473b413cf41500e288814f49617ef005dfb97d676d1ddd389084cf5cL97-R124), [link](https://github.com/EtherealEngine/etherealengine/pull/9233/files?diff=unified&w=0#diff-7b01c310473b413cf41500e288814f49617ef005dfb97d676d1ddd389084cf5cL109-R142), [link](https://github.com/EtherealEngine/etherealengine/pull/9233/files?diff=unified&w=0#diff-db3791fa84e7d82358207a487b79a281df7b9ba9328590880bd9f86339bfa5c0L36-R36), [link](https://github.com/EtherealEngine/etherealengine/pull/9233/files?diff=unified&w=0#diff-db3791fa84e7d82358207a487b79a281df7b9ba9328590880bd9f86339bfa5c0L77-R77)) in `onButton.ts` and `registerEngineProfile.ts`
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e03f3a8</samp>

> _We've looped the `OnQuery` node, no more recursion there_
> _We've made the `OnButton` class, with new features to spare_
> _We've fixed the engine profile, to match the node refactor_
> _So heave away, me hearties, on the count of three, heave-ho!_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
