### PR TITLE
Fix Highlight component suspense errors

### DIFF
--- a/packages/engine/src/renderer/components/HighlightComponent.ts
+++ b/packages/engine/src/renderer/components/HighlightComponent.ts
@@ -28,7 +28,7 @@ import { Mesh } from 'three'
 
 import { getMutableState, useHookstate } from '@etherealengine/hyperflux'
 
-import { defineComponent, useComponent } from '../../ecs/functions/ComponentFunctions'
+import { defineComponent, useOptionalComponent } from '../../ecs/functions/ComponentFunctions'
 import { useEntityContext } from '../../ecs/functions/EntityFunctions'
 import { GroupComponent } from '../../scene/components/GroupComponent'
 import { RendererState } from '../RendererState'
@@ -42,9 +42,10 @@ export const HighlightComponent = defineComponent({
 
     const postProcessingSettingsState = useHookstate(getMutableState(PostProcessingSettingsState))
     const usePostProcessing = useHookstate(getMutableState(RendererState).usePostProcessing)
-    const group = useComponent(entity, GroupComponent)
+    const group = useOptionalComponent(entity, GroupComponent)
 
     useEffect(() => {
+      if (!group) return
       const objs = [...group.value]
       for (const object of objs) {
         object.traverse((obj) => {


### PR DESCRIPTION
## Summary
Highlight component was suspending because there was no groupComponent on colliders


