### PR TITLE
Updated S3 storage provider to make most project files private

### DIFF
--- a/packages/common/src/constants/ProjectKeyConstants.ts
+++ b/packages/common/src/constants/ProjectKeyConstants.ts
@@ -1,0 +1,27 @@
+/*
+CPAL-1.0 License
+
+The contents of this file are subject to the Common Public Attribution License
+Version 1.0. (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE.
+The License is based on the Mozilla Public License Version 1.1, but Sections 14
+and 15 have been added to cover use of software over a computer network and
+provide for limited attribution for the Original Developer. In addition,
+Exhibit A has been modified to be consistent with Exhibit B.
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+specific language governing rights and limitations under the License.
+
+The Original Code is Ethereal Engine.
+
+The Original Developer is the Initial Developer. The Initial Developer of the
+Original Code is the Ethereal Engine team.
+
+All portions of the code written by the Ethereal Engine team are Copyright © 2021-2023
+Ethereal Engine. All Rights Reserved.
+*/
+
+export const projectRegex = /projects\/[a-zA-Z0-9-_]+/
+export const projectPublicRegex = /projects\/[a-zA-Z0-9-_]+\/public\//

--- a/packages/common/src/constants/ProjectKeyConstants.ts
+++ b/packages/common/src/constants/ProjectKeyConstants.ts
@@ -23,5 +23,12 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
+//FIXME: Legacy location of public assets, should be deleted and all files' use of this removed once all existing
+//projects have had their public assets moved to the /public folder
+export const assetsRegex = /projects\/[a-zA-Z0-9-_]+\/assets\//
 export const projectRegex = /projects\/[a-zA-Z0-9-_]+/
 export const projectPublicRegex = /projects\/[a-zA-Z0-9-_]+\/public\//
+//FIXME: These should be removed once scenes and their assets like envmaps, loading screens, and thumbnails
+//are moved to the /public folder
+export const rootImageRegex = /projects\/[a-zA-Z0-9-_]+\/[a-zA-Z0-9-_.]+.(jpg|jpeg|ktx2|png)/
+export const rootSceneJsonRegex = /projects\/[a-zA-Z0-9-_]+\/[a-zA-Z0-9-_]+.scene.json/

--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -67,7 +67,13 @@ import S3BlobStore from 's3-blob-store'
 import { PassThrough, Readable } from 'stream'
 
 import { MULTIPART_CHUNK_SIZE, MULTIPART_CUTOFF_SIZE } from '@etherealengine/common/src/constants/FileSizeConstants'
-import { projectPublicRegex, projectRegex } from '@etherealengine/common/src/constants/ProjectKeyConstants'
+import {
+  assetsRegex,
+  projectPublicRegex,
+  projectRegex,
+  rootImageRegex,
+  rootSceneJsonRegex
+} from '@etherealengine/common/src/constants/ProjectKeyConstants'
 import { Client } from 'minio'
 
 import { FileBrowserContentType } from '@etherealengine/common/src/schemas/media/file-browser.schema'
