### PR TITLE
Fix projects page search

### DIFF
--- a/packages/editor/src/components/projects/ProjectsPage.tsx
+++ b/packages/editor/src/components/projects/ProjectsPage.tsx
@@ -245,7 +245,6 @@ const ProjectsPage = () => {
           : CommunityProjectData
       ).filter((p) => !installedProjects.value?.find((ip) => ip.name.includes(p.name)))
       communityProjects.set(data.sort(sortAlphabetical) ?? [])
-      console.log('DEBUG 2', data, communityProjects, filter.value)
     } catch (error) {
       logger.error(error)
       error.set(error)

--- a/packages/editor/src/components/projects/ProjectsPage.tsx
+++ b/packages/editor/src/components/projects/ProjectsPage.tsx
@@ -143,16 +143,7 @@ const OfficialProjectData = [
   // },
 ]
 
-const CommunityProjectData = [
-  {
-    id: '1570ae14-889a-11ec-886e-b126f7590682',
-    name: 'ee-ethereal-game',
-    repositoryPath: 'https://github.com/etherealengine/ee-ethereal-game',
-    thumbnail: 'https://media.githubusercontent.com/media/EtherealEngine/ee-ethereal-village/dev/thumbnail.png',
-    description: 'A test game',
-    needsRebuild: true
-  }
-] as any
+const CommunityProjectData = [] as any
 
 const ProjectExpansionList = (props: React.PropsWithChildren<{ id: string; summary: string }>) => {
   return (


### PR DESCRIPTION
This pull request fixes the search functionality on the projects page. Previously, the search was not filtering the projects correctly. With this fix, the search will now filter the projects based on the entered query.

the query now filters and shows across both, the installed and community projects section, 

do we want to debounce the query to improve performance ?