### PR TITLE
[bug]: Removed fixed width on Entity Tree search bar

### DIFF
--- a/packages/editor/src/components/Search/styles.ts
+++ b/packages/editor/src/components/Search/styles.ts
@@ -30,7 +30,6 @@ import makeStyles from '@mui/styles/makeStyles'
 export const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     searchRoot: {
-      width: '80px',
       display: 'flex',
       background: 'transparent',
       boxShadow: 'none',


### PR DESCRIPTION
## Summary
Removed fixed width on Entity Tree search bar
It was hardcoded to 80px, but it inherited 120px already.
The hardcoded value was overwriting the default inherited value.

## References
closes #9238

## QA Steps
