### PR TITLE
Updated file-browser to update project files locally

### DIFF
--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -25,10 +25,12 @@ Ethereal Engine. All Rights Reserved.
 
 import { NullableId, Paginated, ServiceInterface } from '@feathersjs/feathers/lib/declarations'
 import appRootPath from 'app-root-path'
+import fs from 'fs'
 import path from 'path/posix'
 
 import { processFileName } from '@etherealengine/common/src/utils/processFileName'
 
+import { isDev } from '@etherealengine/common/src/config'
 import { checkScope } from '@etherealengine/engine/src/common/functions/checkScope'
 import {
   FileBrowserContentType,
@@ -52,6 +54,8 @@ export const projectsRootFolder = path.join(appRootPath.path, 'packages/projects
 export interface FileBrowserParams extends KnexAdapterParams {
   nestingDirectory?: string
 }
+
+const PROJECT_FILE_REGEX = /^projects/
 
 const checkDirectoryInsideNesting = (directory: string, nestingDirectory?: string) => {
   if (!nestingDirectory) {
@@ -97,8 +101,7 @@ export class FileBrowserService
 
     checkDirectoryInsideNesting(directory, params?.nestingDirectory)
 
-    const exists = await storageProvider.doesExist(file, directory)
-    return exists
+    return await storageProvider.doesExist(file, directory)
   }
 
   /**
@@ -171,6 +174,9 @@ export class FileBrowserService
 
     await storageProvider.createInvalidation([key])
 
+    if (isDev && PROJECT_FILE_REGEX.test(directory))
+      fs.mkdirSync(path.resolve(projectsRootFolder, path.join(parentPath, key)), { recursive: true })
+
     return result
   }
 
@@ -195,6 +201,11 @@ export class FileBrowserService
       storageProvider.createInvalidation([oldNamePath]),
       storageProvider.createInvalidation([newNamePath])
     ])
+
+    if (isDev) {
+      if (data.isCopy) fs.copyFileSync(oldNamePath, newNamePath)
+      else fs.renameSync(oldNamePath, newNamePath)
+    }
 
     return result
   }
@@ -226,6 +237,13 @@ export class FileBrowserService
         isDirectory: false
       }
     )
+
+    if (isDev && PROJECT_FILE_REGEX.test(key)) {
+      const filePath = path.resolve(projectsRootFolder, key)
+      const dirname = path.dirname(filePath)
+      fs.mkdirSync(dirname, { recursive: true })
+      fs.writeFileSync(filePath, data.body)
+    }
 
     const hash = createStaticResourceHash(data.body, { mimeType: data.contentType, assetURL: key })
     const cacheDomain = getCacheDomain(storageProvider, params && params.provider == null)
@@ -293,6 +311,8 @@ export class FileBrowserService
     })) as Paginated<StaticResourceType>
 
     if (staticResource?.data?.length > 0) await this.app.service(staticResourcePath).remove(staticResource?.data[0]?.id)
+
+    if (isDev && PROJECT_FILE_REGEX.test(key)) fs.rmSync(path.resolve(projectsRootFolder, key), { recursive: true })
 
     return result
   }

--- a/packages/server-core/src/projects/scene/scene.class.ts
+++ b/packages/server-core/src/projects/scene/scene.class.ts
@@ -49,9 +49,10 @@ import logger from '../../ServerLogger'
 import { getStorageProvider } from '../../media/storageprovider/storageprovider'
 import { ProjectParams } from '../project/project.class'
 import { getSceneData } from './scene-helper'
-const NEW_SCENE_NAME = 'New-Scene'
 
-const sceneAssetFiles = ['.scene.json', '.thumbnail.ktx2', '.envmap.ktx2']
+const DEFAULT_DIRECTORY = 'packages/projects/default-project'
+const NEW_SCENE_NAME = 'New-Scene'
+const SCENE_ASSET_FILES = ['.scene.json', '.thumbnail.ktx2', '.envmap.ktx2']
 
 export interface SceneParams extends Params<SceneQuery> {
   paginate?: false
@@ -179,7 +180,7 @@ export class SceneService
     }
 
     await Promise.all(
-      sceneAssetFiles.map((ext) =>
+      SCENE_ASSET_FILES.map((ext) =>
         storageProvider.moveObject(
           `default${ext}`,
           `${newSceneName}${ext}`,
@@ -190,18 +191,18 @@ export class SceneService
       )
     )
     try {
-      await storageProvider.createInvalidation(sceneAssetFiles.map((asset) => `${directory}${newSceneName}${asset}`))
+      await storageProvider.createInvalidation(SCENE_ASSET_FILES.map((asset) => `${directory}${newSceneName}${asset}`))
     } catch (e) {
       logger.error(e)
-      logger.info(sceneAssetFiles)
+      logger.info(SCENE_ASSET_FILES)
     }
 
     if (isDev) {
       const projectPathLocal = path.resolve(appRootPath.path, localDirectory)
-      for (const ext of sceneAssetFiles) {
+      for (const ext of SCENE_ASSET_FILES) {
         fs.copyFileSync(
-          path.resolve(appRootPath.path, `${localDirectory}default${ext}`),
-          path.resolve(projectPathLocal + newSceneName + ext)
+          path.resolve(appRootPath.path, `${DEFAULT_DIRECTORY}/default${ext}`),
+          path.resolve(projectPathLocal + '/' + newSceneName + ext)
         )
       }
     }
@@ -219,7 +220,7 @@ export class SceneService
     const directory = data.directory!
     const localDirectory = data.localDirectory!
 
-    for (const ext of sceneAssetFiles) {
+    for (const ext of SCENE_ASSET_FILES) {
       const oldSceneJsonName = `${oldSceneName}${ext}`
       const newSceneJsonName = `${newSceneName}${ext}`
 
@@ -235,7 +236,7 @@ export class SceneService
     }
 
     if (isDev) {
-      for (const ext of sceneAssetFiles) {
+      for (const ext of SCENE_ASSET_FILES) {
         const oldSceneJsonPath = path.resolve(appRootPath.path, `${localDirectory}${oldSceneName}${ext}`)
         if (fs.existsSync(oldSceneJsonPath)) {
           const newSceneJsonPath = path.resolve(appRootPath.path, `${localDirectory}${newSceneName}${ext}`)
@@ -279,10 +280,10 @@ export class SceneService
       }
 
       try {
-        await storageProvider.createInvalidation(sceneAssetFiles.map((asset) => `${directory}${name}${asset}`))
+        await storageProvider.createInvalidation(SCENE_ASSET_FILES.map((asset) => `${directory}${name}${asset}`))
       } catch (e) {
         logger.error(e)
-        logger.info(sceneAssetFiles)
+        logger.info(SCENE_ASSET_FILES)
       }
 
       if (isDev) {
@@ -321,20 +322,20 @@ export class SceneService
     const directory = params!.query!.directory!.toString()!
     const localDirectory = params!.query!.localDirectory!.toString()!
 
-    for (const ext of sceneAssetFiles) {
+    for (const ext of SCENE_ASSET_FILES) {
       const assetFilePath = path.resolve(appRootPath.path, `${localDirectory}/${sceneName}${ext}`)
       if (fs.existsSync(assetFilePath)) {
         fs.rmSync(path.resolve(assetFilePath))
       }
     }
 
-    await storageProvider.deleteResources(sceneAssetFiles.map((ext) => `${directory}${sceneName}${ext}`))
+    await storageProvider.deleteResources(SCENE_ASSET_FILES.map((ext) => `${directory}${sceneName}${ext}`))
 
     try {
-      await storageProvider.createInvalidation(sceneAssetFiles.map((asset) => `${directory}${sceneName}${asset}`))
+      await storageProvider.createInvalidation(SCENE_ASSET_FILES.map((asset) => `${directory}${sceneName}${asset}`))
     } catch (e) {
       logger.error(e)
-      logger.info(sceneAssetFiles)
+      logger.info(SCENE_ASSET_FILES)
     }
   }
 }


### PR DESCRIPTION
## Summary

In local dev, when project files were created/moved/removed, those operations only occurred in the storage provider, not in projects/projects/<project>. For those doing local work on projects and wanting to push from their local file system, this meant that no changes were being recorded.

file-browser operations now, if isDev is true and acting on project files, make the equivalent operation on the local file system as well.

Fixed bugs in the creation of new scenes. One, the operation was trying to copy a default.scene.json from the project being operated on, not the default project. Two, the path of the output files was missing a slash.

## References
closes #_insert number here_

## QA Steps
