### PR TITLE
Fix Gizmo Transform Position on Children of Offset Entities

### DIFF
--- a/packages/editor/src/classes/TransformGizmoComponent.ts
+++ b/packages/editor/src/classes/TransformGizmoComponent.ts
@@ -42,10 +42,7 @@ import { VisibleComponent } from '@etherealengine/engine/src/scene/components/Vi
 import { ObjectLayers } from '@etherealengine/engine/src/scene/constants/ObjectLayers'
 import { SnapMode, TransformPivot, TransformSpace } from '@etherealengine/engine/src/scene/constants/transformConstants'
 import { setObjectLayers } from '@etherealengine/engine/src/scene/functions/setObjectLayers'
-import {
-  LocalTransformComponent,
-  TransformComponent
-} from '@etherealengine/engine/src/transform/components/TransformComponent'
+import { LocalTransformComponent } from '@etherealengine/engine/src/transform/components/TransformComponent'
 import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
 import { useEffect } from 'react'
 import { Euler, Object3D } from 'three'
@@ -71,7 +68,7 @@ export const TransformGizmoComponent = defineComponent({
     const entity = useEntityContext()
     const gizmoComponent = useComponent(entity, TransformGizmoComponent)
     const editorHelperState = useHookstate(getMutableState(EditorHelperState))
-    const transformComponent = useComponent(entity, TransformComponent)
+    const transformComponent = useComponent(entity, LocalTransformComponent)
 
     useEffect(() => {
       // create dummy object to attach gizmo to, we can only attach to three js objects


### PR DESCRIPTION
## Summary
Makes Transform Gizmo operate on Local Transform rather than Global. This fixes issues with moving / rotating objects that are children of offset entities

## References
closes #9362 
