### PR TITLE
Check if boundingBox is null

### DIFF
--- a/packages/engine/src/scene/components/UVOLDissolveComponent.ts
+++ b/packages/engine/src/scene/components/UVOLDissolveComponent.ts
@@ -204,6 +204,9 @@ if (positionY < lowerOffset) {
     const dissolveComponent = getComponent(entity, UVOLDissolveComponent)
     if (!dissolveComponent) return true
     dissolveComponent.currentTime += deltaTime
+    if (!mesh.geometry.boundingBox) {
+      mesh.geometry.computeBoundingBox()
+    }
     const minY = mesh.geometry.boundingBox!.min.y
     const maxY = mesh.geometry.boundingBox!.max.y
     const duration = dissolveComponent.duration


### PR DESCRIPTION
This is already computed in `createDissolveMaterial()`. This check is just to make sure it exists before the usage.

## Summary

## References
closes #_insert number here_

## QA Steps
