### PR TITLE
fix local file server shutdown

### DIFF
--- a/packages/server-core/src/media/storageprovider/local.storage.ts
+++ b/packages/server-core/src/media/storageprovider/local.storage.ts
@@ -34,6 +34,7 @@ import { MULTIPART_CUTOFF_SIZE } from '@etherealengine/common/src/constants/File
 
 import { FileBrowserContentType } from '@etherealengine/engine/src/schemas/media/file-browser.schema'
 import { getState } from '@etherealengine/hyperflux'
+import { ChildProcess } from 'child_process'
 import logger from '../../ServerLogger'
 import { ServerMode, ServerState } from '../../ServerState'
 import config from '../../appconfig'
@@ -81,9 +82,30 @@ export class LocalStorage implements StorageProviderInterface {
     this._store = fsStore(this.PATH_PREFIX)
 
     if (getState(ServerState).serverMode === ServerMode.API && !config.testEnabled) {
-      require('child_process').spawn('npm', ['run', 'serve-local-files'], {
-        cwd: process.cwd(),
-        stdio: 'inherit'
+      const child: ChildProcess = require('child_process').spawn(
+        'npx',
+        [
+          'http-server',
+          `${this.PATH_PREFIX}`,
+          '--ssl',
+          '--cert',
+          `${config.server.certPath}`,
+          '--key',
+          `${config.server.keyPath}`,
+          '--port',
+          '8642',
+          '--cors=*',
+          '--brotli',
+          '--gzip'
+        ],
+        {
+          cwd: process.cwd(),
+          stdio: 'inherit',
+          detached: true
+        }
+      )
+      process.on('exit', async () => {
+        process.kill(-child.pid!, 'SIGINT')
       })
     }
     this.getOriginURLs().then((result) => (this.originURLs = result))


### PR DESCRIPTION
## Summary
Detach http server process so that we can kill the process from the main process on exit.(yes you can define multiple exit queries.)

Pulled this up out of #9149 

## References
closes #8958 

## QA Steps
