### PR TITLE
fix delete. Dont pass proxy array(doesnt support includes)

### DIFF
--- a/packages/editor/src/components/hierarchy/HierarchyPanelContainer.tsx
+++ b/packages/editor/src/components/hierarchy/HierarchyPanelContainer.tsx
@@ -313,21 +313,21 @@ export default function HierarchyPanel() {
   const onDeleteNode = useCallback((node: HeirarchyTreeNodeType) => {
     handleClose()
 
-    const objs = node.selected ? selectionState.selectedEntities.value : [node.entity]
+    const objs = node.selected ? getState(SelectionState).selectedEntities : [node.entity]
     EditorControlFunctions.removeObject(objs)
   }, [])
 
   const onDuplicateNode = useCallback((node: HeirarchyTreeNodeType) => {
     handleClose()
 
-    const objs = node.selected ? selectionState.selectedEntities.value : [node.entity]
+    const objs = node.selected ? getState(SelectionState).selectedEntities : [node.entity]
     EditorControlFunctions.duplicateObject(objs)
   }, [])
 
   const onGroupNodes = useCallback((node: HeirarchyTreeNodeType) => {
     handleClose()
 
-    const objs = node.selected ? selectionState.selectedEntities.value : [node.entity]
+    const objs = node.selected ? getState(SelectionState).selectedEntities : [node.entity]
 
     EditorControlFunctions.groupObjects(objs)
   }, [])


### PR DESCRIPTION
## Summary
We were passing a proxified array into removeObject. Which uses a function `filterParentEntities` that calls Array.includes for some reason  the proxified includes is implemented weirdly and doesn't return true when expected.

