### PR TITLE
Use PBR material when appropriate

### DIFF
--- a/packages/engine/src/scene/components/UVOL2Component.ts
+++ b/packages/engine/src/scene/components/UVOL2Component.ts
@@ -30,11 +30,15 @@ import {
   CompressedTexture,
   Group,
   InterleavedBufferAttribute,
+  Matrix3,
   Mesh,
   MeshBasicMaterial,
   MeshStandardMaterial,
+  ShaderLib,
   ShaderMaterial,
   SphereGeometry,
+  UniformsLib,
+  UniformsUtils,
   Vector2
 } from 'three'
 import { GLTF } from '../../assets/loaders/gltf/GLTFLoader'
@@ -266,6 +270,14 @@ const createKey = (target: string, index: number) => {
   return target + index.toString().padStart(KEY_PADDING, '0')
 }
 
+type KeyframeAttribute = {
+  position: InterleavedBufferAttribute
+  normal?: InterleavedBufferAttribute
+}
+type KeyframePositionName = 'keyframeA' | 'keyframeB'
+type KeyframeNormalName = 'keyframeANormal' | 'keyframeBNormal'
+type KeyframeName = KeyframePositionName | KeyframeNormalName
+
 function UVOL2Reactor() {
   const entity = useEntityContext()
   const volumetric = useComponent(entity, VolumetricComponent)
@@ -281,7 +293,7 @@ function UVOL2Reactor() {
   const audioContext = getState(AudioState).audioContext
   const audio = mediaElement.element
 
-  const geometryBuffer = useMemo(() => new Map<string, Mesh | BufferGeometry | InterleavedBufferAttribute>(), [])
+  const geometryBuffer = useMemo(() => new Map<string, Mesh | BufferGeometry | KeyframeAttribute>(), [])
   const textureBuffer = useMemo(() => new Map<string, CompressedTexture>(), [])
   const maxBufferHealth = 10 // seconds
   const minBufferToPlay = 2 // seconds
@@ -291,24 +303,74 @@ function UVOL2Reactor() {
 
   const material = useMemo(() => {
     if (manifest.current.type === UVOL_TYPE.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE) {
-      return new ShaderMaterial({
-        vertexShader: uniformSolveVertexShader,
-        fragmentShader: uniformSolveFragmentShader,
-        uniforms: {
-          repeat: {
-            value: new Vector2(1, 1)
-          },
-          offset: {
-            value: new Vector2(0, 0)
-          },
-          mixRatio: {
-            value: 0
-          },
-          map: {
-            value: null
-          }
+      const firstTarget = Object.keys(component.data.value.geometry.targets)[0]
+      const hasNormals = !manifest.current.geometry.targets[firstTarget].settings.excludeNormals
+      const shaderType = hasNormals ? 'physical' : 'basic'
+
+      let vertexShader = ShaderLib[shaderType].vertexShader.replace(
+        '#include <clipping_planes_pars_vertex>',
+        `#include <clipping_planes_pars_vertex>
+attribute vec3 keyframeA;
+attribute vec3 keyframeB;
+attribute vec3 keyframeANormal;
+attribute vec3 keyframeBNormal;
+uniform float mixRatio;
+uniform vec2 repeat;
+uniform vec2 offset;
+out vec2 custom_vUv;`
+      )
+      vertexShader = vertexShader.replace(
+        '#include <begin_vertex>',
+        `
+vec3 transformed = vec3(position);
+transformed.x += mix(keyframeA.x, keyframeB.x, mixRatio); 
+transformed.y += mix(keyframeA.y, keyframeB.y, mixRatio);
+transformed.z += mix(keyframeA.z, keyframeB.z, mixRatio);
+
+#ifdef USE_ALPHAHASH
+
+  vPosition = vec3( transformed );
+
+#endif`
+      )
+      vertexShader = vertexShader.replace(
+        '#include <beginnormal_vertex>',
+        `
+      vec3 objectNormal = vec3( normal );
+      objectNormal.x += mix(keyframeANormal.x, keyframeBNormal.x, mixRatio);
+      objectNormal.y += mix(keyframeANormal.y, keyframeBNormal.y, mixRatio);
+      objectNormal.z += mix(keyframeANormal.z, keyframeBNormal.z, mixRatio);
+
+      #ifdef USE_TANGENT
+
+        vec3 objectTangent = vec3( tangent.xyz );
+
+      #endif`
+      )
+      const fragmentShader = ShaderLib[shaderType].fragmentShader
+      const uniforms = {
+        mixRatio: {
+          value: 0
+        },
+        map: {
+          value: null
+        },
+        mapTransform: {
+          value: new Matrix3()
         }
+      }
+      const allUniforms = UniformsUtils.merge([ShaderLib.physical.uniforms, UniformsLib.lights, uniforms])
+      const _material = new ShaderMaterial({
+        vertexShader: vertexShader,
+        fragmentShader: fragmentShader,
+        uniforms: allUniforms,
+        defines: {
+          USE_MAP: '',
+          MAP_UV: 'uv'
+        },
+        lights: true
       })
+      return _material
     }
     return new MeshBasicMaterial({ color: 0xffffff })
   }, [])
@@ -398,6 +460,7 @@ function UVOL2Reactor() {
   }, [])
 
   const fetchNonUniformSolveGeometry = (startFrame: number, endFrame: number, target: string) => {
+    // TODO: Needs thorough testing
     const targetData = manifest.current.geometry.targets[target]
     const promises: Promise<Mesh | BufferGeometry>[] = []
 
@@ -458,13 +521,20 @@ function UVOL2Reactor() {
         }
         const i = j + startSegment
         const positionMorphAttributes = model.geometry.morphAttributes.position as InterleavedBufferAttribute[]
+        const normalMorphAttributes = model.geometry.morphAttributes.normal as InterleavedBufferAttribute[]
         const segmentDuration = positionMorphAttributes.length / targetData.frameRate
         const segmentOffset = i * targetData.segmentFrameCount
 
         positionMorphAttributes.forEach((attr, index) => {
           const key = createKey(target, segmentOffset + index)
           attr.name = key
-          geometryBuffer.set(key, attr)
+          if (normalMorphAttributes) {
+            const normalAttr = normalMorphAttributes[index]
+            normalAttr.name = key
+            geometryBuffer.set(key, { position: attr, normal: normalAttr })
+          } else {
+            geometryBuffer.set(key, { position: attr })
+          }
         })
 
         model.geometry.morphAttributes = {}
@@ -656,7 +726,7 @@ function UVOL2Reactor() {
       let headerTemplate: RegExp | undefined = /\/\/\sHEADER_REPLACE_START([\s\S]*?)\/\/\sHEADER_REPLACE_END/
       let mainTemplate: RegExp | undefined = /\/\/\sMAIN_REPLACE_START([\s\S]*?)\/\/\sMAIN_REPLACE_END/
 
-      if (manifest.current.type !== UVOL_TYPE.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE) {
+      if (manifest.current.type !== UVOL_TYPE.UNIFORM_SOLVE_WITH_COMPRESSED_TEXTURE || 1 == 1) {
         headerTemplate = undefined
         mainTemplate = undefined
       }
@@ -722,7 +792,7 @@ function UVOL2Reactor() {
     return integer ? Math.round(frame) : frame
   }
 
-  const getAttribute = (name: 'keyframeA' | 'keyframeB', currentTime: number) => {
+  const getAttribute = (name: KeyframeName, currentTime: number) => {
     const currentGeometryTarget = component.geometryTarget.value
     let index = getFrame(currentTime, manifest.current.geometry.targets[currentGeometryTarget].frameRate, false)
     if (name === 'keyframeA') {
@@ -745,16 +815,21 @@ function UVOL2Reactor() {
         }
 
         if (geometryBuffer.has(createKey(_target, _index))) {
-          const attribute = geometryBuffer.get(createKey(_target, _index))! as InterleavedBufferAttribute
-          return attribute
+          return geometryBuffer.get(createKey(_target, _index)) as KeyframeAttribute
         }
       }
     } else {
-      const attribute = geometryBuffer.get(key)! as InterleavedBufferAttribute
-      return attribute
+      return geometryBuffer.get(key) as KeyframeAttribute
     }
 
     return false
+  }
+
+  const setPositionAndNormal = (name: KeyframePositionName, attr: KeyframeAttribute) => {
+    setAttribute(name, attr.position)
+    if (attr.normal) {
+      setAttribute((name + 'Normal') as KeyframeNormalName, attr.normal)
+    }
   }
 
   /**
@@ -762,12 +837,12 @@ function UVOL2Reactor() {
    * And disposes the old attribute. Since that's not supported by three.js natively,
    * we transfer the old attibute to a new geometry and dispose it.
    */
-  const setAttribute = (name: string, attribute: InterleavedBufferAttribute) => {
+  const setAttribute = (name: KeyframeName, attribute: InterleavedBufferAttribute) => {
     if (mesh.geometry.attributes[name] === attribute) {
       return
     }
 
-    if (name === 'keyframeB') {
+    if (name === 'keyframeB' || name === 'keyframeBNormal') {
       /**
        * Disposing should be done only on keyframeA
        * Because, keyframeA will use the previous buffer of keyframeB in the next frame.
@@ -879,8 +954,8 @@ function UVOL2Reactor() {
           mesh.material.uniforms.map.value.needsUpdate = true
           texture.repeat.copy(repeat)
           texture.offset.copy(offset)
-          mesh.material.uniforms.repeat.value = repeat
-          mesh.material.uniforms.offset.value = offset
+          texture.updateMatrix()
+          mesh.material.uniforms.mapTransform.value.copy(texture.matrix)
           const oldTexture = textureBuffer.get(oldTextureKey)
           if (oldTexture) {
             oldTexture.dispose()
@@ -888,12 +963,13 @@ function UVOL2Reactor() {
           textureBuffer.delete(oldTextureKey)
         }
       } else {
-        const oldTextureKey = mesh.material.map?.name ?? ''
-        if (mesh.material.map !== texture) {
+        const material = mesh.material as MeshBasicMaterial
+        const oldTextureKey = material.map?.name ?? ''
+        if (material.map !== texture) {
           texture.repeat.copy(repeat)
           texture.offset.copy(offset)
-          mesh.material.map = texture
-          mesh.material.map.needsUpdate = true
+          material.map = texture
+          material.map.needsUpdate = true
           const oldTexture = textureBuffer.get(oldTextureKey)
           if (oldTexture) {
             oldTexture.dispose()
@@ -911,27 +987,27 @@ function UVOL2Reactor() {
     if (!keyframeA && !keyframeB) {
       return
     } else if (!keyframeA && keyframeB) {
-      setAttribute('keyframeB', keyframeB)
+      setPositionAndNormal('keyframeB', keyframeB)
       ;(mesh.material as ShaderMaterial).uniforms.mixRatio.value = 1
       return
     } else if (keyframeA && !keyframeB) {
-      setAttribute('keyframeA', keyframeA)
+      setPositionAndNormal('keyframeA', keyframeA)
       ;(mesh.material as ShaderMaterial).uniforms.mixRatio.value = 0
       return
     } else if (keyframeA && keyframeB) {
-      const keyframeAIndex = parseInt(keyframeA.name.slice(-KEY_PADDING))
-      const keyframeATarget = keyframeA.name.slice(0, -KEY_PADDING)
+      const keyframeAIndex = parseInt(keyframeA.position.name.slice(-KEY_PADDING))
+      const keyframeATarget = keyframeA.position.name.slice(0, -KEY_PADDING)
       const keyframeATime = keyframeAIndex / manifest.current.geometry.targets[keyframeATarget].frameRate
 
-      const keyframeBIndex = parseInt(keyframeB.name.slice(-KEY_PADDING))
-      const keyframeBTarget = keyframeB.name.slice(0, -KEY_PADDING)
+      const keyframeBIndex = parseInt(keyframeB.position.name.slice(-KEY_PADDING))
+      const keyframeBTarget = keyframeB.position.name.slice(0, -KEY_PADDING)
       const keyframeBTime = keyframeBIndex / manifest.current.geometry.targets[keyframeBTarget].frameRate
 
       const d1 = Math.abs(currentTime - keyframeATime)
       const d2 = Math.abs(currentTime - keyframeBTime)
       const mixRatio = d1 + d2 > 0 ? d1 / (d1 + d2) : 0.5
-      setAttribute('keyframeA', keyframeA)
-      setAttribute('keyframeB', keyframeB)
+      setPositionAndNormal('keyframeA', keyframeA)
+      setPositionAndNormal('keyframeB', keyframeB)
       ;(mesh.material as ShaderMaterial).uniforms.mixRatio.value = mixRatio
     }
   }


### PR DESCRIPTION
## Summary
When `excludeNormals` is enabled in the manifest, UVOL uses `MeshBasicMaterial`'s shader. Otherwise `MeshStandardMaterial`'s shader. Ofcourse they aren't used directly though.

## References
closes #_insert number here_

## QA Steps
