### PR TITLE
Passed action admin where need to find all projects

### DIFF
--- a/packages/client-core/src/common/services/ProjectService.ts
+++ b/packages/client-core/src/common/services/ProjectService.ts
@@ -79,9 +79,12 @@ export const ProjectState = defineState({
 export const ProjectService = {
   fetchProjects: async () => {
     try {
-      const projects = (await API.instance.client
-        .service(projectPath)
-        .find({ query: { allowed: true } })) as Paginated<ProjectType>
+      const projects = (await API.instance.client.service(projectPath).find({
+        query: {
+          action: 'admin',
+          allowed: true
+        }
+      })) as Paginated<ProjectType>
       getMutableState(ProjectState).merge({
         updateNeeded: false,
         projects: projects.data

--- a/packages/server-core/src/hooks/project-permission-authenticate.ts
+++ b/packages/server-core/src/hooks/project-permission-authenticate.ts
@@ -56,6 +56,7 @@ export default (writeAccess) => {
     if (projectName) {
       const project = (await app.service(projectPath).find({
         query: {
+          action: 'admin',
           name: projectName,
           $limit: 1
         }

--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -313,6 +313,7 @@ export const getProjectEnv = async (app: Application, projectName: string) => {
   const project = (await app.service(projectPath).find({
     query: {
       $limit: 1,
+      action: 'admin',
       name: projectName
     }
   })) as Paginated<ProjectType>
@@ -490,6 +491,7 @@ export const checkProjectDestinationMatch = async (
   if (!existingProject) {
     const projectExists = (await app.service(projectPath).find({
       query: {
+        action: 'admin',
         name: {
           $like: sourceContent.name
         },
@@ -1212,6 +1214,7 @@ export async function getDirectoryArchiveJobBody(
 export const createOrUpdateProjectUpdateJob = async (app: Application, projectName: string): Promise<void> => {
   const projectData = (await app.service(projectPath).find({
     query: {
+      action: 'admin',
       name: projectName,
       $limit: 1
     }
@@ -1268,6 +1271,7 @@ export const checkProjectAutoUpdate = async (app: Application, projectName: stri
   let commitSHA
   const projectData = (await app.service(projectPath).find({
     query: {
+      action: 'admin',
       name: projectName,
       $limit: 1
     }
@@ -1413,6 +1417,7 @@ export const updateProject = async (
     return (
       (await app.service(projectPath).find({
         query: {
+          action: 'admin',
           name: 'default-project',
           $limit: 1
         }
@@ -1438,6 +1443,7 @@ export const updateProject = async (
 
   const projectResult = (await app.service(projectPath).find({
     query: {
+      action: 'admin',
       name: projectName
     }
   })) as Paginated<ProjectType>
@@ -1496,6 +1502,7 @@ export const updateProject = async (
   // when we have successfully re-installed the project, remove the database entry if it already exists
   const existingProjectResult = (await app.service(projectPath).find({
     query: {
+      action: 'admin',
       name: {
         $like: projectName
       }

--- a/packages/server-core/src/projects/project/project.hooks.ts
+++ b/packages/server-core/src/projects/project/project.hooks.ts
@@ -170,7 +170,10 @@ const ensurePushStatus = async (context: HookContext<ProjectService>) => {
       })
 
       const matchingAllowedRepos = (await context.app.service(projectPath).find({
-        query: { repositoryPath: { $in: repositoryPaths } },
+        query: {
+          action: 'admin',
+          repositoryPath: { $in: repositoryPaths }
+        },
         paginate: false
       })) as ProjectType[]
 
@@ -526,6 +529,7 @@ const updateProjectJob = async (context: HookContext) => {
       await jobFinishedPromise
       const result = (await context.app.service(projectPath).find({
         query: {
+          action: 'admin',
           name: {
             $like: projectName
           }

--- a/scripts/update-cronjob-image.ts
+++ b/scripts/update-cronjob-image.ts
@@ -65,6 +65,7 @@ cli.main(async () => {
     await app.setup()
     const autoUpdateProjects = (await app.service(projectPath).find({
       query: {
+        action: 'admin',
         $or: [
           {
             updateType: 'commit'


### PR DESCRIPTION
## Summary
This is being required in some projects in order to override the projects being returned for admin panel use cases and scenes use cases.

## References
closes #_insert number here_

## QA Steps
