### PR TITLE
persist collapsed model objects on hieararchy panel

### DIFF
--- a/packages/editor/src/components/hierarchy/HeirarchyTreeWalker.ts
+++ b/packages/editor/src/components/hierarchy/HeirarchyTreeWalker.ts
@@ -27,7 +27,7 @@ import { Entity } from '@etherealengine/engine/src/ecs/classes/Entity'
 import { getComponent, hasComponent } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
 import { entityExists } from '@etherealengine/engine/src/ecs/functions/EntityFunctions'
 import { EntityTreeComponent } from '@etherealengine/engine/src/ecs/functions/EntityTree'
-import { UUIDComponent } from '@etherealengine/engine/src/scene/components/UUIDComponent'
+import { SceneID } from '@etherealengine/engine/src/schemas/projects/scene.schema'
 import { getState } from '@etherealengine/hyperflux'
 import { EditorState } from '../../services/EditorServices'
 
@@ -49,7 +49,11 @@ export type HeirarchyTreeCollapsedNodeType = { [key: number]: boolean }
  *
  * @param  {entityNode}    expandedNodes
  */
-export function* heirarchyTreeWalker(treeNode: Entity, selectedEntities: Entity[]): Generator<HeirarchyTreeNodeType> {
+export function* heirarchyTreeWalker(
+  activeScene: SceneID,
+  treeNode: Entity,
+  selectedEntities: Entity[]
+): Generator<HeirarchyTreeNodeType> {
   if (!treeNode) return
 
   const stack = [] as HeirarchyTreeNodeType[]
@@ -62,9 +66,8 @@ export function* heirarchyTreeWalker(treeNode: Entity, selectedEntities: Entity[
     if (!entityExists(entityNode)) continue
 
     const expandedNodes = getState(EditorState).expandedNodes
-    const entityUUID = getComponent(entityNode, UUIDComponent)
 
-    const isCollapsed = !expandedNodes[entityUUID]
+    const isCollapsed = !expandedNodes[activeScene]?.[entityNode]
 
     const entityTreeComponent = getComponent(entityNode as Entity, EntityTreeComponent)
 

--- a/packages/editor/src/components/hierarchy/HierarchyPanelContainer.tsx
+++ b/packages/editor/src/components/hierarchy/HierarchyPanelContainer.tsx
@@ -36,7 +36,7 @@ import { getComponent, getOptionalComponent } from '@etherealengine/engine/src/e
 import { EntityTreeComponent, traverseEntityNode } from '@etherealengine/engine/src/ecs/functions/EntityTree'
 import { GroupComponent } from '@etherealengine/engine/src/scene/components/GroupComponent'
 import { NameComponent } from '@etherealengine/engine/src/scene/components/NameComponent'
-import { getMutableState, getState, none, useHookstate } from '@etherealengine/hyperflux'
+import { NO_PROXY, getMutableState, getState, none, useHookstate } from '@etherealengine/hyperflux'
 
 import MenuItem from '@mui/material/MenuItem'
 import { PopoverPosition } from '@mui/material/Popover'
@@ -114,8 +114,11 @@ export default function HierarchyPanel() {
     if (!activeScene.value) return
 
     const rootUUID = SceneState.getScene(activeScene.value)!.scene.root!
+    const rootEntity = UUIDComponent.entitiesByUUID[rootUUID]
 
-    getMutableState(EditorState).expandedNodes.set({ [rootUUID]: true })
+    if (!expandedNodes.value[activeScene.value] && rootEntity) {
+      expandedNodes.set({ [activeScene.value]: { [rootEntity]: true } })
+    }
   }, [activeScene])
 
   useEffect(() => {
@@ -123,6 +126,7 @@ export default function HierarchyPanel() {
     setNodes(
       Array.from(
         heirarchyTreeWalker(
+          activeScene.value,
           SceneState.getRootEntity(getState(SceneState).activeScene!),
           selectionState.selectedEntities.value
         )
@@ -135,26 +139,29 @@ export default function HierarchyPanel() {
   /* Expand & Collapse Functions */
   const expandNode = useCallback(
     (node: HeirarchyTreeNodeType) => {
-      const uuid = getComponent(node.entity, UUIDComponent)
-      getMutableState(EditorState).expandedNodes[uuid].set(true)
+      const scene = activeScene.get(NO_PROXY)
+      if (!scene) return
+      expandedNodes[scene][node.entity].set(true)
     },
-    [expandedNodes]
+    [expandedNodes, activeScene]
   )
 
   const collapseNode = useCallback(
     (node: HeirarchyTreeNodeType) => {
-      const uuid = getComponent(node.entity, UUIDComponent)
-      getMutableState(EditorState).expandedNodes[uuid].set(none)
+      const scene = activeScene.get(NO_PROXY)
+      if (!scene) return
+      expandedNodes[scene][node.entity].set(none)
     },
-    [expandedNodes]
+    [expandedNodes, activeScene]
   )
 
   const expandChildren = useCallback(
     (node: HeirarchyTreeNodeType) => {
+      const scene = activeScene.get(NO_PROXY)
+      if (!scene) return
       handleClose()
       traverseEntityNode(node.entity, (child) => {
-        const uuid = getComponent(child, UUIDComponent)
-        getMutableState(EditorState).expandedNodes[uuid].set(true)
+        expandedNodes[scene][child].set(true)
       })
     },
     [expandedNodes]
@@ -162,10 +169,11 @@ export default function HierarchyPanel() {
 
   const collapseChildren = useCallback(
     (node: HeirarchyTreeNodeType) => {
+      const scene = activeScene.get(NO_PROXY)
+      if (!scene) return
       handleClose()
       traverseEntityNode(node.entity, (child) => {
-        const uuid = getComponent(child, UUIDComponent)
-        getMutableState(EditorState).expandedNodes[uuid].set(none)
+        expandedNodes[scene][child].set(none)
       })
     },
     [expandedNodes]
@@ -223,11 +231,11 @@ export default function HierarchyPanel() {
 
   const onToggle = useCallback(
     (_, node: HeirarchyTreeNodeType) => {
-      const uuid = getComponent(node.entity, UUIDComponent)
-      if (expandedNodes.value[uuid]) collapseNode(node)
+      if (!activeScene.value) return
+      if (expandedNodes.value[activeScene.value][node.entity]) collapseNode(node)
       else expandNode(node)
     },
-    [expandedNodes, expandNode, collapseNode]
+    [activeScene, expandedNodes, expandNode, collapseNode]
   )
 
   const onKeyDown = useCallback(

--- a/packages/editor/src/services/EditorServices.ts
+++ b/packages/editor/src/services/EditorServices.ts
@@ -24,8 +24,16 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { EntityUUID } from '@etherealengine/common/src/interfaces/EntityUUID'
-import { defineState } from '@etherealengine/hyperflux'
+import { Entity } from '@etherealengine/engine/src/ecs/classes/Entity'
+import { SceneID } from '@etherealengine/engine/src/schemas/projects/scene.schema'
+import { defineState, syncStateWithLocalStorage } from '@etherealengine/hyperflux'
 import { LayoutData } from 'rc-dock'
+
+interface IExpandedNodes {
+  [scene: SceneID]: {
+    [entity: Entity]: true
+  }
+}
 
 export const EditorState = defineState({
   name: 'EditorState',
@@ -33,8 +41,11 @@ export const EditorState = defineState({
     projectName: null as string | null,
     sceneName: null as string | null,
     sceneModified: false,
-    expandedNodes: {} as Record<EntityUUID, true>,
+    expandedNodes: {} as IExpandedNodes,
     lockPropertiesPanel: '' as EntityUUID,
     panelLayout: {} as LayoutData
-  })
+  }),
+  onCreate: () => {
+    syncStateWithLocalStorage(EditorState, ['expandedNodes'])
+  }
 })


### PR DESCRIPTION
## Summary

Persist collapsed nodes on the hierarchy panel in browser's local storage and auto-expand them when the scene is loaded.

For each scene, the `expandedNodes` state had to be different. To implement this, `expandedNodes` is now [aware of the scene](https://github.com/EtherealEngine/etherealengine/compare/feat/stored-heirarchy-model-subobjects?expand=1#diff-4baa5e089addf140a58bc6725916580bbfc8a8b468f26e15f9d1adf86aef8a00R33).

The model sub-objects (which are not in Scene JSON) are assigned `EntityUUID`s dynamically. Storing these UUIDs would not expand the hierarchy panel nodes by default. To implement this, `expandedNodes` [now stores `Entity` instead of `EntityUUID`](https://github.com/EtherealEngine/etherealengine/compare/feat/stored-heirarchy-model-subobjects?expand=1#diff-4baa5e089addf140a58bc6725916580bbfc8a8b468f26e15f9d1adf86aef8a00R34). 

## References

closes #9318 

## QA Steps

[91038206-bf3a-49f8-8c2d-4cf4b5a99853.webm](https://github.com/EtherealEngine/etherealengine/assets/55396651/f6c54b44-f36a-4644-97e7-3e77afb4c53c)
