### PR TITLE
Set ECS IK target positions from mocap data via rig world positions

### DIFF
--- a/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
+++ b/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
@@ -233,7 +233,7 @@ const execute = () => {
       const headTarget = getMutableComponent(head, AvatarIKTargetComponent)
 
       if (entity == Engine.instance.localClientEntity) {
-        applyInputSourcePoseToIKTargets()
+        applyInputSourcePoseToIKTargets(head, rightHand, leftHand, rightFoot, leftFoot)
         setIkFootTarget(rigComponent.upperLegLength + rigComponent.lowerLegLength, deltaTime)
       }
 

--- a/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
+++ b/packages/engine/src/avatar/systems/AvatarAnimationSystem.ts
@@ -232,8 +232,10 @@ const execute = () => {
       const headTransform = getComponent(head, TransformComponent)
       const headTarget = getMutableComponent(head, AvatarIKTargetComponent)
 
-      applyInputSourcePoseToIKTargets()
-      setIkFootTarget(rigComponent.upperLegLength + rigComponent.lowerLegLength, deltaTime)
+      if (entity == Engine.instance.localClientEntity) {
+        applyInputSourcePoseToIKTargets()
+        setIkFootTarget(rigComponent.upperLegLength + rigComponent.lowerLegLength, deltaTime)
+      }
 
       //special case for the head if we're in xr mode
       if (getOptionalComponent(entity, XRRigComponent)) {


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 283478f</samp>

Refactor `applyInputSourcePoseToIKTargets` function to take IK target entities as parameters and add support for motion capture rigs. Update `AvatarAnimationSystem` to use the refactored function and only call it for the local avatar.

## References
closes #_insert number here_

## Explanation
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 283478f</samp>

*  Refactor `applyInputSourcePoseToIKTargets` function to take IK target entities as parameters instead of generating them from input source UUIDs ([link](https://github.com/EtherealEngine/etherealengine/pull/9235/files?diff=unified&w=0#diff-dd315d5cf8e5bfa659c55c889ddbdf7e12c87a72a655448a5fb24894407b02f9L269-R273), [link](https://github.com/EtherealEngine/etherealengine/pull/9235/files?diff=unified&w=0#diff-dd315d5cf8e5bfa659c55c889ddbdf7e12c87a72a655448a5fb24894407b02f9L282-L289), [link](https://github.com/EtherealEngine/etherealengine/pull/9235/files?diff=unified&w=0#diff-e0a011e84a40926910be0273bb512c563d8c83d4becd2e1ac35f7075e5a33e20L235-R238))
*  Add support for motion capture rig component to `applyInputSourcePoseToIKTargets` function, using `getWorldPosition` method to set IK target positions ([link](https://github.com/EtherealEngine/etherealengine/pull/9235/files?diff=unified&w=0#diff-dd315d5cf8e5bfa659c55c889ddbdf7e12c87a72a655448a5fb24894407b02f9L35-R38), [link](https://github.com/EtherealEngine/etherealengine/pull/9235/files?diff=unified&w=0#diff-dd315d5cf8e5bfa659c55c889ddbdf7e12c87a72a655448a5fb24894407b02f9L357-R364))
*  Remove unused imports of `EntityUUID` and `UUIDComponent` from `packages/engine/src/avatar/functions/applyInputSourcePoseToIKTargets.ts` ([link](https://github.com/EtherealEngine/etherealengine/pull/9235/files?diff=unified&w=0#diff-dd315d5cf8e5bfa659c55c889ddbdf7e12c87a72a655448a5fb24894407b02f9L28), [link](https://github.com/EtherealEngine/etherealengine/pull/9235/files?diff=unified&w=0#diff-dd315d5cf8e5bfa659c55c889ddbdf7e12c87a72a655448a5fb24894407b02f9L35-R38))
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 283478f</samp>

> _`AvatarAnimationSystem` controls our fate_
> _We are the puppets of the `execute` state_
> _But we can break free from the UUID chains_
> _With `applyInputSourcePoseToIKTargets` we can use our own motion capture brains_

## QA Steps
_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._


## Checklist
- If this PR is still a WIP, convert to a draft
- When this PR is ready, mark it as "Ready for review"
- [ensure all checks pass](https://github.com/etherealengine/etherealengine/wiki/Testing-&-Contributing)
- Changes have been manually QA'd 
- Changes reviewed by at least 2 approved reviewers
