### PR TITLE
`troika-three-text` TextComponent

### DIFF
--- a/packages/editor/src/components/element/ElementList.tsx
+++ b/packages/editor/src/components/element/ElementList.tsx
@@ -69,6 +69,7 @@ import { MountPointComponent } from '@etherealengine/engine/src/scene/components
 import { PostProcessingComponent } from '@etherealengine/engine/src/scene/components/PostProcessingComponent'
 import { SceneDynamicLoadTagComponent } from '@etherealengine/engine/src/scene/components/SceneDynamicLoadTagComponent'
 import { ShadowComponent } from '@etherealengine/engine/src/scene/components/ShadowComponent'
+import { TextComponent } from '@etherealengine/engine/src/scene/components/TextComponent'
 import { Vector3 } from 'three'
 import { PrimitiveGeometryComponent } from '../../../../engine/src/scene/components/PrimitiveGeometryComponent'
 import { ItemTypes } from '../../constants/AssetTypes'
@@ -114,7 +115,14 @@ export const ComponentShelfCategories: Record<string, Component[]> = {
   ],
   FX: [LoopAnimationComponent, ShadowComponent, ParticleSystemComponent, EnvmapComponent, PostProcessingComponent],
   Scripting: [SystemComponent, BehaveGraphComponent],
-  Misc: [EnvMapBakeComponent, ScenePreviewCameraComponent, SkyboxComponent, SplineTrackComponent, SplineComponent]
+  Misc: [
+    EnvMapBakeComponent,
+    ScenePreviewCameraComponent,
+    SkyboxComponent,
+    SplineTrackComponent,
+    SplineComponent,
+    TextComponent
+  ]
 }
 
 const SceneElementListItem = ({ item, onClick, onContextMenu }: SceneElementListItemType) => {

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -161,6 +161,19 @@ export const TextNodeEditor: EditorComponentType = (props) => {
       >
         <div>
           <NumericInputGroup
+            name="OutlineOpacity"
+            label="opacity" // {t('editor:properties.text.outlineOpacity')}  /* @todo: Translation id */
+            min={0}
+            max={100}
+            smallStep={1}
+            mediumStep={2}
+            largeStep={5}
+            value={text.outlineOpacity.value}
+            onChange={updateProperty(TextComponent, 'outlineOpacity')}
+            onRelease={commitProperty(TextComponent, 'outlineOpacity')}
+            unit="%"
+          />
+          <NumericInputGroup
             name="OutlineWidth"
             label="width" // {t('editor:properties.text.outlineWidth')}  /* @todo: Translation id */
             min={0}

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -142,6 +142,25 @@ export const TextNodeEditor: EditorComponentType = (props) => {
           </InputGroup>
         </div>
       </InputGroup>
+      <InputGroup
+        name="OutlineGroup"
+        label="Outline" // {t('editor:properties.text.outlineGroup')}  /* @todo: Translation id */
+      >
+        <div>
+          <NumericInputGroup
+            name="OutlineWidth"
+            label="width" // {t('editor:properties.text.outlineWidth')}  /* @todo: Translation id */
+            min={0}
+            smallStep={0.5}
+            mediumStep={1}
+            largeStep={2}
+            value={text.outlineWidth.value}
+            onChange={updateProperty(TextComponent, 'outlineWidth')}
+            onRelease={commitProperty(TextComponent, 'outlineWidth')}
+            unit="%"
+          />
+        </div>
+      </InputGroup>
     </NodeEditor>
   )
 }

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -205,6 +205,18 @@ export const TextNodeEditor: EditorComponentType = (props) => {
             onRelease={commitProperty(TextComponent, 'strokeOpacity')}
             unit="%"
           />
+          <NumericInputGroup
+            name="StrokeWidth"
+            label="width" // {t('editor:properties.text.strokeWidth')}  /* @todo: Translation id */
+            min={0}
+            smallStep={0.5}
+            mediumStep={1}
+            largeStep={2}
+            value={text.strokeWidth.value}
+            onChange={updateProperty(TextComponent, 'strokeWidth')}
+            onRelease={commitProperty(TextComponent, 'strokeWidth')}
+            unit="%"
+          />
         </div>
       </InputGroup>
     </NodeEditor>

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -63,6 +63,10 @@ export const TextNodeEditor: EditorComponentType = (props) => {
       { label: 'Center', value: 'center' },
       { label: 'Left', value: 'left' },
       { label: 'Right', value: 'right' }
+    ],
+    TextWrapping: [
+      { label: 'Whitespace', value: 'normal' },
+      { label: 'Break Word', value: 'break-word' }
     ]
   }
 
@@ -126,6 +130,18 @@ export const TextNodeEditor: EditorComponentType = (props) => {
               value={text.textAlign.value}
               onChange={updateProperty(TextComponent, 'textAlign')}
               //onChange={(val :TroikaTextDirection) => text.textDirection.set(val)}
+            />
+          </InputGroup>
+          <InputGroup
+            name="TextWrap"
+            label="wrap" // {t('editor:properties.text.textWrap')} /* @todo: Translation id */
+          >
+            <BooleanInput value={text.textWrap.value} onChange={text.textWrap.set} />
+            <SelectInput
+              disabled={!text.textWrap.value} // Enabled when text.textWrap is true
+              options={SelectOptions.TextWrapping}
+              value={text.textWrapKind.value}
+              onChange={updateProperty(TextComponent, 'textWrapKind')}
             />
           </InputGroup>
 

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -40,6 +40,7 @@ import ColorInput from '../inputs/ColorInput'
 import InputGroup from '../inputs/InputGroup'
 import NumericInputGroup from '../inputs/NumericInputGroup'
 import { ControlledStringInput } from '../inputs/StringInput'
+import Vector2Input from '../inputs/Vector2Input'
 
 /**
  * TextNodeEditor component used to provide the editor view to customize link properties.
@@ -197,6 +198,16 @@ export const TextNodeEditor: EditorComponentType = (props) => {
             onRelease={commitProperty(TextComponent, 'outlineBlur')}
             unit="%"
           />
+          <InputGroup
+            name="OutlineOffset"
+            label="offset" // {t('editor:properties.text.outlineOffset')} /* @todo: Translation id */
+          >
+            <Vector2Input
+              value={text.outlineOffset.value}
+              onChange={updateProperty(TextComponent, 'outlineOffset')}
+              onRelease={commitProperty(TextComponent, 'outlineOffset')}
+            />
+          </InputGroup>
         </div>
       </InputGroup>
       <InputGroup

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -46,31 +46,35 @@ import { ControlledStringInput } from '../inputs/StringInput'
 import Vector2Input from '../inputs/Vector2Input'
 
 /**
- * TextNodeEditor component used to provide the editor a view to customize text properties.
- *
+ * @description SelectInput option groups for the TextNodeEditor UI tsx code.
+ * @local Stored `@local` scope of the file, so it only exists once and its not GC'ed when the component is used.
+ */
+const SelectOptions = {
+  TextDirection: [
+    { label: 'Auto', value: 'auto' },
+    { label: 'Left to Right', value: 'ltr' },
+    { label: 'Right to Left', value: 'rtl' }
+  ],
+  TextAlignment: [
+    { label: 'Justify', value: 'justify' },
+    { label: 'Center', value: 'center' },
+    { label: 'Left', value: 'left' },
+    { label: 'Right', value: 'right' }
+  ],
+  TextWrapping: [
+    { label: 'Whitespace', value: 'normal' },
+    { label: 'Break Word', value: 'break-word' }
+  ]
+}
+
+/**
+ * @description TextNodeEditor component used to provide the editor a view to customize text properties.
  * @type {Class component}
  */
 export const TextNodeEditor: EditorComponentType = (props) => {
   const { t } = useTranslation()
   const text = useComponent(props.entity, TextComponent)
   const advancedActive = useHookstate(false)
-  const SelectOptions = {
-    TextDirection: [
-      { label: 'Auto', value: 'auto' },
-      { label: 'Left to Right', value: 'ltr' },
-      { label: 'Right to Left', value: 'rtl' }
-    ],
-    TextAlignment: [
-      { label: 'Justify', value: 'justify' },
-      { label: 'Center', value: 'center' },
-      { label: 'Left', value: 'left' },
-      { label: 'Right', value: 'right' }
-    ],
-    TextWrapping: [
-      { label: 'Whitespace', value: 'normal' },
-      { label: 'Break Word', value: 'break-word' }
-    ]
-  }
 
   return (
     <NodeEditor {...props} name="Text Component" description="A Text component">

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -247,6 +247,16 @@ export const TextNodeEditor: EditorComponentType = (props) => {
         label="Outline" // {t('editor:properties.text.outlineGroup')}  /* @todo: Translation id */
       >
         <div>
+          <InputGroup
+            name="OutlineColor"
+            label="color" // {t('editor:properties.text.outlineColor')}  /* @todo: Translation id */
+          >
+            <ColorInput
+              value={text.outlineColor.value}
+              onChange={updateProperty(TextComponent, 'outlineColor')}
+              onRelease={commitProperty(TextComponent, 'outlineColor')}
+            />
+          </InputGroup>
           <NumericInputGroup
             name="OutlineOpacity"
             label="opacity" // {t('editor:properties.text.outlineOpacity')}  /* @todo: Translation id */
@@ -298,9 +308,19 @@ export const TextNodeEditor: EditorComponentType = (props) => {
       </InputGroup>
       <InputGroup
         name="StrokeGroup"
-        label="Stroke" // {t('editor:properties.text.StrokeGroup')}  /* @todo: Translation id */
+        label="Stroke" // {t('editor:properties.text.strokeGroup')}  /* @todo: Translation id */
       >
         <div>
+          <InputGroup
+            name="StrokeColor"
+            label="color" // {t('editor:properties.text.strokeColor')}  /* @todo: Translation id */
+          >
+            <ColorInput
+              value={text.strokeColor.value}
+              onChange={updateProperty(TextComponent, 'strokeColor')}
+              onRelease={commitProperty(TextComponent, 'strokeColor')}
+            />
+          </InputGroup>
           <NumericInputGroup
             name="StrokeOpacity"
             label="opacity" // {t('editor:properties.text.strokeOpacity)}  /* @todo: Translation id */

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -114,6 +114,17 @@ export const TextNodeEditor: EditorComponentType = (props) => {
             />
           </InputGroup>
           <NumericInputGroup
+            name="TextDepthOffset"
+            label="depthOffset" // {t('editor:properties.text.textDepthOffset')}  /* @todo: Translation id */
+            smallStep={0.01}
+            mediumStep={0.1}
+            largeStep={0.25}
+            value={text.textDepthOffset.value}
+            onChange={updateProperty(TextComponent, 'textDepthOffset')}
+            onRelease={commitProperty(TextComponent, 'textDepthOffset')}
+            unit="px"
+          />
+          <NumericInputGroup
             name="TextCurveRadius"
             label="curveRadius" // {t('editor:properties.text.textCurveRadius')}  /* @todo: Translation id */
             smallStep={1}

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -174,6 +174,26 @@ export const TextNodeEditor: EditorComponentType = (props) => {
           />
         </div>
       </InputGroup>
+      <InputGroup
+        name="StrokeGroup"
+        label="Stroke" // {t('editor:properties.text.StrokeGroup')}  /* @todo: Translation id */
+      >
+        <div>
+          <NumericInputGroup
+            name="StrokeOpacity"
+            label="opacity" // {t('editor:properties.text.strokeOpacity)}  /* @todo: Translation id */
+            min={0}
+            max={100}
+            smallStep={1}
+            mediumStep={2}
+            largeStep={10}
+            value={text.strokeOpacity.value}
+            onChange={updateProperty(TextComponent, 'strokeOpacity')}
+            onRelease={commitProperty(TextComponent, 'strokeOpacity')}
+            unit="%"
+          />
+        </div>
+      </InputGroup>
     </NodeEditor>
   )
 }

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -52,13 +52,33 @@ export const TextNodeEditor: EditorComponentType = (props) => {
 
   return (
     <NodeEditor {...props} name="Text Component" description="A Text component">
-      <InputGroup name="Text" label="Text">
+      <InputGroup name="TextContents" label="Contents">
         <ControlledStringInput
           value={text.text.value}
           onChange={updateProperty(TextComponent, 'text')}
           onRelease={commitProperty(TextComponent, 'text')}
         />
       </InputGroup>
+      <InputGroup
+        name="TextGroup"
+        label="Text" // {t('editor:properties.text.textGroup')}  /* @todo: Translation id */
+      >
+        <div>
+          <NumericInputGroup
+            name="TextIndent"
+            label="indent" // {t('editor:properties.text.textIndent')}  /* @todo: Translation id */
+            min={0}
+            smallStep={0.1}
+            mediumStep={0.5}
+            largeStep={1}
+            value={text.textIndent.value}
+            onChange={updateProperty(TextComponent, 'textIndent')}
+            onRelease={commitProperty(TextComponent, 'textIndent')}
+            unit="px"
+          />
+        </div>
+      </InputGroup>
+
       <InputGroup
         name="FontGroup"
         label="Font" // {t('editor:properties.text.fontGroup')}  /* @todo: Translation id */

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -59,27 +59,44 @@ export const TextNodeEditor: EditorComponentType = (props) => {
           onRelease={commitProperty(TextComponent, 'text')}
         />
       </InputGroup>
-      <NumericInputGroup
-        name="FontSize"
-        label="Font.size" // {t('editor:properties.text.fontSize')}  /* @todo: Translation id */
-        min={0}
-        smallStep={1}
-        mediumStep={2}
-        largeStep={4}
-        value={text.fontSize.value}
-        onChange={updateProperty(TextComponent, 'fontSize')}
-        onRelease={commitProperty(TextComponent, 'fontSize')}
-        unit="px"
-      />
       <InputGroup
-        name="FontColor"
-        label="Font.color" // {t('editor:properties.text.fontColor')}  /* @todo: Translation id */
+        name="FontGroup"
+        label="Font" // {t('editor:properties.text.fontGroup')}  /* @todo: Translation id */
       >
-        <ColorInput
-          value={text.fontColor.value}
-          onChange={updateProperty(TextComponent, 'fontColor')}
-          onRelease={commitProperty(TextComponent, 'fontColor')}
-        />
+        <div>
+          <InputGroup
+            name="FontFamily"
+            label="family" // {t('editor:properties.text.fontGroup')}  /* @todo: Translation id */
+          >
+            <ControlledStringInput
+              value={text.font.value!}
+              onChange={updateProperty(TextComponent, 'font')}
+              onRelease={commitProperty(TextComponent, 'font')}
+            />
+          </InputGroup>
+          <NumericInputGroup
+            name="FontSize"
+            label="size" // {t('editor:properties.text.fontSize')}  /* @todo: Translation id */
+            min={0}
+            smallStep={0.01}
+            mediumStep={0.1}
+            largeStep={0.5}
+            value={text.fontSize.value}
+            onChange={updateProperty(TextComponent, 'fontSize')}
+            onRelease={commitProperty(TextComponent, 'fontSize')}
+            unit="em"
+          />
+          <InputGroup
+            name="FontColor"
+            label="color" // {t('editor:properties.text.fontColor')}  /* @todo: Translation id */
+          >
+            <ColorInput
+              value={text.fontColor.value}
+              onChange={updateProperty(TextComponent, 'fontColor')}
+              onRelease={commitProperty(TextComponent, 'fontColor')}
+            />
+          </InputGroup>
+        </div>
       </InputGroup>
     </NodeEditor>
   )

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -65,6 +65,18 @@ export const TextNodeEditor: EditorComponentType = (props) => {
       >
         <div>
           <NumericInputGroup
+            name="TextWidth"
+            label="width" // {t('editor:properties.text.textWidth')}  /* @todo: Translation id */
+            min={0}
+            smallStep={0.01}
+            mediumStep={0.1}
+            largeStep={0.5}
+            value={text.textWidth.value}
+            onChange={updateProperty(TextComponent, 'textWidth')}
+            onRelease={commitProperty(TextComponent, 'textWidth')}
+            unit="px"
+          />
+          <NumericInputGroup
             name="TextIndent"
             label="indent" // {t('editor:properties.text.textIndent')}  /* @todo: Translation id */
             min={0}

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -57,6 +57,12 @@ export const TextNodeEditor: EditorComponentType = (props) => {
       { label: 'Auto', value: 'auto' },
       { label: 'Left to Right', value: 'ltr' },
       { label: 'Right to Left', value: 'rtl' }
+    ],
+    TextAlignment: [
+      { label: 'Justify', value: 'justify' },
+      { label: 'Center', value: 'center' },
+      { label: 'Left', value: 'left' },
+      { label: 'Right', value: 'right' }
     ]
   }
 
@@ -111,6 +117,18 @@ export const TextNodeEditor: EditorComponentType = (props) => {
             onRelease={commitProperty(TextComponent, 'textIndent')}
             unit="px"
           />
+          <InputGroup
+            name="TextAlign"
+            label="align" // {t('editor:properties.text.textAlign')} /* @todo: Translation id */
+          >
+            <SelectInput
+              options={SelectOptions.TextAlignment}
+              value={text.textAlign.value}
+              onChange={updateProperty(TextComponent, 'textAlign')}
+              //onChange={(val :TroikaTextDirection) => text.textDirection.set(val)}
+            />
+          </InputGroup>
+
           <InputGroup
             name="TextAnchor"
             label="anchor" // {t('editor:properties.text.textAnchor')} /* @todo: Translation id */

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -65,6 +65,19 @@ export const TextNodeEditor: EditorComponentType = (props) => {
       >
         <div>
           <NumericInputGroup
+            name="TextOpacity"
+            label="opacity" // {t('editor:properties.text.textOpacity')}  /* @todo: Translation id */
+            min={0}
+            max={100}
+            smallStep={1}
+            mediumStep={5}
+            largeStep={10}
+            value={text.textOpacity.value}
+            onChange={updateProperty(TextComponent, 'textOpacity')}
+            onRelease={commitProperty(TextComponent, 'textOpacity')}
+            unit="%"
+          />
+          <NumericInputGroup
             name="TextWidth"
             label="width" // {t('editor:properties.text.textWidth')}  /* @todo: Translation id */
             min={0}

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -103,6 +103,16 @@ export const TextNodeEditor: EditorComponentType = (props) => {
             onRelease={commitProperty(TextComponent, 'textIndent')}
             unit="px"
           />
+          <InputGroup
+            name="TextAnchor"
+            label="anchor" // {t('editor:properties.text.textAnchor')} /* @todo: Translation id */
+          >
+            <Vector2Input
+              value={text.textAnchor.value}
+              onChange={updateProperty(TextComponent, 'textAnchor')}
+              onRelease={commitProperty(TextComponent, 'textAnchor')}
+            />
+          </InputGroup>
           <NumericInputGroup
             name="LettersSpacing"
             label="spacing" // {t('editor:properties.text.letterSpacing')}  /* @todo: Translation id */

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -114,6 +114,17 @@ export const TextNodeEditor: EditorComponentType = (props) => {
             />
           </InputGroup>
           <NumericInputGroup
+            name="TextCurveRadius"
+            label="curveRadius" // {t('editor:properties.text.textCurveRadius')}  /* @todo: Translation id */
+            smallStep={1}
+            mediumStep={5}
+            largeStep={15}
+            value={text.textCurveRadius.value}
+            onChange={updateProperty(TextComponent, 'textCurveRadius')}
+            onRelease={commitProperty(TextComponent, 'textCurveRadius')}
+            unit="deg"
+          />
+          <NumericInputGroup
             name="LettersSpacing"
             label="spacing" // {t('editor:properties.text.letterSpacing')}  /* @todo: Translation id */
             min={-0.5}

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -36,6 +36,7 @@ import {
 import NodeEditor from '@etherealengine/editor/src/components/properties/NodeEditor'
 import { useComponent } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
 import { TextComponent } from '@etherealengine/engine/src/scene/components/TextComponent'
+import BooleanInput from '../inputs/BooleanInput'
 import ColorInput from '../inputs/ColorInput'
 import InputGroup from '../inputs/InputGroup'
 import NumericInputGroup from '../inputs/NumericInputGroup'
@@ -241,6 +242,12 @@ export const TextNodeEditor: EditorComponentType = (props) => {
             unit="%"
           />
         </div>
+      </InputGroup>
+      <InputGroup
+        name="GPUAccelerated"
+        label="GPU Accelerated" // {t('editor:properties.textbox.gpuAccelerated')}  /* @todo: Translation id */
+      >
+        <BooleanInput value={text.gpuAccelerated.value} onChange={text.gpuAccelerated.set} />
       </InputGroup>
     </NodeEditor>
   )

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -40,17 +40,25 @@ import BooleanInput from '../inputs/BooleanInput'
 import ColorInput from '../inputs/ColorInput'
 import InputGroup from '../inputs/InputGroup'
 import NumericInputGroup from '../inputs/NumericInputGroup'
+import SelectInput from '../inputs/SelectInput'
 import { ControlledStringInput } from '../inputs/StringInput'
 import Vector2Input from '../inputs/Vector2Input'
 
 /**
- * TextNodeEditor component used to provide the editor view to customize link properties.
+ * TextNodeEditor component used to provide the editor a view to customize text properties.
  *
  * @type {Class component}
  */
 export const TextNodeEditor: EditorComponentType = (props) => {
   const { t } = useTranslation()
   const text = useComponent(props.entity, TextComponent)
+  const SelectOptions = {
+    TextDirection: [
+      { label: 'Auto', value: 'auto' },
+      { label: 'Left to Right', value: 'ltr' },
+      { label: 'Right to Left', value: 'rtl' }
+    ]
+  }
 
   return (
     <NodeEditor {...props} name="Text Component" description="A Text component">
@@ -147,6 +155,17 @@ export const TextNodeEditor: EditorComponentType = (props) => {
             onRelease={commitProperty(TextComponent, 'letterSpacing')}
             unit="px"
           />
+          <InputGroup
+            name="TextDirection"
+            label="direction" // {t('editor:properties.text.textDirection')} /* @todo: Translation id */
+          >
+            <SelectInput
+              options={SelectOptions.TextDirection}
+              value={text.textDirection.value}
+              onChange={updateProperty(TextComponent, 'textDirection')}
+              //onChange={(val :TroikaTextDirection) => text.textDirection.set(val)}
+            />
+          </InputGroup>
         </div>
       </InputGroup>
 

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -1,0 +1,90 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import TextFieldsIcon from '@mui/icons-material/TextFields'
+
+import {
+  EditorComponentType,
+  commitProperty,
+  updateProperty
+} from '@etherealengine/editor/src/components/properties//Util'
+import NodeEditor from '@etherealengine/editor/src/components/properties/NodeEditor'
+import { useComponent } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
+import { TextComponent } from '@etherealengine/engine/src/scene/components/TextComponent'
+import ColorInput from '../inputs/ColorInput'
+import InputGroup from '../inputs/InputGroup'
+import NumericInputGroup from '../inputs/NumericInputGroup'
+import { ControlledStringInput } from '../inputs/StringInput'
+
+/**
+ * TextNodeEditor component used to provide the editor view to customize link properties.
+ *
+ * @type {Class component}
+ */
+export const TextNodeEditor: EditorComponentType = (props) => {
+  const { t } = useTranslation()
+  const text = useComponent(props.entity, TextComponent)
+
+  return (
+    <NodeEditor {...props} name="Text Component" description="A Text component">
+      <InputGroup name="Text" label="Text">
+        <ControlledStringInput
+          value={text.text.value}
+          onChange={updateProperty(TextComponent, 'text')}
+          onRelease={commitProperty(TextComponent, 'text')}
+        />
+      </InputGroup>
+      <NumericInputGroup
+        name="FontSize"
+        label="Font.size" // {t('editor:properties.text.fontSize')}  /* @todo: Translation id */
+        min={0}
+        smallStep={1}
+        mediumStep={2}
+        largeStep={4}
+        value={text.fontSize.value}
+        onChange={updateProperty(TextComponent, 'fontSize')}
+        onRelease={commitProperty(TextComponent, 'fontSize')}
+        unit="px"
+      />
+      <InputGroup
+        name="FontColor"
+        label="Font.color" // {t('editor:properties.text.fontColor')}  /* @todo: Translation id */
+      >
+        <ColorInput
+          value={text.fontColor.value}
+          onChange={updateProperty(TextComponent, 'fontColor')}
+          onRelease={commitProperty(TextComponent, 'fontColor')}
+        />
+      </InputGroup>
+    </NodeEditor>
+  )
+}
+
+TextNodeEditor.iconComponent = TextFieldsIcon
+
+export default TextNodeEditor

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -36,6 +36,7 @@ import {
 import NodeEditor from '@etherealengine/editor/src/components/properties/NodeEditor'
 import { useComponent } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
 import { TextComponent } from '@etherealengine/engine/src/scene/components/TextComponent'
+import { useHookstate } from '@hookstate/core'
 import BooleanInput from '../inputs/BooleanInput'
 import ColorInput from '../inputs/ColorInput'
 import InputGroup from '../inputs/InputGroup'
@@ -52,6 +53,7 @@ import Vector2Input from '../inputs/Vector2Input'
 export const TextNodeEditor: EditorComponentType = (props) => {
   const { t } = useTranslation()
   const text = useComponent(props.entity, TextComponent)
+  const advancedActive = useHookstate(false)
   const SelectOptions = {
     TextDirection: [
       { label: 'Auto', value: 'auto' },
@@ -107,19 +109,19 @@ export const TextNodeEditor: EditorComponentType = (props) => {
             value={text.textWidth.value}
             onChange={updateProperty(TextComponent, 'textWidth')}
             onRelease={commitProperty(TextComponent, 'textWidth')}
-            unit="px"
+            unit="em"
           />
           <NumericInputGroup
             name="TextIndent"
             label="indent" // {t('editor:properties.text.textIndent')}  /* @todo: Translation id */
             min={0}
-            smallStep={0.1}
-            mediumStep={0.5}
-            largeStep={1}
+            smallStep={0.01}
+            mediumStep={0.1}
+            largeStep={0.5}
             value={text.textIndent.value}
             onChange={updateProperty(TextComponent, 'textIndent')}
             onRelease={commitProperty(TextComponent, 'textIndent')}
-            unit="px"
+            unit="em"
           />
           <InputGroup
             name="TextAlign"
@@ -202,7 +204,6 @@ export const TextNodeEditor: EditorComponentType = (props) => {
           </InputGroup>
         </div>
       </InputGroup>
-
       <InputGroup
         name="FontGroup"
         label="Font" // {t('editor:properties.text.fontGroup')}  /* @todo: Translation id */
@@ -349,11 +350,81 @@ export const TextNodeEditor: EditorComponentType = (props) => {
         </div>
       </InputGroup>
       <InputGroup
-        name="GPUAccelerated"
-        label="GPU Accelerated" // {t('editor:properties.textbox.gpuAccelerated')}  /* @todo: Translation id */
+        name="AdvancedActive"
+        label="Show Advanced" // {t('editor:properties.textbox.advancedActive')}  /* @todo: Translation id */
       >
-        <BooleanInput value={text.gpuAccelerated.value} onChange={text.gpuAccelerated.set} />
+        <BooleanInput value={advancedActive.value} onChange={advancedActive.set} />
       </InputGroup>
+      {advancedActive.value ? (
+        /*Show Advanced Options only when Active*/
+        <InputGroup
+          name="AdvancedGroup"
+          label="Advanced" // {t('editor:properties.textbox.advancedGroup')}  /* @todo: Translation id */
+        >
+          <div>
+            <InputGroup
+              name="ClippingActive"
+              label="clip.active" // {t('editor:properties.textbox.clippingActive')}  /* @todo: Translation id */
+            >
+              <BooleanInput value={text.clipActive.value} onChange={text.clipActive.set} />
+            </InputGroup>
+            <InputGroup
+              disabled={!text.clipActive.value}
+              name="ClippingMin"
+              label="clip.min" // {t('editor:properties.text.clippingMin')} /* @todo: Translation id */
+            >
+              <Vector2Input
+                value={text.clipRectMin.value}
+                onChange={updateProperty(TextComponent, 'clipRectMin')}
+                onRelease={commitProperty(TextComponent, 'clipRectMin')}
+              />
+            </InputGroup>
+            <InputGroup
+              disabled={!text.clipActive.value}
+              name="ClippingMax"
+              label="clip.max" // {t('editor:properties.text.clippingMax')} /* @todo: Translation id */
+            >
+              <Vector2Input
+                value={text.clipRectMax.value}
+                onChange={updateProperty(TextComponent, 'clipRectMax')}
+                onRelease={commitProperty(TextComponent, 'clipRectMax')}
+              />
+            </InputGroup>
+            <NumericInputGroup
+              name="GlyphResolution"
+              label="glyph.resolution" // {t('editor:properties.text.glyphResolution')}  /* @todo: Translation id */
+              min={1}
+              smallStep={1}
+              mediumStep={1}
+              largeStep={2}
+              value={text.glyphResolution.value}
+              onChange={updateProperty(TextComponent, 'glyphResolution')}
+              onRelease={commitProperty(TextComponent, 'glyphResolution')}
+              unit="2^N"
+            />
+            <NumericInputGroup
+              name="GlyphDetail"
+              label="glyph.detail" // {t('editor:properties.text.glyphDetail')}  /* @todo: Translation id */
+              min={1}
+              smallStep={1}
+              mediumStep={1}
+              largeStep={1}
+              value={text.glyphDetail.value}
+              onChange={updateProperty(TextComponent, 'glyphDetail')}
+              onRelease={commitProperty(TextComponent, 'glyphDetail')}
+              unit="subdiv"
+            />
+            <InputGroup
+              name="GPUAccelerated"
+              label="GPU Accelerated" // {t('editor:properties.textbox.gpuAccelerated')}  /* @todo: Translation id */
+            >
+              <BooleanInput value={text.gpuAccelerated.value} onChange={text.gpuAccelerated.set} />
+            </InputGroup>
+          </div>
+        </InputGroup>
+      ) : (
+        <>{/*advanced.inactive*/}</>
+      )}
     </NodeEditor>
   )
 }

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -185,6 +185,18 @@ export const TextNodeEditor: EditorComponentType = (props) => {
             onRelease={commitProperty(TextComponent, 'outlineWidth')}
             unit="%"
           />
+          <NumericInputGroup
+            name="OutlineBlur"
+            label="blur" // {t('editor:properties.text.outlineBlur')}  /* @todo: Translation id */
+            min={0}
+            smallStep={1}
+            mediumStep={2}
+            largeStep={5}
+            value={text.outlineBlur.value}
+            onChange={updateProperty(TextComponent, 'outlineBlur')}
+            onRelease={commitProperty(TextComponent, 'outlineBlur')}
+            unit="%"
+          />
         </div>
       </InputGroup>
       <InputGroup

--- a/packages/editor/src/components/properties/TextNodeEditor.tsx
+++ b/packages/editor/src/components/properties/TextNodeEditor.tsx
@@ -76,6 +76,18 @@ export const TextNodeEditor: EditorComponentType = (props) => {
             onRelease={commitProperty(TextComponent, 'textIndent')}
             unit="px"
           />
+          <NumericInputGroup
+            name="LettersSpacing"
+            label="spacing" // {t('editor:properties.text.letterSpacing')}  /* @todo: Translation id */
+            min={-0.5}
+            smallStep={0.01}
+            mediumStep={0.1}
+            largeStep={0.2}
+            value={text.letterSpacing.value}
+            onChange={updateProperty(TextComponent, 'letterSpacing')}
+            onRelease={commitProperty(TextComponent, 'letterSpacing')}
+            unit="px"
+          />
         </div>
       </InputGroup>
 

--- a/packages/editor/src/functions/ComponentEditors.tsx
+++ b/packages/editor/src/functions/ComponentEditors.tsx
@@ -80,6 +80,7 @@ import { LinkComponent } from '@etherealengine/engine/src/scene/components/LinkC
 import { ShadowComponent } from '@etherealengine/engine/src/scene/components/ShadowComponent'
 
 import { PrimitiveGeometryComponent } from '@etherealengine/engine/src/scene/components/PrimitiveGeometryComponent'
+import { TextComponent } from '@etherealengine/engine/src/scene/components/TextComponent'
 import LinkNodeEditor from '../components/properties/LinkNodeEditor'
 import LoopAnimationNodeEditor from '../components/properties/LoopAnimationNodeEditor'
 import MediaNodeEditor from '../components/properties/MediaNodeEditor'
@@ -104,6 +105,7 @@ import { SplineNodeEditor } from '../components/properties/SplineNodeEditor'
 import { SplineTrackNodeEditor } from '../components/properties/SplineTrackNodeEditor'
 import SpotLightNodeEditor from '../components/properties/SpotLightNodeEditor'
 import SystemNodeEditor from '../components/properties/SystemNodeEditor'
+import TextNodeEditor from '../components/properties/TextNodeEditor'
 import { EditorComponentType } from '../components/properties/Util'
 import { VariantNodeEditor } from '../components/properties/VariantNodeEditor'
 import VideoNodeEditor from '../components/properties/VideoNodeEditor'
@@ -153,3 +155,4 @@ EntityNodeEditor.set(SplineComponent, SplineNodeEditor)
 EntityNodeEditor.set(SplineTrackComponent, SplineTrackNodeEditor)
 EntityNodeEditor.set(BehaveGraphComponent, BehaveGraphNodeEditor)
 EntityNodeEditor.set(LinkComponent, LinkNodeEditor)
+EntityNodeEditor.set(TextComponent, TextNodeEditor)

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -32,7 +32,6 @@
     "@behave-graph/core": "https://gitpkg.now.sh/bhouston/behave-graph/packages/core?main",
     "@behave-graph/scene": "https://gitpkg.now.sh/bhouston/behave-graph/packages/scene?main",
     "@behave-graph/struct": "https://gitpkg.now.sh/etherealengine/behave-graph/packages/struct?dev",
-
     "@dimforge/rapier3d-compat": "0.11.1",
     "@etherealengine/common": "^1.5.0",
     "@etherealengine/hyperflux": "^1.5.0",
@@ -69,6 +68,7 @@
     "three": "0.158.0",
     "three-mesh-bvh": "^0.6.8",
     "three.quarks": "0.11.1",
+    "troika-three-text": "^0.49.0",
     "ts-matches": "5.3.0",
     "typescript": "5.0.2",
     "web-worker": "1.2.0"

--- a/packages/engine/src/scene/SceneModule.ts
+++ b/packages/engine/src/scene/SceneModule.ts
@@ -65,6 +65,7 @@ import { SplineComponent } from './components/SplineComponent'
 import { SplineTrackComponent } from './components/SplineTrackComponent'
 import { SpotLightComponent } from './components/SpotLightComponent'
 import { SystemComponent } from './components/SystemComponent'
+import { TextComponent } from './components/TextComponent'
 import { VariantComponent } from './components/VariantComponent'
 import { VideoComponent } from './components/VideoComponent'
 import { VisibleComponent } from './components/VisibleComponent'
@@ -127,7 +128,8 @@ export const SceneComponents = [
   WaterComponent,
   TransformComponent,
   XRAnchorComponent,
-  LinkComponent
+  LinkComponent,
+  TextComponent
 ]
 
 export {

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -64,6 +64,8 @@ type TextMesh = Mesh & {
   textIndent: number /** Indentation for the first character of a line; see CSS `text-indent`. */
   letterSpacing: number /** Spacing between letters after kerning is applied. */
   maxWidth: number /** Value above which text starts wrapping */
+  anchorX: number | string | 'left' | 'center' | 'right'
+  anchorY: number | string | 'top' | 'top-baseline' | 'top-cap' | 'top-ex' | 'middle' | 'bottom-baseline' | 'bottom'
   // Font properties
   font: string | null /** Defaults to Noto Sans when null */
   fontSize: number
@@ -119,11 +121,6 @@ type TextMesh = Mesh & {
   // TODO                                                      //
   //  Remove the unused properties. Only temp for easier dev  //
   //_________________________________________________________//
-  // Defines the position in the text block that should line up with the local origin.
-  // Can be specified as a numeric x position in local units, a string percentage of the total
-  // text block width e.g. `'25%'`, or one of the allowed keyword strings
-  anchorX: number | string | 'left' | 'center' | 'right'
-  anchorY: number | string | 'top' | 'top-baseline' | 'top-cap' | 'top-ex' | 'middle' | 'bottom-baseline' | 'bottom'
   // Sets the base direction for the text. The default value of "auto" will choose a direction based
   // on the text's content according to the bidi spec. A value of "ltr" or "rtl" will force the direction.
   direction: 'auto' | 'ltr' | 'rtl'
@@ -193,7 +190,12 @@ export const TextComponent = defineComponent({
       textOpacity: 100, // range[0..100], sent to troika as [0..1] :number
       textWidth: Infinity,
       textIndent: 0,
+      textAnchor: new Vector2(
+        /* X */ 0, // range[0..100+], sent to troika as [0..100]% :string
+        /* Y */ 0 // range[0..100+], sent to troika as [0..100]% :string
+      ),
       letterSpacing: 0,
+
       // Font Properties
       font: FontDefault, // font: string|null
       fontSize: 0.2,
@@ -223,6 +225,7 @@ export const TextComponent = defineComponent({
     if (matches.number.test(json.textOpacity)) component.textOpacity.set(json.textOpacity)
     if (matches.number.test(json.textWidth)) component.textWidth.set(json.textWidth)
     if (matches.number.test(json.textIndent)) component.textIndent.set(json.textIndent)
+    if (matches.object.test(json.textAnchor) && json.textAnchor.isVector2) component.textAnchor.set(json.textAnchor)
     if (matches.number.test(json.letterSpacing)) component.letterSpacing.set(json.letterSpacing)
     // Font Properties
     if (matches.string.test(json.font)) component.font.set(json.font)
@@ -246,6 +249,7 @@ export const TextComponent = defineComponent({
       textOpacity: component.textOpacity.value,
       textWidth: component.textWidth.value,
       textIndent: component.textIndent.value,
+      textAnchor: component.textAnchor.value,
       letterSpacing: component.letterSpacing.value,
       // Font Properties
       font: component.font.value,
@@ -275,6 +279,8 @@ export const TextComponent = defineComponent({
       text.troikaMesh.value.fillOpacity = text.textOpacity.value / 100
       text.troikaMesh.value.maxWidth = text.textWidth.value
       text.troikaMesh.value.textIndent = text.textIndent.value
+      text.troikaMesh.value.anchorX = `${text.textAnchor.x.value}%`
+      text.troikaMesh.value.anchorY = `${text.textAnchor.y.value}%`
       text.troikaMesh.value.letterSpacing = text.letterSpacing.value
       // Update the font properties
       text.troikaMesh.value.font = text.font.value
@@ -294,6 +300,7 @@ export const TextComponent = defineComponent({
       text.text,
       text.textOpacity,
       text.textIndent,
+      text.textAnchor,
       text.textWidth,
       text.letterSpacing,
       text.textIndent,

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -66,6 +66,7 @@ type TextMesh = Mesh & {
   // Font properties
   font: string | null /** Defaults to Noto Sans when null */
   fontSize: number
+  outlineWidth: number | string // @note: Troika marks this as an Experimental API
   //____ Presentation properties ____
   color: TroikaColor /** aka fontColor */
   sync: () => void /** Async Render the text using the current properties. troika accepts a callback function, but that feature is not mapped */
@@ -81,11 +82,6 @@ type TextMesh = Mesh & {
   // The color of the text outline, if `outlineWidth`/`outlineBlur`/`outlineOffsetX/Y` are set.
   // Defaults to black.
   outlineColor: TroikaColor // WARNING: This API is experimental and may change.
-  // The width of an outline/halo to be drawn around each text glyph using the `outlineColor` and `outlineOpacity`.
-  // Can be specified as either an absolute number in local units, or as a percentage string e.g.
-  // `"12%"` which is treated as a percentage of the `fontSize`. Defaults to `0`, which means
-  // no outline will be drawn unless an `outlineOffsetX/Y` or `outlineBlur` is set.
-  outlineWidth: number | string // WARNING: This API is experimental and may change.
   // The color of the text stroke, if `strokeWidth` is greater than zero. Defaults to gray.
   strokeColor: TroikaColor // WARNING: This API is experimental and may change.
   // The opacity of the stroke, if `strokeWidth` is greater than zero. Defaults to `1`.
@@ -220,6 +216,8 @@ export const TextComponent = defineComponent({
       font: FontDefault, // font: string|null
       fontSize: 0.2,
       fontColor: new Color(0x9966ff),
+      // Font Outline Properties
+      outlineWidth: 0, // sent to troika as [0..100]% :string
       // Internal State
       troikaMesh: new TroikaText() as TextMesh
     }
@@ -237,6 +235,7 @@ export const TextComponent = defineComponent({
     else if (matches.nill.test(json.font)) component.font.set(null)
     if (matches.number.test(json.fontSize)) component.fontSize.set(json.fontSize)
     if (matches.object.test(json.fontColor) && json.fontColor.isColor) component.fontColor.set(json.fontColor)
+    if (matches.number.test(json.outlineWidth)) component.outlineWidth.set(json.outlineWidth)
   },
 
   toJSON: (entity, component) => {
@@ -249,7 +248,8 @@ export const TextComponent = defineComponent({
       // Font Properties
       font: component.font.value,
       fontSize: component.fontSize.value,
-      fontColor: component.fontColor.value
+      fontColor: component.fontColor.value,
+      outlineWidth: component.outlineWidth.value
     }
   },
 
@@ -271,9 +271,19 @@ export const TextComponent = defineComponent({
       text.troikaMesh.value.font = text.font.value
       text.troikaMesh.value.fontSize = text.fontSize.value
       text.troikaMesh.value.color = text.fontColor.value.getHex()
+      text.troikaMesh.value.outlineWidth = `${text.outlineWidth.value}%`
       // Order troika to syncrhonize the mesh
       text.troikaMesh.value.sync()
-    }, [text.text, text.textIndent, text.textWidth, text.letterSpacing, text.textIndent, text.fontSize, text.fontColor])
+    }, [
+      text.text,
+      text.textIndent,
+      text.textWidth,
+      text.letterSpacing,
+      text.textIndent,
+      text.fontSize,
+      text.fontColor,
+      text.outlineWidth
+    ])
 
     /* Reactive system
     useExecute(() => {}, { with: InputSystemGroup })

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -188,7 +188,7 @@ type TextMesh = Mesh & {
  *  @description
  *  Noto Sans is the default font for text rendering.
  *  @abstract
- *  troika.Text.font accepts a nullable string, and defaults to Noto Sans when null is passed
+ *  troika.Text.font accepts a nullable string URI (URL or path), and defaults to Noto Sans when null is passed
  */
 const FontDefault = null! as string | null
 /** @todo Remove. Only temp for testing */

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -49,18 +49,20 @@ type TroikaColor = string | number | THREE.Color
 export type TroikaTextDirection = 'auto' | 'ltr' | 'rtl'
 
 /**
+ * @summary
+ * Defines the horizontal alignment of each line within the overall bounding box.
  * @description
  * troika.Text alignment type, as declared by `troika-three-text` in its Text.textAlign `@member` property.
- * Defines the horizontal alignment of each line within the overall bounding box.
  */
 export type TroikaTextAlignment = 'left' | 'center' | 'right' | 'justify'
 
 /**
+ * @summary
+ * Defines whether text should wrap when a line reaches `maxWidth`.
+ * @enum `'normal'`: Allow wrapping according to the `overflowWrap` property. Honors newline characters to manually break lines, making it behave more like `'pre-wrap'` does in CSS.
+ * @enum `'nowrap'`: Does not allow text to wrap.
  * @description
  * troika.Text wrap, as declared by `troika-three-text` in its Text.whiteSpace `@member` property.
- * Defines whether text should wrap when a line reaches `maxWidth`.
- * @option `'normal'`: Allow wrapping according to the `overflowWrap` property. Honors newline characters to manually break lines, making it behave more like `'pre-wrap'` does in CSS.
- * @option `'nowrap'`: Does not allow text to wrap.
  */
 export type TroikaTextWrap = 'normal' | 'nowrap'
 
@@ -68,13 +70,13 @@ export type TroikaTextWrap = 'normal' | 'nowrap'
  * @description
  * troika.Text wrapping kind, as declared by `troika-three-text` in its Text.overflowWrap `@member` property.
  * Defines how text wraps if TroikaTextWrap is set to `normal` _(aka TextComponent.textWrap: true)_.
- * @option `'normal'`: Break at whitespace characters
- * @option `'break-word'`: Break within words
+ * @enum `'normal'`: Break at whitespace characters
+ * @enum `'break-word'`: Break within words
  */
 export type TroikaTextWrapKind = 'normal' | 'break-word'
 
 /**
- * @description
+ * @summary
  * Javascript-to-Typescript compatiblity type for the `troika-three-text` Text mesh class.
  *
  * @example
@@ -84,7 +86,7 @@ export type TroikaTextWrapKind = 'normal' | 'break-word'
  * @note
  * Go to the `troika-three-text`.Text class implementation for documentation about each of the fields.
  *
- * @abstract
+ * @description
  * Respects the shape of the original troika.Text class,
  * by intersecting the three.Mesh class with an explicit list of properties originally contained in the Text class.
  * Only the properties used by this implementation are explicitly declared in this type.
@@ -165,9 +167,9 @@ type TextMesh = Mesh & {
 }
 
 /**
- *  @description
+ *  @summary
  *  Noto Sans is the default font for text rendering.
- *  @abstract
+ *  @description
  *  troika.Text.font accepts a nullable string URI (URL or path), and defaults to Noto Sans when null is passed
  */
 const FontDefault = null! as string | null

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -1,0 +1,401 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and 
+provide for limited attribution for the Original Developer. In addition, 
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023 
+Ethereal Engine. All Rights Reserved.
+*/
+
+import { useEffect } from 'react'
+
+import { isClient } from '@etherealengine/engine/src/common/functions/getEnvironment'
+import { defineComponent, useComponent } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
+import { useEntityContext } from '@etherealengine/engine/src/ecs/functions/EntityFunctions'
+
+import { Color, Mesh } from 'three'
+import { Text as TroikaText } from 'troika-three-text'
+import { matches } from '../../common/functions/MatchesUtils'
+import { addObjectToGroup } from './GroupComponent'
+
+/**
+ * @description
+ * troika.Color type, as declared by `troika-three-text` in its Text.color `@member` declaration
+ */
+type TroikaColor = string | number | THREE.Color
+
+/**
+ * @description
+ * Type for Javascript-to-Typescript compatiblity of the `troika-three-text` Text mesh class.
+ *
+ * @example
+ * import { Text as TroikaText } from 'troika-three-text'
+ * let textMesh = new TroikaText() as TextMesh
+ *
+ * @abstract
+ * Respects the shape of the original troika.Text class,
+ * by intersecting the three.Mesh class with an explicit list of properties originally contained in the Text class.
+ * Only the properties used by this implementation are explicitly declared.
+ * @note
+ * Go to the `troika-three-text`.Text class implementation for documentation about each of the fields.
+ */
+type TextMesh = Mesh & {
+  /* --- Text layout properties: --- */
+  text: string
+  fontSize: number
+  /* --- Presentation properties: --- */
+  color: TroikaColor
+  sync: () => void /* Async Render the text using the current properties. troika accepts a callback function, but that feature is not mapped */
+
+  //__________
+  //  TODO  //
+  //_______//
+  /**
+   * @member {number|string} anchorX
+   * Defines the horizontal position in the text block that should line up with the local origin.
+   * Can be specified as a numeric x position in local units, a string percentage of the total
+   * text block width e.g. `'25%'`, or one of the following keyword strings: 'left', 'center',
+   * or 'right'.
+   */
+  anchorX: number | string
+
+  /**
+   * @member {number|string} anchorY
+   * Defines the vertical position in the text block that should line up with the local origin.
+   * Can be specified as a numeric y position in local units (note: down is negative y), a string
+   * percentage of the total text block height e.g. `'25%'`, or one of the following keyword strings:
+   * 'top', 'top-baseline', 'top-cap', 'top-ex', 'middle', 'bottom-baseline', or 'bottom'.
+   */
+  anchorY: number | string
+
+  /**
+   * @member {number} curveRadius
+   * Defines a cylindrical radius along which the text's plane will be curved. Positive numbers put
+   * the cylinder's centerline (oriented vertically) that distance in front of the text, for a concave
+   * curvature, while negative numbers put it behind the text for a convex curvature. The centerline
+   * will be aligned with the text's local origin; you can use `anchorX` to offset it.
+   *
+   * Since each glyph is by default rendered with a simple quad, each glyph remains a flat plane
+   * internally. You can use `glyphGeometryDetail` to add more vertices for curvature inside glyphs.
+   */
+  curveRadius: number
+
+  /**
+   * @member {string} direction
+   * Sets the base direction for the text. The default value of "auto" will choose a direction based
+   * on the text's content according to the bidi spec. A value of "ltr" or "rtl" will force the direction.
+   */
+  direction: 'auto' | 'ltr' | 'rtl'
+
+  /**
+   * @member {string|null} font
+   * URL of a custom font to be used. Font files can be in .ttf, .otf, or .woff (not .woff2) formats.
+   * Defaults to Noto Sans.
+   */
+  font: string | null /** Defaults to Noto Sans */
+  unicodeFontsURL: string | null //defaults to CDN
+
+  /**
+   * @member {number|'normal'|'bold'}
+   * The weight of the font. Currently only used for fallback Noto fonts.
+   */
+  fontWeight: number | 'normal' | 'bold'
+
+  /**
+   * @member {'normal'|'italic'}
+   * The style of the font. Currently only used for fallback Noto fonts.
+   */
+  fontStyle: 'normal' | 'italic'
+
+  /**
+   * @member {string|null} lang
+   * The language code of this text; can be used for explicitly selecting certain CJK fonts.
+   */
+  lang: string | null
+
+  /**
+   * @member {number} letterSpacing
+   * Sets a uniform adjustment to spacing between letters after kerning is applied. Positive
+   * numbers increase spacing and negative numbers decrease it.
+   */
+  letterSpacing: number
+
+  /**
+   * @member {number|string} lineHeight
+   * Sets the height of each line of text, as a multiple of the `fontSize`. Defaults to 'normal'
+   * which chooses a reasonable height based on the chosen font's ascender/descender metrics.
+   */
+  lineHeight: number | 'normal'
+
+  /**
+   * @member {number} maxWidth
+   * The maximum width of the text block, above which text may start wrapping according to the
+   * `whiteSpace` and `overflowWrap` properties.
+   */
+  maxWidth: number
+
+  /**
+   * @member {string} overflowWrap
+   * Defines how text wraps if the `whiteSpace` property is `normal`. Can be either `'normal'`
+   * to break at whitespace characters, or `'break-word'` to allow breaking within words.
+   * Defaults to `'normal'`.
+   */
+  overflowWrap: 'normal' | 'break-word'
+
+  /**
+   * @member {string} textAlign
+   * The horizontal alignment of each line of text within the overall text bounding box.
+   */
+  textAlign: 'left' | 'center' | 'right' | 'justify'
+
+  /**
+   * @member {number} textIndent
+   * Indentation for the first character of a line; see CSS `text-indent`.
+   */
+  textIndent: number
+
+  /**
+   * @member {string} whiteSpace
+   * Defines whether text should wrap when a line reaches the `maxWidth`. Can
+   * be either `'normal'` (the default), to allow wrapping according to the `overflowWrap` property,
+   * or `'nowrap'` to prevent wrapping. Note that `'normal'` here honors newline characters to
+   * manually break lines, making it behave more like `'pre-wrap'` does in CSS.
+   */
+  whiteSpace: 'normal' | 'nowrap'
+
+  // === Presentation properties: === //
+
+  /**
+   * @member {THREE.Material} material
+   * Defines a _base_ material to be used when rendering the text. This material will be
+   * automatically replaced with a material derived from it, that adds shader code to
+   * decrease the alpha for each fragment (pixel) outside the text glyphs, with antialiasing.
+   * By default it will derive from a simple white MeshBasicMaterial, but you can use any
+   * of the other mesh materials to gain other features like lighting, texture maps, etc.
+   *
+   * Also see the `color` shortcut property.
+   */
+  material: THREE.Material
+
+  /**
+   * @member {object|null} colorRanges
+   * WARNING: This API is experimental and may change.
+   * This allows more fine-grained control of colors for individual or ranges of characters,
+   * taking precedence over the material's `color`. Its format is an Object whose keys each
+   * define a starting character index for a range, and whose values are the color for each
+   * range. The color value can be a numeric hex color value, a `THREE.Color` object, or
+   * any of the strings accepted by `THREE.Color`.
+   */
+  colorRanges: object | null
+
+  /**
+   * @member {number|string} outlineWidth
+   * WARNING: This API is experimental and may change.
+   * The width of an outline/halo to be drawn around each text glyph using the `outlineColor` and `outlineOpacity`.
+   * Can be specified as either an absolute number in local units, or as a percentage string e.g.
+   * `"12%"` which is treated as a percentage of the `fontSize`. Defaults to `0`, which means
+   * no outline will be drawn unless an `outlineOffsetX/Y` or `outlineBlur` is set.
+   */
+  outlineWidth: number | string
+
+  /**
+   * @member {string|number|THREE.Color} outlineColor
+   * WARNING: This API is experimental and may change.
+   * The color of the text outline, if `outlineWidth`/`outlineBlur`/`outlineOffsetX/Y` are set.
+   * Defaults to black.
+   */
+  outlineColor: TroikaColor
+
+  /**
+   * @member {number} outlineOpacity
+   * WARNING: This API is experimental and may change.
+   * The opacity of the outline, if `outlineWidth`/`outlineBlur`/`outlineOffsetX/Y` are set.
+   * Defaults to `1`.
+   */
+  outlineOpacity: number
+
+  /**
+   * @member {number|string} outlineBlur
+   * WARNING: This API is experimental and may change.
+   * A blur radius applied to the outer edge of the text's outline. If the `outlineWidth` is
+   * zero, the blur will be applied at the glyph edge, like CSS's `text-shadow` blur radius.
+   * Can be specified as either an absolute number in local units, or as a percentage string e.g.
+   * `"12%"` which is treated as a percentage of the `fontSize`. Defaults to `0`.
+   */
+  outlineBlur: number | string
+
+  /**
+   * @member {number|string} outlineOffsetX
+   * WARNING: This API is experimental and may change.
+   * A horizontal offset for the text outline.
+   * Can be specified as either an absolute number in local units, or as a percentage string e.g. `"12%"`
+   * which is treated as a percentage of the `fontSize`. Defaults to `0`.
+   */
+  outlineOffsetX: number | string
+
+  /**
+   * @member {number|string} outlineOffsetY
+   * WARNING: This API is experimental and may change.
+   * A vertical offset for the text outline.
+   * Can be specified as either an absolute number in local units, or as a percentage string e.g. `"12%"`
+   * which is treated as a percentage of the `fontSize`. Defaults to `0`.
+   */
+  outlineOffsetY: number | string
+
+  /**
+   * @member {number|string} strokeWidth
+   * WARNING: This API is experimental and may change.
+   * The width of an inner stroke drawn inside each text glyph using the `strokeColor` and `strokeOpacity`.
+   * Can be specified as either an absolute number in local units, or as a percentage string e.g. `"12%"`
+   * which is treated as a percentage of the `fontSize`. Defaults to `0`.
+   */
+  strokeWidth: number | string
+
+  /**
+   * @member {string|number|THREE.Color} strokeColor
+   * WARNING: This API is experimental and may change.
+   * The color of the text stroke, if `strokeWidth` is greater than zero. Defaults to gray.
+   */
+  strokeColor: TroikaColor
+
+  /**
+   * @member {number} strokeOpacity
+   * WARNING: This API is experimental and may change.
+   * The opacity of the stroke, if `strokeWidth` is greater than zero. Defaults to `1`.
+   */
+  strokeOpacity: number
+
+  /**
+   * @member {number} fillOpacity
+   * WARNING: This API is experimental and may change.
+   * The opacity of the glyph's fill from 0 to 1. This behaves like the material's `opacity` but allows
+   * giving the fill a different opacity than the `strokeOpacity`. A fillOpacity of `0` makes the
+   * interior of the glyph invisible, leaving just the `strokeWidth`. Defaults to `1`.
+   */
+  fillOpacity: number
+
+  /**
+   * @member {number} depthOffset
+   * This is a shortcut for setting the material's `polygonOffset` and related properties,
+   * which can be useful in preventing z-fighting when this text is laid on top of another
+   * plane in the scene. Positive numbers are further from the camera, negatives closer.
+   */
+  depthOffset: number
+
+  /**
+   * @member {Array<number>} clipRect
+   * If specified, defines a `[minX, minY, maxX, maxY]` of a rectangle outside of which all
+   * pixels will be discarded. This can be used for example to clip overflowing text when
+   * `whiteSpace='nowrap'`.
+   */
+  clipRect: Array<number>
+
+  /**
+   * @member {string} orientation
+   * Defines the axis plane on which the text should be laid out when the mesh has no extra
+   * rotation transform. It is specified as a string with two axes: the horizontal axis with
+   * positive pointing right, and the vertical axis with positive pointing up. By default this
+   * is '+x+y', meaning the text sits on the xy plane with the text's top toward positive y
+   * and facing positive z. A value of '+x-z' would place it on the xz plane with the text's
+   * top toward negative z and facing positive y.
+   */
+  orientation: string
+
+  /**
+   * @member {number} glyphGeometryDetail
+   * Controls number of vertical/horizontal segments that make up each glyph's rectangular
+   * plane. Defaults to 1. This can be increased to provide more geometrical detail for custom
+   * vertex shader effects, for example.
+   */
+  glyphGeometryDetail: number
+
+  /**
+   * @member {number|null} sdfGlyphSize
+   * The size of each glyph's SDF (signed distance field) used for rendering. This must be a
+   * power-of-two number. Defaults to 64 which is generally a good balance of size and quality
+   * for most fonts. Larger sizes can improve the quality of glyph rendering by increasing
+   * the sharpness of corners and preventing loss of very thin lines, at the expense of
+   * increased memory footprint and longer SDF generation time.
+   */
+  sdfGlyphSize: number | null
+
+  /**
+   * @member {boolean} gpuAccelerateSDF
+   * When `true`, the SDF generation process will be GPU-accelerated with WebGL when possible,
+   * making it much faster especially for complex glyphs, and falling back to a JavaScript version
+   * executed in web workers when support isn't available. It should automatically detect support,
+   * but it's still somewhat experimental, so you can set it to `false` to force it to use the JS
+   * version if you encounter issues with it.
+   */
+  gpuAccelerateSDF: boolean
+  debugSDF: boolean
+}
+
+export const TextComponent = defineComponent({
+  name: 'TextComponent',
+  jsonID: 'Text_troika',
+
+  onInit: (entity) => {
+    return {
+      // Text properties to configure
+      text: 'Some Text',
+      fontSize: 0.2,
+      fontColor: new Color(0x9966ff),
+      troikaMesh: new TroikaText() as TextMesh
+    }
+  },
+
+  onSet: (entity, component, json) => {
+    if (!json) return
+    if (matches.string.test(json.text)) component.text.set(json.text)
+    if (matches.number.test(json.fontSize)) component.fontSize.set(json.fontSize)
+    if (matches.object.test(json.fontColor) && json.fontColor.isColor) component.fontColor.set(json.fontColor)
+  },
+
+  toJSON: (entity, component) => {
+    return {
+      text: component.text.value,
+      fontSize: component.fontSize.value,
+      fontColor: component.fontColor.value
+    }
+  },
+
+  reactor: function () {
+    if (!isClient) return null
+    const entity = useEntityContext()
+    const text = useComponent(entity, TextComponent)
+
+    // Add the text mesh to the scene
+    addObjectToGroup(entity, text.troikaMesh.value)
+
+    useEffect(() => {
+      // Update the rendering
+      text.troikaMesh.value.text = text.text.value
+      text.troikaMesh.value.fontSize = text.fontSize.value
+      text.troikaMesh.value.color = text.fontColor.value.getHex()
+      text.troikaMesh.value.sync()
+    }, [text.text, text.fontSize, text.fontColor])
+
+    /* Reactive system
+    useExecute(() => {}, { with: InputSystemGroup })
+    */
+
+    return null
+  }
+})

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -69,6 +69,7 @@ type TextMesh = Mesh & {
   fontSize: number
   outlineOpacity: number // @note: Troika marks this as an Experimental API
   outlineWidth: number | string // @note: Troika marks this as an Experimental API
+  outlineBlur: number | string // @note: Troika marks this as an Experimental API
   strokeOpacity: number // @note: Troika marks this as an Experimental API
   strokeWidth: number | string // @note: Troika marks this as an Experimental API
 
@@ -157,11 +158,6 @@ type TextMesh = Mesh & {
   // range. The color value can be a numeric hex color value, a `THREE.Color` object, or
   // any of the strings accepted by `THREE.Color`.
   colorRanges: object | null // WARNING: This API is experimental and may change.
-  // A blur radius applied to the outer edge of the text's outline. If the `outlineWidth` is
-  // zero, the blur will be applied at the glyph edge, like CSS's `text-shadow` blur radius.
-  // Can be specified as either an absolute number in local units, or as a percentage string e.g.
-  // `"12%"` which is treated as a percentage of the `fontSize`. Defaults to `0`.
-  outlineBlur: number | string // WARNING: This API is experimental and may change.
   // An offset for the text outline.
   // Can be specified as either an absolute number in local units, or as a percentage string e.g. `"12%"`
   // which is treated as a percentage of the `fontSize`. Defaults to `0`.
@@ -212,6 +208,7 @@ export const TextComponent = defineComponent({
       // Font Outline Properties
       outlineOpacity: 0, // range[0..100], sent to troika as [0..1] :number
       outlineWidth: 0, // range[0..100+], sent to troika as [0..100]% :string
+      outlineBlur: 0, // range[0..100+], sent to troika as [0..100]% :string
       // Font Stroke Properties
       strokeOpacity: 0, // range[0..100], sent to troika as [0..1] :number
       strokeWidth: 0, // range[0..100+], sent to troika as [0..100]% :string
@@ -235,6 +232,7 @@ export const TextComponent = defineComponent({
     if (matches.object.test(json.fontColor) && json.fontColor.isColor) component.fontColor.set(json.fontColor)
     if (matches.number.test(json.outlineOpacity)) component.outlineOpacity.set(json.outlineOpacity)
     if (matches.number.test(json.outlineWidth)) component.outlineWidth.set(json.outlineWidth)
+    if (matches.number.test(json.outlineBlur)) component.outlineBlur.set(json.outlineBlur)
     if (matches.number.test(json.strokeOpacity)) component.strokeOpacity.set(json.strokeOpacity)
     if (matches.number.test(json.strokeWidth)) component.strokeWidth.set(json.strokeWidth)
   },
@@ -253,6 +251,7 @@ export const TextComponent = defineComponent({
       fontColor: component.fontColor.value,
       outlineOpacity: component.outlineOpacity.value,
       outlineWidth: component.outlineWidth.value,
+      outlineBlur: component.outlineBlur.value,
       strokeOpacity: component.strokeOpacity.value,
       strokeWidth: component.strokeWidth.value
     }
@@ -279,9 +278,10 @@ export const TextComponent = defineComponent({
       text.troikaMesh.value.color = text.fontColor.value.getHex()
       text.troikaMesh.value.outlineOpacity = text.outlineOpacity.value / 100
       text.troikaMesh.value.outlineWidth = `${text.outlineWidth.value}%`
+      text.troikaMesh.value.outlineBlur = `${text.outlineBlur.value}%`
       text.troikaMesh.value.strokeOpacity = text.strokeOpacity.value / 100
       text.troikaMesh.value.strokeWidth = `${text.strokeWidth.value}%`
-      // Order troika to syncrhonize the mesh
+      // Order troika to synchronize the mesh
       text.troikaMesh.value.sync()
     }, [
       text.text,
@@ -294,6 +294,7 @@ export const TextComponent = defineComponent({
       text.fontColor,
       text.outlineOpacity,
       text.outlineWidth,
+      text.outlineBlur,
       text.strokeOpacity,
       text.strokeWidth
     ])

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -60,6 +60,7 @@ type TextMesh = Mesh & {
   //____ Text layout properties ____
   text: string
   // Text properties
+  fillOpacity: number // @note: Troika marks this as an Experimental API
   textIndent: number /** Indentation for the first character of a line; see CSS `text-indent`. */
   letterSpacing: number /** Spacing between letters after kerning is applied. */
   maxWidth: number /** Value above which text starts wrapping */
@@ -86,10 +87,6 @@ type TextMesh = Mesh & {
   strokeColor: TroikaColor // WARNING: This API is experimental and may change.
   // The opacity of the stroke, if `strokeWidth` is greater than zero. Defaults to `1`.
   strokeOpacity: number // WARNING: This API is experimental and may change.
-  // The opacity of the glyph's fill from 0 to 1. This behaves like the material's `opacity` but allows
-  // giving the fill a different opacity than the `strokeOpacity`. A fillOpacity of `0` makes the
-  // interior of the glyph invisible, leaving just the `strokeWidth`. Defaults to `1`.
-  fillOpacity: number // WARNING: This API is experimental and may change.
   // This is a shortcut for setting the material's `polygonOffset` and related properties,
   // which can be useful in preventing z-fighting when this text is laid on top of another
   // plane in the scene. Positive numbers are further from the camera, negatives closer.
@@ -209,6 +206,7 @@ export const TextComponent = defineComponent({
     return {
       // Text contents to render
       text: 'Some Text',
+      textOpacity: 100, // range[0..100], sent to troika as [0..1] :number
       textWidth: Infinity,
       textIndent: 0,
       letterSpacing: 0,
@@ -227,6 +225,7 @@ export const TextComponent = defineComponent({
     if (!json) return
     // Text contents to render
     if (matches.string.test(json.text)) component.text.set(json.text)
+    if (matches.number.test(json.textOpacity)) component.textOpacity.set(json.textOpacity)
     if (matches.number.test(json.textWidth)) component.textWidth.set(json.textWidth)
     if (matches.number.test(json.textIndent)) component.textIndent.set(json.textIndent)
     if (matches.number.test(json.letterSpacing)) component.letterSpacing.set(json.letterSpacing)
@@ -242,6 +241,7 @@ export const TextComponent = defineComponent({
     return {
       // Text contents to render
       text: component.text.value,
+      textOpacity: component.textOpacity.value,
       textWidth: component.textWidth.value,
       textIndent: component.textIndent.value,
       letterSpacing: component.letterSpacing.value,
@@ -264,6 +264,7 @@ export const TextComponent = defineComponent({
     useEffect(() => {
       // Update the Text content to render
       text.troikaMesh.value.text = text.text.value
+      text.troikaMesh.value.fillOpacity = text.textOpacity.value / 100
       text.troikaMesh.value.maxWidth = text.textWidth.value
       text.troikaMesh.value.textIndent = text.textIndent.value
       text.troikaMesh.value.letterSpacing = text.letterSpacing.value
@@ -276,6 +277,7 @@ export const TextComponent = defineComponent({
       text.troikaMesh.value.sync()
     }, [
       text.text,
+      text.textOpacity,
       text.textIndent,
       text.textWidth,
       text.letterSpacing,

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -144,12 +144,6 @@ type TextMesh = Mesh & {
   // of the other mesh materials to gain other features like lighting, texture maps, etc.
   // Also see the `color` shortcut property.
   material: THREE.Material
-  // This allows more fine-grained control of colors for individual or ranges of characters,
-  // taking precedence over the material's `color`. Its format is an Object whose keys each
-  // define a starting character index for a range, and whose values are the color for each
-  // range. The color value can be a numeric hex color value, a `THREE.Color` object, or
-  // any of the strings accepted by `THREE.Color`.
-  colorRanges: object | null // WARNING: This API is experimental and may change.
   // Defines the axis plane on which the text should be laid out when the mesh has no extra
   // rotation transform. It is specified as a string with two axes: the horizontal axis with
   // positive pointing right, and the vertical axis with positive pointing up. By default this
@@ -158,11 +152,13 @@ type TextMesh = Mesh & {
   // top toward negative z and facing positive y.
   orientation: string
 
+  //____ Maybes ____
+  lang: string | null // The language code of this text; can be used for explicitly selecting certain CJK fonts.
+  unicodeFontsURL: string | null // defaults to CDN
+
   //____ Unlikely ____
   fontWeight: number | 'normal' | 'bold' // The weight of the font. Currently only used for fallback Noto fonts.
   fontStyle: 'normal' | 'italic' // The style of the font. Currently only used for fallback Noto fonts.
-  lang: string | null // The language code of this text; can be used for explicitly selecting certain CJK fonts.
-  unicodeFontsURL: string | null // defaults to CDN
   debugSDF: boolean
 }
 

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -67,6 +67,7 @@ type TextMesh = Mesh & {
   // Font properties
   font: string | null /** Defaults to Noto Sans when null */
   fontSize: number
+  outlineOpacity: number // @note: Troika marks this as an Experimental API
   outlineWidth: number | string // @note: Troika marks this as an Experimental API
   strokeOpacity: number // @note: Troika marks this as an Experimental API
   //____ Presentation properties ____
@@ -154,9 +155,6 @@ type TextMesh = Mesh & {
   // range. The color value can be a numeric hex color value, a `THREE.Color` object, or
   // any of the strings accepted by `THREE.Color`.
   colorRanges: object | null // WARNING: This API is experimental and may change.
-  // The opacity of the outline, if `outlineWidth`/`outlineBlur`/`outlineOffsetX/Y` are set.
-  // Defaults to `1`.
-  outlineOpacity: number // WARNING: This API is experimental and may change.
   // A blur radius applied to the outer edge of the text's outline. If the `outlineWidth` is
   // zero, the blur will be applied at the glyph edge, like CSS's `text-shadow` blur radius.
   // Can be specified as either an absolute number in local units, or as a percentage string e.g.
@@ -214,6 +212,7 @@ export const TextComponent = defineComponent({
       fontSize: 0.2,
       fontColor: new Color(0x9966ff),
       // Font Outline Properties
+      outlineOpacity: 0, // range[0..100], sent to troika as [0..1] :number
       outlineWidth: 0, // range[0..100+], sent to troika as [0..100]% :string
       // Font Stroke Properties
       strokeOpacity: 0, // range[0..100], sent to troika as [0..1] :number
@@ -235,6 +234,7 @@ export const TextComponent = defineComponent({
     else if (matches.nill.test(json.font)) component.font.set(null)
     if (matches.number.test(json.fontSize)) component.fontSize.set(json.fontSize)
     if (matches.object.test(json.fontColor) && json.fontColor.isColor) component.fontColor.set(json.fontColor)
+    if (matches.number.test(json.outlineOpacity)) component.outlineOpacity.set(json.outlineOpacity)
     if (matches.number.test(json.outlineWidth)) component.outlineWidth.set(json.outlineWidth)
     if (matches.number.test(json.strokeOpacity)) component.strokeOpacity.set(json.strokeOpacity)
   },
@@ -251,6 +251,7 @@ export const TextComponent = defineComponent({
       font: component.font.value,
       fontSize: component.fontSize.value,
       fontColor: component.fontColor.value,
+      outlineOpacity: component.outlineOpacity.value,
       outlineWidth: component.outlineWidth.value,
       strokeOpacity: component.strokeOpacity.value
     }
@@ -275,6 +276,7 @@ export const TextComponent = defineComponent({
       text.troikaMesh.value.font = text.font.value
       text.troikaMesh.value.fontSize = text.fontSize.value
       text.troikaMesh.value.color = text.fontColor.value.getHex()
+      text.troikaMesh.value.outlineOpacity = text.outlineOpacity.value / 100
       text.troikaMesh.value.outlineWidth = `${text.outlineWidth.value}%`
       text.troikaMesh.value.strokeOpacity = text.strokeOpacity.value / 100
       // Order troika to syncrhonize the mesh
@@ -288,6 +290,7 @@ export const TextComponent = defineComponent({
       text.textIndent,
       text.fontSize,
       text.fontColor,
+      text.outlineOpacity,
       text.outlineWidth,
       text.strokeOpacity
     ])

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -68,6 +68,7 @@ type TextMesh = Mesh & {
   font: string | null /** Defaults to Noto Sans when null */
   fontSize: number
   outlineWidth: number | string // @note: Troika marks this as an Experimental API
+  strokeOpacity: number // @note: Troika marks this as an Experimental API
   //____ Presentation properties ____
   color: TroikaColor /** aka fontColor */
   sync: () => void /** Async Render the text using the current properties. troika accepts a callback function, but that feature is not mapped */
@@ -85,8 +86,6 @@ type TextMesh = Mesh & {
   outlineColor: TroikaColor // WARNING: This API is experimental and may change.
   // The color of the text stroke, if `strokeWidth` is greater than zero. Defaults to gray.
   strokeColor: TroikaColor // WARNING: This API is experimental and may change.
-  // The opacity of the stroke, if `strokeWidth` is greater than zero. Defaults to `1`.
-  strokeOpacity: number // WARNING: This API is experimental and may change.
   // This is a shortcut for setting the material's `polygonOffset` and related properties,
   // which can be useful in preventing z-fighting when this text is laid on top of another
   // plane in the scene. Positive numbers are further from the camera, negatives closer.
@@ -215,7 +214,9 @@ export const TextComponent = defineComponent({
       fontSize: 0.2,
       fontColor: new Color(0x9966ff),
       // Font Outline Properties
-      outlineWidth: 0, // sent to troika as [0..100]% :string
+      outlineWidth: 0, // range[0..100+], sent to troika as [0..100]% :string
+      // Font Stroke Properties
+      strokeOpacity: 0, // range[0..100], sent to troika as [0..1] :number
       // Internal State
       troikaMesh: new TroikaText() as TextMesh
     }
@@ -235,6 +236,7 @@ export const TextComponent = defineComponent({
     if (matches.number.test(json.fontSize)) component.fontSize.set(json.fontSize)
     if (matches.object.test(json.fontColor) && json.fontColor.isColor) component.fontColor.set(json.fontColor)
     if (matches.number.test(json.outlineWidth)) component.outlineWidth.set(json.outlineWidth)
+    if (matches.number.test(json.strokeOpacity)) component.strokeOpacity.set(json.strokeOpacity)
   },
 
   toJSON: (entity, component) => {
@@ -249,7 +251,8 @@ export const TextComponent = defineComponent({
       font: component.font.value,
       fontSize: component.fontSize.value,
       fontColor: component.fontColor.value,
-      outlineWidth: component.outlineWidth.value
+      outlineWidth: component.outlineWidth.value,
+      strokeOpacity: component.strokeOpacity.value
     }
   },
 
@@ -273,6 +276,7 @@ export const TextComponent = defineComponent({
       text.troikaMesh.value.fontSize = text.fontSize.value
       text.troikaMesh.value.color = text.fontColor.value.getHex()
       text.troikaMesh.value.outlineWidth = `${text.outlineWidth.value}%`
+      text.troikaMesh.value.strokeOpacity = text.strokeOpacity.value / 100
       // Order troika to syncrhonize the mesh
       text.troikaMesh.value.sync()
     }, [
@@ -284,7 +288,8 @@ export const TextComponent = defineComponent({
       text.textIndent,
       text.fontSize,
       text.fontColor,
-      text.outlineWidth
+      text.outlineWidth,
+      text.strokeOpacity
     ])
 
     /* Reactive system

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -217,6 +217,7 @@ export const TextComponent = defineComponent({
     return {
       // Text contents to render
       text: 'Some Text',
+      textIndent: 0,
       // Font Properties
       font: FontDefault, // font: string|null
       fontSize: 0.2,
@@ -230,6 +231,7 @@ export const TextComponent = defineComponent({
     if (!json) return
     // Text contents to render
     if (matches.string.test(json.text)) component.text.set(json.text)
+    if (matches.number.test(json.textIndent)) component.textIndent.set(json.textIndent)
     // Font Properties
     if (matches.string.test(json.font)) component.font.set(json.font)
     else if (matches.nill.test(json.font)) component.font.set(null)
@@ -241,6 +243,7 @@ export const TextComponent = defineComponent({
     return {
       // Text contents to render
       text: component.text.value,
+      textIndent: component.textIndent.value,
       // Font Properties
       font: component.font.value,
       fontSize: component.fontSize.value,
@@ -259,12 +262,14 @@ export const TextComponent = defineComponent({
     useEffect(() => {
       // Update the Text content to render
       text.troikaMesh.value.text = text.text.value
+      text.troikaMesh.value.textIndent = text.textIndent.value
       // Update the font properties
       text.troikaMesh.value.font = text.font.value
       text.troikaMesh.value.fontSize = text.fontSize.value
       text.troikaMesh.value.color = text.fontColor.value.getHex()
+      // Order troika to syncrhonize the mesh
       text.troikaMesh.value.sync()
-    }, [text.text, text.fontSize, text.fontColor])
+    }, [text.text, text.textIndent, text.fontSize, text.fontColor])
 
     /* Reactive system
     useExecute(() => {}, { with: InputSystemGroup })

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -30,6 +30,7 @@ import { defineComponent, useComponent } from '@etherealengine/engine/src/ecs/fu
 import { useEntityContext } from '@etherealengine/engine/src/ecs/functions/EntityFunctions'
 
 import { Color, Mesh, Vector2 } from 'three'
+import { MathUtils } from 'three/src/math/MathUtils'
 import { Text as TroikaText } from 'troika-three-text'
 import { matches } from '../../common/functions/MatchesUtils'
 import { addObjectToGroup } from './GroupComponent'
@@ -66,6 +67,7 @@ type TextMesh = Mesh & {
   maxWidth: number /** Value above which text starts wrapping */
   anchorX: number | string | 'left' | 'center' | 'right'
   anchorY: number | string | 'top' | 'top-baseline' | 'top-cap' | 'top-ex' | 'middle' | 'bottom-baseline' | 'bottom'
+  curveRadius: number
   // Font properties
   font: string | null /** Defaults to Noto Sans when null */
   fontSize: number
@@ -84,13 +86,6 @@ type TextMesh = Mesh & {
   sync: () => void /** Async Render the text using the current properties. troika accepts a callback function, but that feature is not mapped */
 
   //____ Simple Properties
-  // Defines a cylindrical radius along which the text's plane will be curved. Positive numbers put
-  // the cylinder's centerline (oriented vertically) that distance in front of the text, for a concave
-  // curvature, while negative numbers put it behind the text for a convex curvature. The centerline
-  // will be aligned with the text's local origin; you can use `anchorX` to offset it.
-  // Since each glyph is by default rendered with a simple quad, each glyph remains a flat plane
-  // internally. You can use `glyphGeometryDetail` to add more vertices for curvature inside glyphs.
-  curveRadius: number
   // The color of the text outline, if `outlineWidth`/`outlineBlur`/`outlineOffsetX/Y` are set.
   // Defaults to black.
   outlineColor: TroikaColor // WARNING: This API is experimental and may change.
@@ -194,6 +189,7 @@ export const TextComponent = defineComponent({
         /* X */ 0, // range[0..100+], sent to troika as [0..100]% :string
         /* Y */ 0 // range[0..100+], sent to troika as [0..100]% :string
       ),
+      textCurveRadius: 0,
       letterSpacing: 0,
 
       // Font Properties
@@ -226,6 +222,7 @@ export const TextComponent = defineComponent({
     if (matches.number.test(json.textWidth)) component.textWidth.set(json.textWidth)
     if (matches.number.test(json.textIndent)) component.textIndent.set(json.textIndent)
     if (matches.object.test(json.textAnchor) && json.textAnchor.isVector2) component.textAnchor.set(json.textAnchor)
+    if (matches.number.test(json.textCurveRadius)) component.textCurveRadius.set(json.textCurveRadius)
     if (matches.number.test(json.letterSpacing)) component.letterSpacing.set(json.letterSpacing)
     // Font Properties
     if (matches.string.test(json.font)) component.font.set(json.font)
@@ -250,6 +247,7 @@ export const TextComponent = defineComponent({
       textWidth: component.textWidth.value,
       textIndent: component.textIndent.value,
       textAnchor: component.textAnchor.value,
+      textCurveRadius: component.textCurveRadius.value,
       letterSpacing: component.letterSpacing.value,
       // Font Properties
       font: component.font.value,
@@ -281,6 +279,7 @@ export const TextComponent = defineComponent({
       text.troikaMesh.value.textIndent = text.textIndent.value
       text.troikaMesh.value.anchorX = `${text.textAnchor.x.value}%`
       text.troikaMesh.value.anchorY = `${text.textAnchor.y.value}%`
+      text.troikaMesh.value.curveRadius = MathUtils.degToRad(text.textCurveRadius.value)
       text.troikaMesh.value.letterSpacing = text.letterSpacing.value
       // Update the font properties
       text.troikaMesh.value.font = text.font.value
@@ -301,6 +300,7 @@ export const TextComponent = defineComponent({
       text.textOpacity,
       text.textIndent,
       text.textAnchor,
+      text.textCurveRadius,
       text.textWidth,
       text.letterSpacing,
       text.textIndent,

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -98,7 +98,6 @@ type TextMesh = Mesh & {
   textAlign: TroikaTextAlignment
   overflowWrap: TroikaTextWrapKind
   whiteSpace: TroikaTextWrap
-
   letterSpacing: number /** Spacing between letters after kerning is applied. */
   maxWidth: number /** Value above which text starts wrapping */
   anchorX: number | string | 'left' | 'center' | 'right'
@@ -109,15 +108,16 @@ type TextMesh = Mesh & {
   // Font properties
   font: string | null /** Defaults to Noto Sans when null */
   fontSize: number
+  color: TroikaColor /** aka fontColor */
   outlineOpacity: number // @note: Troika marks this as an Experimental API
   outlineWidth: number | string // @note: Troika marks this as an Experimental API
   outlineBlur: number | string // @note: Troika marks this as an Experimental API
   outlineOffsetX: number | string // @note: Troika marks this as an Experimental API
   outlineOffsetY: number | string // @note: Troika marks this as an Experimental API
+  outlineColor: TroikaColor // @note: Troika marks this as an Experimental API
   strokeOpacity: number // @note: Troika marks this as an Experimental API
   strokeWidth: number | string // @note: Troika marks this as an Experimental API
-  //____ Presentation properties ____
-  color: TroikaColor /** aka fontColor */
+  strokeColor: TroikaColor // @note: Troika marks this as an Experimental API
   //____ SDF Properties ____
   gpuAccelerateSDF: boolean // Allows force-disabling GPU acceleration of SDF. Uses the JS fallback when true
   //____ Callbacks ____
@@ -128,14 +128,8 @@ type TextMesh = Mesh & {
   //  Remove the unused properties. Only temp for easier dev  //
   //_________________________________________________________//
   //____ Simple Properties
-  // The color of the text outline, if `outlineWidth`/`outlineBlur`/`outlineOffsetX/Y` are set.
-  // Defaults to black.
-  outlineColor: TroikaColor // WARNING: This API is experimental and may change.
-  // The color of the text stroke, if `strokeWidth` is greater than zero. Defaults to gray.
-  strokeColor: TroikaColor // WARNING: This API is experimental and may change.
-  // If specified, defines a `[minX, minY, maxX, maxY]` of a rectangle outside of which all
-  // pixels will be discarded. This can be used for example to clip overflowing text when
-  // `whiteSpace='nowrap'`.
+  // If specified, defines a `[minX, minY, maxX, maxY]` of a rectangle outside of which all pixels will be discarded.
+  // This can be used for example to clip overflowing text when `whiteSpace='nowrap'`.
   clipRect: Array<number>
   //____ SDF & Geometry ____
   // Controls number of vertical/horizontal segments that make up each glyph's rectangular
@@ -229,9 +223,11 @@ export const TextComponent = defineComponent({
         /* X */ 0, // range[0..100+], sent to troika as [0..100]% :string
         /* Y */ 0 // range[0..100+], sent to troika as [0..100]% :string
       ),
+      outlineColor: new Color(0x000000),
       // Font Stroke Properties
       strokeOpacity: 0, // range[0..100], sent to troika as [0..1] :number
       strokeWidth: 0, // range[0..100+], sent to troika as [0..100]% :string
+      strokeColor: new Color(0x444444),
       // SDF Configuration
       gpuAccelerated: true,
       // Internal State
@@ -264,8 +260,11 @@ export const TextComponent = defineComponent({
     if (matches.number.test(json.outlineBlur)) component.outlineBlur.set(json.outlineBlur)
     if (matches.object.test(json.outlineOffset) && json.outlineOffset.isVector2)
       component.outlineOffset.set(json.outlineOffset)
+    if (matches.object.test(json.outlineColor) && json.outlineColor.isColor)
+      component.outlineColor.set(json.outlineColor)
     if (matches.number.test(json.strokeOpacity)) component.strokeOpacity.set(json.strokeOpacity)
     if (matches.number.test(json.strokeWidth)) component.strokeWidth.set(json.strokeWidth)
+    if (matches.object.test(json.strokeColor) && json.strokeColor.isColor) component.strokeColor.set(json.strokeColor)
     // SDF configuration
     if (matches.boolean.test(json.gpuAccelerated)) component.gpuAccelerated.set(json.gpuAccelerated)
   },
@@ -293,8 +292,10 @@ export const TextComponent = defineComponent({
       outlineWidth: component.outlineWidth.value,
       outlineBlur: component.outlineBlur.value,
       outlineOffset: component.outlineOffset.value,
+      outlineColor: component.outlineColor.value,
       strokeOpacity: component.strokeOpacity.value,
       strokeWidth: component.strokeWidth.value,
+      strokeColor: component.strokeColor.value,
       // SDF configuration
       gpuAccelerated: component.gpuAccelerated.value
     }
@@ -332,8 +333,10 @@ export const TextComponent = defineComponent({
       text.troikaMesh.value.outlineBlur = `${text.outlineBlur.value}%`
       text.troikaMesh.value.outlineOffsetX = `${text.outlineOffset.x.value}%`
       text.troikaMesh.value.outlineOffsetY = `${text.outlineOffset.y.value}%`
+      text.troikaMesh.value.outlineColor = text.outlineColor.value.getHex()
       text.troikaMesh.value.strokeOpacity = text.strokeOpacity.value / 100
       text.troikaMesh.value.strokeWidth = `${text.strokeWidth.value}%`
+      text.troikaMesh.value.strokeColor = text.strokeColor.value.getHex()
       // SDF configuration
       text.troikaMesh.value.gpuAccelerateSDF = text.gpuAccelerated.value
       // Order troika to synchronize the mesh
@@ -357,8 +360,10 @@ export const TextComponent = defineComponent({
       text.outlineWidth,
       text.outlineBlur,
       text.outlineOffset,
+      text.outlineColor,
       text.strokeOpacity,
       text.strokeWidth,
+      text.strokeColor,
       text.gpuAccelerated
     ])
 

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -29,7 +29,7 @@ import { isClient } from '@etherealengine/engine/src/common/functions/getEnviron
 import { defineComponent, useComponent } from '@etherealengine/engine/src/ecs/functions/ComponentFunctions'
 import { useEntityContext } from '@etherealengine/engine/src/ecs/functions/EntityFunctions'
 
-import { Color, Mesh } from 'three'
+import { Color, Mesh, Vector2 } from 'three'
 import { Text as TroikaText } from 'troika-three-text'
 import { matches } from '../../common/functions/MatchesUtils'
 import { addObjectToGroup } from './GroupComponent'
@@ -70,6 +70,8 @@ type TextMesh = Mesh & {
   outlineOpacity: number // @note: Troika marks this as an Experimental API
   outlineWidth: number | string // @note: Troika marks this as an Experimental API
   outlineBlur: number | string // @note: Troika marks this as an Experimental API
+  outlineOffsetX: number | string // @note: Troika marks this as an Experimental API
+  outlineOffsetY: number | string // @note: Troika marks this as an Experimental API
   strokeOpacity: number // @note: Troika marks this as an Experimental API
   strokeWidth: number | string // @note: Troika marks this as an Experimental API
 
@@ -158,11 +160,6 @@ type TextMesh = Mesh & {
   // range. The color value can be a numeric hex color value, a `THREE.Color` object, or
   // any of the strings accepted by `THREE.Color`.
   colorRanges: object | null // WARNING: This API is experimental and may change.
-  // An offset for the text outline.
-  // Can be specified as either an absolute number in local units, or as a percentage string e.g. `"12%"`
-  // which is treated as a percentage of the `fontSize`. Defaults to `0`.
-  outlineOffsetX: number | string // WARNING: This API is experimental and may change.
-  outlineOffsetY: number | string // WARNING: This API is experimental and may change.
   // Defines the axis plane on which the text should be laid out when the mesh has no extra
   // rotation transform. It is specified as a string with two axes: the horizontal axis with
   // positive pointing right, and the vertical axis with positive pointing up. By default this
@@ -209,6 +206,10 @@ export const TextComponent = defineComponent({
       outlineOpacity: 0, // range[0..100], sent to troika as [0..1] :number
       outlineWidth: 0, // range[0..100+], sent to troika as [0..100]% :string
       outlineBlur: 0, // range[0..100+], sent to troika as [0..100]% :string
+      outlineOffset: new Vector2(
+        /* X */ 0, // range[0..100+], sent to troika as [0..100]% :string
+        /* Y */ 0 // range[0..100+], sent to troika as [0..100]% :string
+      ),
       // Font Stroke Properties
       strokeOpacity: 0, // range[0..100], sent to troika as [0..1] :number
       strokeWidth: 0, // range[0..100+], sent to troika as [0..100]% :string
@@ -233,6 +234,8 @@ export const TextComponent = defineComponent({
     if (matches.number.test(json.outlineOpacity)) component.outlineOpacity.set(json.outlineOpacity)
     if (matches.number.test(json.outlineWidth)) component.outlineWidth.set(json.outlineWidth)
     if (matches.number.test(json.outlineBlur)) component.outlineBlur.set(json.outlineBlur)
+    if (matches.object.test(json.outlineOffset) && json.outlineOffset.isVector2)
+      component.outlineOffset.set(json.outlineOffset)
     if (matches.number.test(json.strokeOpacity)) component.strokeOpacity.set(json.strokeOpacity)
     if (matches.number.test(json.strokeWidth)) component.strokeWidth.set(json.strokeWidth)
   },
@@ -252,6 +255,7 @@ export const TextComponent = defineComponent({
       outlineOpacity: component.outlineOpacity.value,
       outlineWidth: component.outlineWidth.value,
       outlineBlur: component.outlineBlur.value,
+      outlineOffset: component.outlineOffset.value,
       strokeOpacity: component.strokeOpacity.value,
       strokeWidth: component.strokeWidth.value
     }
@@ -279,6 +283,8 @@ export const TextComponent = defineComponent({
       text.troikaMesh.value.outlineOpacity = text.outlineOpacity.value / 100
       text.troikaMesh.value.outlineWidth = `${text.outlineWidth.value}%`
       text.troikaMesh.value.outlineBlur = `${text.outlineBlur.value}%`
+      text.troikaMesh.value.outlineOffsetX = `${text.outlineOffset.x.value}%`
+      text.troikaMesh.value.outlineOffsetY = `${text.outlineOffset.y.value}%`
       text.troikaMesh.value.strokeOpacity = text.strokeOpacity.value / 100
       text.troikaMesh.value.strokeWidth = `${text.strokeWidth.value}%`
       // Order troika to synchronize the mesh
@@ -295,6 +301,7 @@ export const TextComponent = defineComponent({
       text.outlineOpacity,
       text.outlineWidth,
       text.outlineBlur,
+      text.outlineOffset,
       text.strokeOpacity,
       text.strokeWidth
     ])

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -42,310 +42,167 @@ type TroikaColor = string | number | THREE.Color
 
 /**
  * @description
- * Type for Javascript-to-Typescript compatiblity of the `troika-three-text` Text mesh class.
+ * Javascript-to-Typescript compatiblity type for the `troika-three-text` Text mesh class.
  *
  * @example
  * import { Text as TroikaText } from 'troika-three-text'
  * let textMesh = new TroikaText() as TextMesh
  *
+ * @note
+ * Go to the `troika-three-text`.Text class implementation for documentation about each of the fields.
+ *
  * @abstract
  * Respects the shape of the original troika.Text class,
  * by intersecting the three.Mesh class with an explicit list of properties originally contained in the Text class.
- * Only the properties used by this implementation are explicitly declared.
- * @note
- * Go to the `troika-three-text`.Text class implementation for documentation about each of the fields.
+ * Only the properties used by this implementation are explicitly declared in this type.
  */
 type TextMesh = Mesh & {
-  /* --- Text layout properties: --- */
+  //____ Text layout properties ____
   text: string
+  font: string | null /** Defaults to Noto Sans when null */
   fontSize: number
-  /* --- Presentation properties: --- */
-  color: TroikaColor
-  sync: () => void /* Async Render the text using the current properties. troika accepts a callback function, but that feature is not mapped */
+  //____ Presentation properties ____
+  color: TroikaColor /** aka fontColor */
+  sync: () => void /** Async Render the text using the current properties. troika accepts a callback function, but that feature is not mapped */
 
-  //__________
-  //  TODO  //
-  //_______//
-  /**
-   * @member {number|string} anchorX
-   * Defines the horizontal position in the text block that should line up with the local origin.
-   * Can be specified as a numeric x position in local units, a string percentage of the total
-   * text block width e.g. `'25%'`, or one of the following keyword strings: 'left', 'center',
-   * or 'right'.
-   */
-  anchorX: number | string
-
-  /**
-   * @member {number|string} anchorY
-   * Defines the vertical position in the text block that should line up with the local origin.
-   * Can be specified as a numeric y position in local units (note: down is negative y), a string
-   * percentage of the total text block height e.g. `'25%'`, or one of the following keyword strings:
-   * 'top', 'top-baseline', 'top-cap', 'top-ex', 'middle', 'bottom-baseline', or 'bottom'.
-   */
-  anchorY: number | string
-
-  /**
-   * @member {number} curveRadius
-   * Defines a cylindrical radius along which the text's plane will be curved. Positive numbers put
-   * the cylinder's centerline (oriented vertically) that distance in front of the text, for a concave
-   * curvature, while negative numbers put it behind the text for a convex curvature. The centerline
-   * will be aligned with the text's local origin; you can use `anchorX` to offset it.
-   *
-   * Since each glyph is by default rendered with a simple quad, each glyph remains a flat plane
-   * internally. You can use `glyphGeometryDetail` to add more vertices for curvature inside glyphs.
-   */
+  //_____________________________________________________________
+  // TODO                                                      //
+  //  Remove the unused properties. Only temp for easier dev  //
+  //_________________________________________________________//
+  // Defines the position in the text block that should line up with the local origin.
+  // Can be specified as a numeric x position in local units, a string percentage of the total
+  // text block width e.g. `'25%'`, or one of the allowed keyword strings
+  anchorX: number | string | 'left' | 'center' | 'right'
+  anchorY: number | string | 'top' | 'top-baseline' | 'top-cap' | 'top-ex' | 'middle' | 'bottom-baseline' | 'bottom'
+  // Defines a cylindrical radius along which the text's plane will be curved. Positive numbers put
+  // the cylinder's centerline (oriented vertically) that distance in front of the text, for a concave
+  // curvature, while negative numbers put it behind the text for a convex curvature. The centerline
+  // will be aligned with the text's local origin; you can use `anchorX` to offset it.
+  // Since each glyph is by default rendered with a simple quad, each glyph remains a flat plane
+  // internally. You can use `glyphGeometryDetail` to add more vertices for curvature inside glyphs.
   curveRadius: number
-
-  /**
-   * @member {string} direction
-   * Sets the base direction for the text. The default value of "auto" will choose a direction based
-   * on the text's content according to the bidi spec. A value of "ltr" or "rtl" will force the direction.
-   */
+  // Sets the base direction for the text. The default value of "auto" will choose a direction based
+  // on the text's content according to the bidi spec. A value of "ltr" or "rtl" will force the direction.
   direction: 'auto' | 'ltr' | 'rtl'
-
-  /**
-   * @member {string|null} font
-   * URL of a custom font to be used. Font files can be in .ttf, .otf, or .woff (not .woff2) formats.
-   * Defaults to Noto Sans.
-   */
-  font: string | null /** Defaults to Noto Sans */
-  unicodeFontsURL: string | null //defaults to CDN
-
-  /**
-   * @member {number|'normal'|'bold'}
-   * The weight of the font. Currently only used for fallback Noto fonts.
-   */
-  fontWeight: number | 'normal' | 'bold'
-
-  /**
-   * @member {'normal'|'italic'}
-   * The style of the font. Currently only used for fallback Noto fonts.
-   */
-  fontStyle: 'normal' | 'italic'
-
-  /**
-   * @member {string|null} lang
-   * The language code of this text; can be used for explicitly selecting certain CJK fonts.
-   */
-  lang: string | null
-
-  /**
-   * @member {number} letterSpacing
-   * Sets a uniform adjustment to spacing between letters after kerning is applied. Positive
-   * numbers increase spacing and negative numbers decrease it.
-   */
+  // Sets a uniform adjustment to spacing between letters after kerning is applied.
+  // Positive numbers increase spacing and negative numbers decrease it.
   letterSpacing: number
-
-  /**
-   * @member {number|string} lineHeight
-   * Sets the height of each line of text, as a multiple of the `fontSize`. Defaults to 'normal'
-   * which chooses a reasonable height based on the chosen font's ascender/descender metrics.
-   */
+  // Sets the height of each line of text, as a multiple of the `fontSize`. Defaults to 'normal'
+  // which chooses a reasonable height based on the chosen font's ascender/descender metrics.
   lineHeight: number | 'normal'
-
-  /**
-   * @member {number} maxWidth
-   * The maximum width of the text block, above which text may start wrapping according to the
-   * `whiteSpace` and `overflowWrap` properties.
-   */
+  // The maximum width of the text block, above which text may start wrapping according to the
+  // `whiteSpace` and `overflowWrap` properties.
   maxWidth: number
-
-  /**
-   * @member {string} overflowWrap
-   * Defines how text wraps if the `whiteSpace` property is `normal`. Can be either `'normal'`
-   * to break at whitespace characters, or `'break-word'` to allow breaking within words.
-   * Defaults to `'normal'`.
-   */
+  // Defines how text wraps if the `whiteSpace` property is `normal`. Can be either `'normal'`
+  // to break at whitespace characters, or `'break-word'` to allow breaking within words.
+  // Defaults to `'normal'`.
   overflowWrap: 'normal' | 'break-word'
-
-  /**
-   * @member {string} textAlign
-   * The horizontal alignment of each line of text within the overall text bounding box.
-   */
+  // The horizontal alignment of each line of text within the overall text bounding box.
   textAlign: 'left' | 'center' | 'right' | 'justify'
-
-  /**
-   * @member {number} textIndent
-   * Indentation for the first character of a line; see CSS `text-indent`.
-   */
+  // Indentation for the first character of a line; see CSS `text-indent`.
   textIndent: number
-
-  /**
-   * @member {string} whiteSpace
-   * Defines whether text should wrap when a line reaches the `maxWidth`. Can
-   * be either `'normal'` (the default), to allow wrapping according to the `overflowWrap` property,
-   * or `'nowrap'` to prevent wrapping. Note that `'normal'` here honors newline characters to
-   * manually break lines, making it behave more like `'pre-wrap'` does in CSS.
-   */
+  // Defines whether text should wrap when a line reaches the `maxWidth`.
+  // Can be `'normal'` (the default), to allow wrapping according to the `overflowWrap` property,
+  // or `'nowrap'` to prevent wrapping.
+  // Note that `'normal'` here honors newline characters to manually break lines, making it behave more like `'pre-wrap'` does in CSS.
   whiteSpace: 'normal' | 'nowrap'
 
   // === Presentation properties: === //
-
-  /**
-   * @member {THREE.Material} material
-   * Defines a _base_ material to be used when rendering the text. This material will be
-   * automatically replaced with a material derived from it, that adds shader code to
-   * decrease the alpha for each fragment (pixel) outside the text glyphs, with antialiasing.
-   * By default it will derive from a simple white MeshBasicMaterial, but you can use any
-   * of the other mesh materials to gain other features like lighting, texture maps, etc.
-   *
-   * Also see the `color` shortcut property.
-   */
+  // Defines a _base_ material to be used when rendering the text. This material will be
+  // automatically replaced with a material derived from it, that adds shader code to
+  // decrease the alpha for each fragment (pixel) outside the text glyphs, with antialiasing.
+  // By default it will derive from a simple white MeshBasicMaterial, but you can use any
+  // of the other mesh materials to gain other features like lighting, texture maps, etc.
+  // Also see the `color` shortcut property.
   material: THREE.Material
-
-  /**
-   * @member {object|null} colorRanges
-   * WARNING: This API is experimental and may change.
-   * This allows more fine-grained control of colors for individual or ranges of characters,
-   * taking precedence over the material's `color`. Its format is an Object whose keys each
-   * define a starting character index for a range, and whose values are the color for each
-   * range. The color value can be a numeric hex color value, a `THREE.Color` object, or
-   * any of the strings accepted by `THREE.Color`.
-   */
-  colorRanges: object | null
-
-  /**
-   * @member {number|string} outlineWidth
-   * WARNING: This API is experimental and may change.
-   * The width of an outline/halo to be drawn around each text glyph using the `outlineColor` and `outlineOpacity`.
-   * Can be specified as either an absolute number in local units, or as a percentage string e.g.
-   * `"12%"` which is treated as a percentage of the `fontSize`. Defaults to `0`, which means
-   * no outline will be drawn unless an `outlineOffsetX/Y` or `outlineBlur` is set.
-   */
-  outlineWidth: number | string
-
-  /**
-   * @member {string|number|THREE.Color} outlineColor
-   * WARNING: This API is experimental and may change.
-   * The color of the text outline, if `outlineWidth`/`outlineBlur`/`outlineOffsetX/Y` are set.
-   * Defaults to black.
-   */
-  outlineColor: TroikaColor
-
-  /**
-   * @member {number} outlineOpacity
-   * WARNING: This API is experimental and may change.
-   * The opacity of the outline, if `outlineWidth`/`outlineBlur`/`outlineOffsetX/Y` are set.
-   * Defaults to `1`.
-   */
-  outlineOpacity: number
-
-  /**
-   * @member {number|string} outlineBlur
-   * WARNING: This API is experimental and may change.
-   * A blur radius applied to the outer edge of the text's outline. If the `outlineWidth` is
-   * zero, the blur will be applied at the glyph edge, like CSS's `text-shadow` blur radius.
-   * Can be specified as either an absolute number in local units, or as a percentage string e.g.
-   * `"12%"` which is treated as a percentage of the `fontSize`. Defaults to `0`.
-   */
-  outlineBlur: number | string
-
-  /**
-   * @member {number|string} outlineOffsetX
-   * WARNING: This API is experimental and may change.
-   * A horizontal offset for the text outline.
-   * Can be specified as either an absolute number in local units, or as a percentage string e.g. `"12%"`
-   * which is treated as a percentage of the `fontSize`. Defaults to `0`.
-   */
-  outlineOffsetX: number | string
-
-  /**
-   * @member {number|string} outlineOffsetY
-   * WARNING: This API is experimental and may change.
-   * A vertical offset for the text outline.
-   * Can be specified as either an absolute number in local units, or as a percentage string e.g. `"12%"`
-   * which is treated as a percentage of the `fontSize`. Defaults to `0`.
-   */
-  outlineOffsetY: number | string
-
-  /**
-   * @member {number|string} strokeWidth
-   * WARNING: This API is experimental and may change.
-   * The width of an inner stroke drawn inside each text glyph using the `strokeColor` and `strokeOpacity`.
-   * Can be specified as either an absolute number in local units, or as a percentage string e.g. `"12%"`
-   * which is treated as a percentage of the `fontSize`. Defaults to `0`.
-   */
-  strokeWidth: number | string
-
-  /**
-   * @member {string|number|THREE.Color} strokeColor
-   * WARNING: This API is experimental and may change.
-   * The color of the text stroke, if `strokeWidth` is greater than zero. Defaults to gray.
-   */
-  strokeColor: TroikaColor
-
-  /**
-   * @member {number} strokeOpacity
-   * WARNING: This API is experimental and may change.
-   * The opacity of the stroke, if `strokeWidth` is greater than zero. Defaults to `1`.
-   */
-  strokeOpacity: number
-
-  /**
-   * @member {number} fillOpacity
-   * WARNING: This API is experimental and may change.
-   * The opacity of the glyph's fill from 0 to 1. This behaves like the material's `opacity` but allows
-   * giving the fill a different opacity than the `strokeOpacity`. A fillOpacity of `0` makes the
-   * interior of the glyph invisible, leaving just the `strokeWidth`. Defaults to `1`.
-   */
-  fillOpacity: number
-
-  /**
-   * @member {number} depthOffset
-   * This is a shortcut for setting the material's `polygonOffset` and related properties,
-   * which can be useful in preventing z-fighting when this text is laid on top of another
-   * plane in the scene. Positive numbers are further from the camera, negatives closer.
-   */
+  // This allows more fine-grained control of colors for individual or ranges of characters,
+  // taking precedence over the material's `color`. Its format is an Object whose keys each
+  // define a starting character index for a range, and whose values are the color for each
+  // range. The color value can be a numeric hex color value, a `THREE.Color` object, or
+  // any of the strings accepted by `THREE.Color`.
+  colorRanges: object | null // WARNING: This API is experimental and may change.
+  // The width of an outline/halo to be drawn around each text glyph using the `outlineColor` and `outlineOpacity`.
+  // Can be specified as either an absolute number in local units, or as a percentage string e.g.
+  // `"12%"` which is treated as a percentage of the `fontSize`. Defaults to `0`, which means
+  // no outline will be drawn unless an `outlineOffsetX/Y` or `outlineBlur` is set.
+  outlineWidth: number | string // WARNING: This API is experimental and may change.
+  // The color of the text outline, if `outlineWidth`/`outlineBlur`/`outlineOffsetX/Y` are set.
+  // Defaults to black.
+  outlineColor: TroikaColor // WARNING: This API is experimental and may change.
+  // The opacity of the outline, if `outlineWidth`/`outlineBlur`/`outlineOffsetX/Y` are set.
+  // Defaults to `1`.
+  outlineOpacity: number // WARNING: This API is experimental and may change.
+  // A blur radius applied to the outer edge of the text's outline. If the `outlineWidth` is
+  // zero, the blur will be applied at the glyph edge, like CSS's `text-shadow` blur radius.
+  // Can be specified as either an absolute number in local units, or as a percentage string e.g.
+  // `"12%"` which is treated as a percentage of the `fontSize`. Defaults to `0`.
+  outlineBlur: number | string // WARNING: This API is experimental and may change.
+  // An offset for the text outline.
+  // Can be specified as either an absolute number in local units, or as a percentage string e.g. `"12%"`
+  // which is treated as a percentage of the `fontSize`. Defaults to `0`.
+  outlineOffsetX: number | string // WARNING: This API is experimental and may change.
+  outlineOffsetY: number | string // WARNING: This API is experimental and may change.
+  // The width of an inner stroke drawn inside each text glyph using the `strokeColor` and `strokeOpacity`.
+  // Can be specified as either an absolute number in local units, or as a percentage string e.g. `"12%"`
+  // which is treated as a percentage of the `fontSize`. Defaults to `0`.
+  strokeWidth: number | string // WARNING: This API is experimental and may change.
+  // The color of the text stroke, if `strokeWidth` is greater than zero. Defaults to gray.
+  strokeColor: TroikaColor // WARNING: This API is experimental and may change.
+  // The opacity of the stroke, if `strokeWidth` is greater than zero. Defaults to `1`.
+  strokeOpacity: number // WARNING: This API is experimental and may change.
+  // The opacity of the glyph's fill from 0 to 1. This behaves like the material's `opacity` but allows
+  // giving the fill a different opacity than the `strokeOpacity`. A fillOpacity of `0` makes the
+  // interior of the glyph invisible, leaving just the `strokeWidth`. Defaults to `1`.
+  fillOpacity: number // WARNING: This API is experimental and may change.
+  // This is a shortcut for setting the material's `polygonOffset` and related properties,
+  // which can be useful in preventing z-fighting when this text is laid on top of another
+  // plane in the scene. Positive numbers are further from the camera, negatives closer.
   depthOffset: number
-
-  /**
-   * @member {Array<number>} clipRect
-   * If specified, defines a `[minX, minY, maxX, maxY]` of a rectangle outside of which all
-   * pixels will be discarded. This can be used for example to clip overflowing text when
-   * `whiteSpace='nowrap'`.
-   */
+  // If specified, defines a `[minX, minY, maxX, maxY]` of a rectangle outside of which all
+  // pixels will be discarded. This can be used for example to clip overflowing text when
+  // `whiteSpace='nowrap'`.
   clipRect: Array<number>
-
-  /**
-   * @member {string} orientation
-   * Defines the axis plane on which the text should be laid out when the mesh has no extra
-   * rotation transform. It is specified as a string with two axes: the horizontal axis with
-   * positive pointing right, and the vertical axis with positive pointing up. By default this
-   * is '+x+y', meaning the text sits on the xy plane with the text's top toward positive y
-   * and facing positive z. A value of '+x-z' would place it on the xz plane with the text's
-   * top toward negative z and facing positive y.
-   */
+  // Defines the axis plane on which the text should be laid out when the mesh has no extra
+  // rotation transform. It is specified as a string with two axes: the horizontal axis with
+  // positive pointing right, and the vertical axis with positive pointing up. By default this
+  // is '+x+y', meaning the text sits on the xy plane with the text's top toward positive y
+  // and facing positive z. A value of '+x-z' would place it on the xz plane with the text's
+  // top toward negative z and facing positive y.
   orientation: string
-
-  /**
-   * @member {number} glyphGeometryDetail
-   * Controls number of vertical/horizontal segments that make up each glyph's rectangular
-   * plane. Defaults to 1. This can be increased to provide more geometrical detail for custom
-   * vertex shader effects, for example.
-   */
+  // Controls number of vertical/horizontal segments that make up each glyph's rectangular
+  // plane. Defaults to 1. This can be increased to provide more geometrical detail for custom
+  // vertex shader effects, for example.
   glyphGeometryDetail: number
-
-  /**
-   * @member {number|null} sdfGlyphSize
-   * The size of each glyph's SDF (signed distance field) used for rendering. This must be a
-   * power-of-two number. Defaults to 64 which is generally a good balance of size and quality
-   * for most fonts. Larger sizes can improve the quality of glyph rendering by increasing
-   * the sharpness of corners and preventing loss of very thin lines, at the expense of
-   * increased memory footprint and longer SDF generation time.
-   */
+  // The size of each glyph's SDF (signed distance field) used for rendering. This must be a
+  // power-of-two number. Defaults to 64 which is generally a good balance of size and quality
+  // for most fonts. Larger sizes can improve the quality of glyph rendering by increasing
+  // the sharpness of corners and preventing loss of very thin lines, at the expense of
+  // increased memory footprint and longer SDF generation time.
   sdfGlyphSize: number | null
-
-  /**
-   * @member {boolean} gpuAccelerateSDF
-   * When `true`, the SDF generation process will be GPU-accelerated with WebGL when possible,
-   * making it much faster especially for complex glyphs, and falling back to a JavaScript version
-   * executed in web workers when support isn't available. It should automatically detect support,
-   * but it's still somewhat experimental, so you can set it to `false` to force it to use the JS
-   * version if you encounter issues with it.
-   */
+  // When `true`, the SDF generation process will be GPU-accelerated with WebGL when possible,
+  // making it much faster especially for complex glyphs, and falling back to a JavaScript version
+  // executed in web workers when support isn't available. It should automatically detect support,
+  // but it's still somewhat experimental, so you can set it to `false` to force it to use the JS
+  // version if you encounter issues with it.
   gpuAccelerateSDF: boolean
+
+  //____ Unlikely ____
+  fontWeight: number | 'normal' | 'bold' // The weight of the font. Currently only used for fallback Noto fonts.
+  fontStyle: 'normal' | 'italic' // The style of the font. Currently only used for fallback Noto fonts.
+  lang: string | null // The language code of this text; can be used for explicitly selecting certain CJK fonts.
+  unicodeFontsURL: string | null // defaults to CDN
   debugSDF: boolean
 }
+
+/**
+ *  @description
+ *  Noto Sans is the default font for text rendering.
+ *  @abstract
+ *  troika.Text.font accepts a nullable string, and defaults to Noto Sans when null is passed
+ */
+const FontDefault = null! as string | null
+/** @todo Remove. Only temp for testing */
+const FontOrbitronURL = 'https://fonts.gstatic.com/s/orbitron/v9/yMJRMIlzdpvBhQQL_Qq7dys.woff'
 
 export const TextComponent = defineComponent({
   name: 'TextComponent',
@@ -353,24 +210,34 @@ export const TextComponent = defineComponent({
 
   onInit: (entity) => {
     return {
-      // Text properties to configure
+      // Text contents to render
       text: 'Some Text',
+      // Font Properties
+      font: FontDefault, // font: string|null
       fontSize: 0.2,
       fontColor: new Color(0x9966ff),
+      // Internal State
       troikaMesh: new TroikaText() as TextMesh
     }
   },
 
   onSet: (entity, component, json) => {
     if (!json) return
+    // Text contents to render
     if (matches.string.test(json.text)) component.text.set(json.text)
+    // Font Properties
+    if (matches.string.test(json.font)) component.font.set(json.font)
+    else if (matches.nill.test(json.font)) component.font.set(null)
     if (matches.number.test(json.fontSize)) component.fontSize.set(json.fontSize)
     if (matches.object.test(json.fontColor) && json.fontColor.isColor) component.fontColor.set(json.fontColor)
   },
 
   toJSON: (entity, component) => {
     return {
+      // Text contents to render
       text: component.text.value,
+      // Font Properties
+      font: component.font.value,
       fontSize: component.fontSize.value,
       fontColor: component.fontColor.value
     }
@@ -385,8 +252,10 @@ export const TextComponent = defineComponent({
     addObjectToGroup(entity, text.troikaMesh.value)
 
     useEffect(() => {
-      // Update the rendering
+      // Update the Text content to render
       text.troikaMesh.value.text = text.text.value
+      // Update the font properties
+      text.troikaMesh.value.font = text.font.value
       text.troikaMesh.value.fontSize = text.fontSize.value
       text.troikaMesh.value.color = text.fontColor.value.getHex()
       text.troikaMesh.value.sync()

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -67,6 +67,7 @@ type TextMesh = Mesh & {
   maxWidth: number /** Value above which text starts wrapping */
   anchorX: number | string | 'left' | 'center' | 'right'
   anchorY: number | string | 'top' | 'top-baseline' | 'top-cap' | 'top-ex' | 'middle' | 'bottom-baseline' | 'bottom'
+  depthOffset: number
   curveRadius: number
   // Font properties
   font: string | null /** Defaults to Noto Sans when null */
@@ -91,10 +92,6 @@ type TextMesh = Mesh & {
   outlineColor: TroikaColor // WARNING: This API is experimental and may change.
   // The color of the text stroke, if `strokeWidth` is greater than zero. Defaults to gray.
   strokeColor: TroikaColor // WARNING: This API is experimental and may change.
-  // This is a shortcut for setting the material's `polygonOffset` and related properties,
-  // which can be useful in preventing z-fighting when this text is laid on top of another
-  // plane in the scene. Positive numbers are further from the camera, negatives closer.
-  depthOffset: number
   // If specified, defines a `[minX, minY, maxX, maxY]` of a rectangle outside of which all
   // pixels will be discarded. This can be used for example to clip overflowing text when
   // `whiteSpace='nowrap'`.
@@ -189,6 +186,7 @@ export const TextComponent = defineComponent({
         /* X */ 0, // range[0..100+], sent to troika as [0..100]% :string
         /* Y */ 0 // range[0..100+], sent to troika as [0..100]% :string
       ),
+      textDepthOffset: 0, // For Z-fighting adjustments. Similar to anchor.Z
       textCurveRadius: 0,
       letterSpacing: 0,
 
@@ -222,6 +220,7 @@ export const TextComponent = defineComponent({
     if (matches.number.test(json.textWidth)) component.textWidth.set(json.textWidth)
     if (matches.number.test(json.textIndent)) component.textIndent.set(json.textIndent)
     if (matches.object.test(json.textAnchor) && json.textAnchor.isVector2) component.textAnchor.set(json.textAnchor)
+    if (matches.number.test(json.textDepthOffset)) component.textDepthOffset.set(json.textDepthOffset)
     if (matches.number.test(json.textCurveRadius)) component.textCurveRadius.set(json.textCurveRadius)
     if (matches.number.test(json.letterSpacing)) component.letterSpacing.set(json.letterSpacing)
     // Font Properties
@@ -247,6 +246,7 @@ export const TextComponent = defineComponent({
       textWidth: component.textWidth.value,
       textIndent: component.textIndent.value,
       textAnchor: component.textAnchor.value,
+      textDepthOffset: component.textDepthOffset.value,
       textCurveRadius: component.textCurveRadius.value,
       letterSpacing: component.letterSpacing.value,
       // Font Properties
@@ -279,6 +279,7 @@ export const TextComponent = defineComponent({
       text.troikaMesh.value.textIndent = text.textIndent.value
       text.troikaMesh.value.anchorX = `${text.textAnchor.x.value}%`
       text.troikaMesh.value.anchorY = `${text.textAnchor.y.value}%`
+      text.troikaMesh.value.depthOffset = text.textDepthOffset.value
       text.troikaMesh.value.curveRadius = MathUtils.degToRad(text.textCurveRadius.value)
       text.troikaMesh.value.letterSpacing = text.letterSpacing.value
       // Update the font properties
@@ -301,6 +302,7 @@ export const TextComponent = defineComponent({
       text.textIndent,
       text.textAnchor,
       text.textCurveRadius,
+      text.textDepthOffset,
       text.textWidth,
       text.letterSpacing,
       text.textIndent,

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -62,14 +62,13 @@ type TextMesh = Mesh & {
   // Text properties
   textIndent: number /** Indentation for the first character of a line; see CSS `text-indent`. */
   letterSpacing: number /** Spacing between letters after kerning is applied. */
+  maxWidth: number /** Value above which text starts wrapping */
   // Font properties
   font: string | null /** Defaults to Noto Sans when null */
   fontSize: number
   //____ Presentation properties ____
   color: TroikaColor /** aka fontColor */
   sync: () => void /** Async Render the text using the current properties. troika accepts a callback function, but that feature is not mapped */
-
-  //____ WIP ____
 
   //____ Simple Properties
   // Defines a cylindrical radius along which the text's plane will be curved. Positive numbers put
@@ -79,9 +78,6 @@ type TextMesh = Mesh & {
   // Since each glyph is by default rendered with a simple quad, each glyph remains a flat plane
   // internally. You can use `glyphGeometryDetail` to add more vertices for curvature inside glyphs.
   curveRadius: number
-  // The maximum width of the text block, above which text may start wrapping according to the
-  // `whiteSpace` and `overflowWrap` properties.
-  maxWidth: number
   // The color of the text outline, if `outlineWidth`/`outlineBlur`/`outlineOffsetX/Y` are set.
   // Defaults to black.
   outlineColor: TroikaColor // WARNING: This API is experimental and may change.
@@ -217,6 +213,7 @@ export const TextComponent = defineComponent({
     return {
       // Text contents to render
       text: 'Some Text',
+      textWidth: Infinity,
       textIndent: 0,
       letterSpacing: 0,
       // Font Properties
@@ -232,6 +229,7 @@ export const TextComponent = defineComponent({
     if (!json) return
     // Text contents to render
     if (matches.string.test(json.text)) component.text.set(json.text)
+    if (matches.number.test(json.textWidth)) component.textWidth.set(json.textWidth)
     if (matches.number.test(json.textIndent)) component.textIndent.set(json.textIndent)
     if (matches.number.test(json.letterSpacing)) component.letterSpacing.set(json.letterSpacing)
     // Font Properties
@@ -245,6 +243,7 @@ export const TextComponent = defineComponent({
     return {
       // Text contents to render
       text: component.text.value,
+      textWidth: component.textWidth.value,
       textIndent: component.textIndent.value,
       letterSpacing: component.letterSpacing.value,
       // Font Properties
@@ -265,6 +264,7 @@ export const TextComponent = defineComponent({
     useEffect(() => {
       // Update the Text content to render
       text.troikaMesh.value.text = text.text.value
+      text.troikaMesh.value.maxWidth = text.textWidth.value
       text.troikaMesh.value.textIndent = text.textIndent.value
       text.troikaMesh.value.letterSpacing = text.letterSpacing.value
       // Update the font properties
@@ -273,7 +273,7 @@ export const TextComponent = defineComponent({
       text.troikaMesh.value.color = text.fontColor.value.getHex()
       // Order troika to syncrhonize the mesh
       text.troikaMesh.value.sync()
-    }, [text.text, text.textIndent, text.letterSpacing, text.textIndent, text.fontSize, text.fontColor])
+    }, [text.text, text.textIndent, text.textWidth, text.letterSpacing, text.textIndent, text.fontSize, text.fontColor])
 
     /* Reactive system
     useExecute(() => {}, { with: InputSystemGroup })

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -70,6 +70,8 @@ type TextMesh = Mesh & {
   outlineOpacity: number // @note: Troika marks this as an Experimental API
   outlineWidth: number | string // @note: Troika marks this as an Experimental API
   strokeOpacity: number // @note: Troika marks this as an Experimental API
+  strokeWidth: number | string // @note: Troika marks this as an Experimental API
+
   //____ Presentation properties ____
   color: TroikaColor /** aka fontColor */
   sync: () => void /** Async Render the text using the current properties. troika accepts a callback function, but that feature is not mapped */
@@ -165,10 +167,6 @@ type TextMesh = Mesh & {
   // which is treated as a percentage of the `fontSize`. Defaults to `0`.
   outlineOffsetX: number | string // WARNING: This API is experimental and may change.
   outlineOffsetY: number | string // WARNING: This API is experimental and may change.
-  // The width of an inner stroke drawn inside each text glyph using the `strokeColor` and `strokeOpacity`.
-  // Can be specified as either an absolute number in local units, or as a percentage string e.g. `"12%"`
-  // which is treated as a percentage of the `fontSize`. Defaults to `0`.
-  strokeWidth: number | string // WARNING: This API is experimental and may change.
   // Defines the axis plane on which the text should be laid out when the mesh has no extra
   // rotation transform. It is specified as a string with two axes: the horizontal axis with
   // positive pointing right, and the vertical axis with positive pointing up. By default this
@@ -216,6 +214,7 @@ export const TextComponent = defineComponent({
       outlineWidth: 0, // range[0..100+], sent to troika as [0..100]% :string
       // Font Stroke Properties
       strokeOpacity: 0, // range[0..100], sent to troika as [0..1] :number
+      strokeWidth: 0, // range[0..100+], sent to troika as [0..100]% :string
       // Internal State
       troikaMesh: new TroikaText() as TextMesh
     }
@@ -237,6 +236,7 @@ export const TextComponent = defineComponent({
     if (matches.number.test(json.outlineOpacity)) component.outlineOpacity.set(json.outlineOpacity)
     if (matches.number.test(json.outlineWidth)) component.outlineWidth.set(json.outlineWidth)
     if (matches.number.test(json.strokeOpacity)) component.strokeOpacity.set(json.strokeOpacity)
+    if (matches.number.test(json.strokeWidth)) component.strokeWidth.set(json.strokeWidth)
   },
 
   toJSON: (entity, component) => {
@@ -253,7 +253,8 @@ export const TextComponent = defineComponent({
       fontColor: component.fontColor.value,
       outlineOpacity: component.outlineOpacity.value,
       outlineWidth: component.outlineWidth.value,
-      strokeOpacity: component.strokeOpacity.value
+      strokeOpacity: component.strokeOpacity.value,
+      strokeWidth: component.strokeWidth.value
     }
   },
 
@@ -279,6 +280,7 @@ export const TextComponent = defineComponent({
       text.troikaMesh.value.outlineOpacity = text.outlineOpacity.value / 100
       text.troikaMesh.value.outlineWidth = `${text.outlineWidth.value}%`
       text.troikaMesh.value.strokeOpacity = text.strokeOpacity.value / 100
+      text.troikaMesh.value.strokeWidth = `${text.strokeWidth.value}%`
       // Order troika to syncrhonize the mesh
       text.troikaMesh.value.sync()
     }, [
@@ -292,7 +294,8 @@ export const TextComponent = defineComponent({
       text.fontColor,
       text.outlineOpacity,
       text.outlineWidth,
-      text.strokeOpacity
+      text.strokeOpacity,
+      text.strokeWidth
     ])
 
     /* Reactive system

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -59,6 +59,10 @@ type TroikaColor = string | number | THREE.Color
 type TextMesh = Mesh & {
   //____ Text layout properties ____
   text: string
+  // Text properties
+  textIndent: number /** Indentation for the first character of a line; see CSS `text-indent`. */
+  letterSpacing: number /** Spacing between letters after kerning is applied. */
+  // Font properties
   font: string | null /** Defaults to Noto Sans when null */
   fontSize: number
   //____ Presentation properties ____
@@ -66,7 +70,6 @@ type TextMesh = Mesh & {
   sync: () => void /** Async Render the text using the current properties. troika accepts a callback function, but that feature is not mapped */
 
   //____ WIP ____
-  textIndent: number /** Indentation for the first character of a line; see CSS `text-indent`. */
 
   //____ Simple Properties
   // Defines a cylindrical radius along which the text's plane will be curved. Positive numbers put
@@ -76,9 +79,6 @@ type TextMesh = Mesh & {
   // Since each glyph is by default rendered with a simple quad, each glyph remains a flat plane
   // internally. You can use `glyphGeometryDetail` to add more vertices for curvature inside glyphs.
   curveRadius: number
-  // Sets a uniform adjustment to spacing between letters after kerning is applied.
-  // Positive numbers increase spacing and negative numbers decrease it.
-  letterSpacing: number
   // The maximum width of the text block, above which text may start wrapping according to the
   // `whiteSpace` and `overflowWrap` properties.
   maxWidth: number
@@ -218,6 +218,7 @@ export const TextComponent = defineComponent({
       // Text contents to render
       text: 'Some Text',
       textIndent: 0,
+      letterSpacing: 0,
       // Font Properties
       font: FontDefault, // font: string|null
       fontSize: 0.2,
@@ -232,6 +233,7 @@ export const TextComponent = defineComponent({
     // Text contents to render
     if (matches.string.test(json.text)) component.text.set(json.text)
     if (matches.number.test(json.textIndent)) component.textIndent.set(json.textIndent)
+    if (matches.number.test(json.letterSpacing)) component.letterSpacing.set(json.letterSpacing)
     // Font Properties
     if (matches.string.test(json.font)) component.font.set(json.font)
     else if (matches.nill.test(json.font)) component.font.set(null)
@@ -244,6 +246,7 @@ export const TextComponent = defineComponent({
       // Text contents to render
       text: component.text.value,
       textIndent: component.textIndent.value,
+      letterSpacing: component.letterSpacing.value,
       // Font Properties
       font: component.font.value,
       fontSize: component.fontSize.value,
@@ -263,13 +266,14 @@ export const TextComponent = defineComponent({
       // Update the Text content to render
       text.troikaMesh.value.text = text.text.value
       text.troikaMesh.value.textIndent = text.textIndent.value
+      text.troikaMesh.value.letterSpacing = text.letterSpacing.value
       // Update the font properties
       text.troikaMesh.value.font = text.font.value
       text.troikaMesh.value.fontSize = text.fontSize.value
       text.troikaMesh.value.color = text.fontColor.value.getHex()
       // Order troika to syncrhonize the mesh
       text.troikaMesh.value.sync()
-    }, [text.text, text.textIndent, text.fontSize, text.fontColor])
+    }, [text.text, text.textIndent, text.letterSpacing, text.textIndent, text.fontSize, text.fontColor])
 
     /* Reactive system
     useExecute(() => {}, { with: InputSystemGroup })

--- a/packages/engine/src/scene/components/TextComponent.tsx
+++ b/packages/engine/src/scene/components/TextComponent.tsx
@@ -44,9 +44,16 @@ type TroikaColor = string | number | THREE.Color
 /**
  * @description
  * troika.Text direction type, as declared by `troika-three-text` in its Text.direction `@member` property.
- * `auto` means choosing direction based on the contents.
+ * `auto` means choosing direction based on the text contents.
  */
 export type TroikaTextDirection = 'auto' | 'ltr' | 'rtl'
+
+/**
+ * @description
+ * troika.Text alignment type, as declared by `troika-three-text` in its Text.textAlign `@member` property.
+ * Defines the horizontal alignment of each line within the overall bounding box.
+ */
+export type TroikaTextAlignment = 'left' | 'center' | 'right' | 'justify'
 
 /**
  * @description
@@ -70,6 +77,7 @@ type TextMesh = Mesh & {
   // Text properties
   fillOpacity: number // @note: Troika marks this as an Experimental API
   textIndent: number /** Indentation for the first character of a line; see CSS `text-indent`. */
+  textAlign: TroikaTextAlignment
   letterSpacing: number /** Spacing between letters after kerning is applied. */
   maxWidth: number /** Value above which text starts wrapping */
   anchorX: number | string | 'left' | 'center' | 'right'
@@ -128,8 +136,6 @@ type TextMesh = Mesh & {
   // to break at whitespace characters, or `'break-word'` to allow breaking within words.
   // Defaults to `'normal'`.
   overflowWrap: 'normal' | 'break-word'
-  // The horizontal alignment of each line of text within the overall text bounding box.
-  textAlign: 'left' | 'center' | 'right' | 'justify'
   // Defines whether text should wrap when a line reaches the `maxWidth`.
   // Can be `'normal'` (the default), to allow wrapping according to the `overflowWrap` property,
   // or `'nowrap'` to prevent wrapping.
@@ -187,6 +193,7 @@ export const TextComponent = defineComponent({
       textOpacity: 100, // range[0..100], sent to troika as [0..1] :number
       textWidth: Infinity,
       textIndent: 0,
+      textAlign: 'justify' as TroikaTextAlignment,
       textAnchor: new Vector2(
         /* X */ 0, // range[0..100+], sent to troika as [0..100]% :string
         /* Y */ 0 // range[0..100+], sent to troika as [0..100]% :string
@@ -225,6 +232,7 @@ export const TextComponent = defineComponent({
     if (matches.number.test(json.textOpacity)) component.textOpacity.set(json.textOpacity)
     if (matches.number.test(json.textWidth)) component.textWidth.set(json.textWidth)
     if (matches.number.test(json.textIndent)) component.textIndent.set(json.textIndent)
+    if (matches.string.test(json.textAlign)) component.textAlign.set(json.textAlign)
     if (matches.object.test(json.textAnchor) && json.textAnchor.isVector2) component.textAnchor.set(json.textAnchor)
     if (matches.number.test(json.textDepthOffset)) component.textDepthOffset.set(json.textDepthOffset)
     if (matches.number.test(json.textCurveRadius)) component.textCurveRadius.set(json.textCurveRadius)
@@ -253,6 +261,7 @@ export const TextComponent = defineComponent({
       textOpacity: component.textOpacity.value,
       textWidth: component.textWidth.value,
       textIndent: component.textIndent.value,
+      textAlign: component.textAlign.value,
       textAnchor: component.textAnchor.value,
       textDepthOffset: component.textDepthOffset.value,
       textCurveRadius: component.textCurveRadius.value,
@@ -287,6 +296,7 @@ export const TextComponent = defineComponent({
       text.troikaMesh.value.fillOpacity = text.textOpacity.value / 100
       text.troikaMesh.value.maxWidth = text.textWidth.value
       text.troikaMesh.value.textIndent = text.textIndent.value
+      text.troikaMesh.value.textAlign = text.textAlign.value
       text.troikaMesh.value.anchorX = `${text.textAnchor.x.value}%`
       text.troikaMesh.value.anchorY = `${text.textAnchor.y.value}%`
       text.troikaMesh.value.depthOffset = text.textDepthOffset.value
@@ -312,6 +322,7 @@ export const TextComponent = defineComponent({
       text.text,
       text.textOpacity,
       text.textIndent,
+      text.textAlign,
       text.textAnchor,
       text.textCurveRadius,
       text.textDepthOffset,


### PR DESCRIPTION
## Summary
Adds support for the Troika text renderer plugin, and (almost all) its configuration options.
Its output is a spatial Component that is exposed in the studio with a TextNodeEditor.

## References
`todo`
## QA Steps
`todo`

## TODO
- [ ] Map the `troika.Text.lineHeight` property into the editor.
- [ ] Map the `troika.Text.orientation` property into the editor.
- [ ] Implement `THREE.Material` support.
- [ ] Add `info` hover explanations to all of the complex options exposed.
- [ ] Decide if multi-lang support should be added. _(`troika.Text.lang` and `troika.Text.unicodeFontsURL`)_