@@ -305,7 +311,11 @@ export class S3Provider implements StorageProviderInterface {
     const args = params.isDirectory
       ? {
           ACL:
-            projectRegex.test(key) && !projectPublicRegex.test(key)
+            projectRegex.test(key) &&
+            !projectPublicRegex.test(key) &&
+            !assetsRegex.test(key) &&
+            !rootImageRegex.test(key) &&
+            !rootSceneJsonRegex.test(key)
               ? ObjectCannedACL.private
               : ObjectCannedACL.public_read,
           Body: Buffer.alloc(0),
@@ -315,7 +325,11 @@ export class S3Provider implements StorageProviderInterface {
         }
       : {
           ACL:
-            projectRegex.test(key) && !projectPublicRegex.test(key)
+            projectRegex.test(key) &&
+            !projectPublicRegex.test(key) &&
+            !assetsRegex.test(key) &&
+            !rootImageRegex.test(key) &&
+            !rootSceneJsonRegex.test(key)
               ? ObjectCannedACL.private
               : ObjectCannedACL.public_read,
           Body: data.Body,
@@ -346,14 +360,17 @@ export class S3Provider implements StorageProviderInterface {
         reject(err)
       }
     } else if (config.aws.s3.s3DevMode === 'local') {
-      const response = await this.minioClient?.putObject(args.Bucket, args.Key, args.Body, {
+      return await this.minioClient?.putObject(args.Bucket, args.Key, args.Body, {
         'Content-Type': args.ContentType
       })
-      return response
     } else if (data.Body?.length > MULTIPART_CUTOFF_SIZE) {
       const multiPartStartArgs = {
         ACL:
-          projectRegex.test(key) && !projectPublicRegex.test(key)
+          projectRegex.test(key) &&
+          !projectPublicRegex.test(key) &&
+          !assetsRegex.test(key) &&
+          !rootImageRegex.test(key) &&
+          !rootSceneJsonRegex.test(key)
             ? ObjectCannedACL.private
             : ObjectCannedACL.public_read,
         Bucket: this.bucket,
@@ -734,7 +751,11 @@ export class S3Provider implements StorageProviderInterface {
         const key = path.join(newFilePath, file.Key.replace(oldFilePath, ''))
         const input = {
           ACL:
-            projectRegex.test(key) && !projectPublicRegex.test(key)
+            projectRegex.test(key) &&
+            !projectPublicRegex.test(key) &&
+            !assetsRegex.test(key) &&
+            !rootImageRegex.test(key) &&
+            !rootSceneJsonRegex.test(key)
               ? ObjectCannedACL.private
               : ObjectCannedACL.public_read,
           Bucket: this.bucket,

--- a/packages/server-core/src/media/storageprovider/s3.storage.ts
+++ b/packages/server-core/src/media/storageprovider/s3.storage.ts
@@ -109,6 +109,15 @@ function handler(event) {
 }
 `
 
+export const getACL = (key: string) =>
+  projectRegex.test(key) &&
+  !projectPublicRegex.test(key) &&
+  !assetsRegex.test(key) &&
+  !rootImageRegex.test(key) &&
+  !rootSceneJsonRegex.test(key)
+    ? ObjectCannedACL.private
+    : ObjectCannedACL.public_read
+
 /**
  * Storage provide class to communicate with AWS S3 API.
  */
@@ -310,28 +319,14 @@ export class S3Provider implements StorageProviderInterface {
 
     const args = params.isDirectory
       ? {
-          ACL:
-            projectRegex.test(key) &&
-            !projectPublicRegex.test(key) &&
-            !assetsRegex.test(key) &&
-            !rootImageRegex.test(key) &&
-            !rootSceneJsonRegex.test(key)
-              ? ObjectCannedACL.private
-              : ObjectCannedACL.public_read,
+          ACL: getACL(key),
           Body: Buffer.alloc(0),
           Bucket: this.bucket,
           ContentType: 'application/x-empty',
           Key: key + '/'
         }
       : {
-          ACL:
-            projectRegex.test(key) &&
-            !projectPublicRegex.test(key) &&
-            !assetsRegex.test(key) &&
-            !rootImageRegex.test(key) &&
-            !rootSceneJsonRegex.test(key)
-              ? ObjectCannedACL.private
-              : ObjectCannedACL.public_read,
+          ACL: getACL(key),
           Body: data.Body,
           Bucket: this.bucket,
           ContentType: data.ContentType,
@@ -365,14 +360,7 @@ export class S3Provider implements StorageProviderInterface {
       })
     } else if (data.Body?.length > MULTIPART_CUTOFF_SIZE) {
       const multiPartStartArgs = {
-        ACL:
-          projectRegex.test(key) &&
-          !projectPublicRegex.test(key) &&
-          !assetsRegex.test(key) &&
-          !rootImageRegex.test(key) &&
-          !rootSceneJsonRegex.test(key)
-            ? ObjectCannedACL.private
-            : ObjectCannedACL.public_read,
+        ACL: getACL(key),
         Bucket: this.bucket,
         Key: key,
         ContentType: data.ContentType
@@ -750,14 +738,7 @@ export class S3Provider implements StorageProviderInterface {
       ...listResponse.Contents.map(async (file) => {
         const key = path.join(newFilePath, file.Key.replace(oldFilePath, ''))
         const input = {
-          ACL:
-            projectRegex.test(key) &&
-            !projectPublicRegex.test(key) &&
-            !assetsRegex.test(key) &&
-            !rootImageRegex.test(key) &&
-            !rootSceneJsonRegex.test(key)
-              ? ObjectCannedACL.private
-              : ObjectCannedACL.public_read,
+          ACL: getACL(key),
           Bucket: this.bucket,
           CopySource: `/${this.bucket}/${file.Key}`,
           Key: key

--- a/packages/server-core/tests/storageprovider/storageproviderconfig.ts
+++ b/packages/server-core/tests/storageprovider/storageproviderconfig.ts
@@ -23,7 +23,13 @@ All portions of the code written by the Ethereal Engine team are Copyright © 20
 Ethereal Engine. All Rights Reserved.
 */
 
-import { CreateBucketCommand, DeleteObjectCommand, HeadBucketCommand, ListObjectsV2Command } from '@aws-sdk/client-s3'
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  HeadBucketCommand,
+  ListObjectsV2Command,
+  ObjectCannedACL
+} from '@aws-sdk/client-s3'
 import appRootPath from 'app-root-path'
 import fs from 'fs'
 import path from 'path'
@@ -92,7 +98,7 @@ const s3StorageBeforeTest = async (provider: S3Provider): Promise<any> => {
     if (err.code !== 'NotFound') throw err
   }
   if (bucketExists == null) {
-    await provider.provider.send(new CreateBucketCommand({ Bucket: provider.bucket, ACL: 'public-read' }))
+    await provider.provider.send(new CreateBucketCommand({ Bucket: provider.bucket, ACL: ObjectCannedACL.public_read }))
   }
   return
 }

--- a/packages/server/scripts/upload-avatar.ts
+++ b/packages/server/scripts/upload-avatar.ts
@@ -28,7 +28,13 @@ const dotenv = require('dotenv')
 const fs = require('fs')
 const knex = require('knex')
 const { staticResourcePath } = require('@etherealengine/engine/src/media/static-resource.schema')
-const { projectPublicRegex, projectRegex } = require('@etherealengine/common/src/constants/ProjectKeyConstants')
+const {
+  assetsRegex,
+  projectPublicRegex,
+  projectRegex,
+  rootImageRegex,
+  rootSceneJsonRegex
+} = require('@etherealengine/common/src/constants/ProjectKeyConstants')
 const { ObjectCannedACL, S3Client } = require('@aws-sdk/client-s3')
 const { nanoid } = require('nanoid')
 const { v4 } = require('uuid')
@@ -100,7 +106,11 @@ const uploadFile = (Key, Body) => {
               Bucket: BUCKET,
               Key,
               ACL:
-                projectRegex.test(Key) && !projectPublicRegex.test(Key)
+                projectRegex.test(Key) &&
+                !projectPublicRegex.test(Key) &&
+                !assetsRegex.test(Key) &&
+                !rootImageRegex.test(Key) &&
+                !rootSceneJsonRegex.test(Key)
                   ? ObjectCannedACL.private
                   : ObjectCannedACL.public_read
             },

--- a/packages/server/scripts/upload-avatar.ts
+++ b/packages/server/scripts/upload-avatar.ts
@@ -28,7 +28,8 @@ const dotenv = require('dotenv')
 const fs = require('fs')
 const knex = require('knex')
 const { staticResourcePath } = require('@etherealengine/engine/src/media/static-resource.schema')
-const { S3Client } = require('@aws-sdk/client-s3')
+const { projectPublicRegex, projectRegex } = require('@etherealengine/common/src/constants/ProjectKeyConstants')
+const { ObjectCannedACL, S3Client } = require('@aws-sdk/client-s3')
 const { nanoid } = require('nanoid')
 const { v4 } = require('uuid')
 
@@ -98,7 +99,10 @@ const uploadFile = (Key, Body) => {
               Body,
               Bucket: BUCKET,
               Key,
-              ACL: 'public-read'
+              ACL:
+                projectRegex.test(Key) && !projectPublicRegex.test(Key)
+                  ? ObjectCannedACL.private
+                  : ObjectCannedACL.public_read
             },
             (err, data) => {
               resolve(data)

--- a/packages/server/scripts/upload-avatar.ts
+++ b/packages/server/scripts/upload-avatar.ts
@@ -24,6 +24,8 @@ Ethereal Engine. All Rights Reserved.
 */
 
 /* eslint-disable @typescript-eslint/no-var-requires */
+import { getACL } from '@etherealengine/server-core/src/media/storageprovider/s3.storage'
+
 const dotenv = require('dotenv')
 const fs = require('fs')
 const knex = require('knex')
@@ -105,14 +107,7 @@ const uploadFile = (Key, Body) => {
               Body,
               Bucket: BUCKET,
               Key,
-              ACL:
-                projectRegex.test(Key) &&
-                !projectPublicRegex.test(Key) &&
-                !assetsRegex.test(Key) &&
-                !rootImageRegex.test(Key) &&
-                !rootSceneJsonRegex.test(Key)
-                  ? ObjectCannedACL.private
-                  : ObjectCannedACL.public_read
+              ACL: getACL(Key)
             },
             (err, data) => {
               resolve(data)


### PR DESCRIPTION
When adding files to S3, any project files not in a top-level `public` folder will have a private ACL so as not to expose code. Anything within the top-level `public` folder will remain as public-read, no matter how deep, but `public` folders in other project folders will not be made public.

## Summary

## References
closes #_insert number here_

## QA Steps
