### PR TITLE
Add back .ts as a Tailwind module export

### DIFF
--- a/packages/client/tailwind.config.js
+++ b/packages/client/tailwind.config.js
@@ -27,7 +27,7 @@ Ethereal Engine. All Rights Reserved.
 
 module.exports = {
   mode: 'jit',
-  content: ['../**/*.{tsx}'],
+  content: ['../**/*.{tsx,ts}'],
   darkMode: 'class',
   important: true, // important in prod is must be
   theme: ['default'],


### PR DESCRIPTION
## Summary
Adds .ts as a Tailwind module export, fixes css being wrong across different pages (namely /capture), rendering them unuseable.

## References
closes #_insert number here_

## QA Steps
