### PR TITLE
Force db refresh on builder

### DIFF
--- a/scripts/check-db-exists.ts
+++ b/scripts/check-db-exists.ts
@@ -56,7 +56,7 @@ const knexClient = knex({
 cli.main(async () => {
   const [results] = await knexClient.raw("SHOW TABLES LIKE 'user';")
 
-  if (results.length === 0) {
+  if (results.length === 0 || process.env.BUILDER_FORCE_DB_REFRESH === 'true') {
     console.log('User table not found, seeding the database...')
 
     const initPromise = new Promise((resolve) => {


### PR DESCRIPTION
## Summary

Using a different ENV_VAR than FORCE_DB_REFRESH since the builder configmap starts with the builder's extraEnv, then overwrites it with api/client/instanceserver values. If builder's FORCE_DB_REFRESH is true but the api's is false, then it'll end up being false on the configmap. If we set the api's to true, then the api servers will do their own refresh, which we don't want.

## References
closes #9404

## QA Steps
