### PR TITLE
Tweaked FileBrowserContentPanel to allow better setting of nesting directory

### DIFF
--- a/packages/client-core/src/admin/components/Project/ProjectFilesDrawer.tsx
+++ b/packages/client-core/src/admin/components/Project/ProjectFilesDrawer.tsx
@@ -66,6 +66,7 @@ const ProjectFilesDrawer = ({ open, selectedProject, onClose }: Props) => {
               disableDnD
               selectedFile={selectedProject.name}
               onSelectionChanged={onSelectionChanged}
+              nestingDirectory={selectedProject.name}
             />
           </Box>
           <Box sx={{ flexGrow: 1 }}>

--- a/packages/client-core/src/admin/components/Recordings/RecordingsDrawer.tsx
+++ b/packages/client-core/src/admin/components/Recordings/RecordingsDrawer.tsx
@@ -73,6 +73,7 @@ const RecordingFilesDrawer = ({ open, onClose, selectedRecordingId }: Props) => 
                   selectedFile={selectedRecordingId}
                   onSelectionChanged={onSelectionChanged}
                   folderName="recordings"
+                  nestingDirectory={selectedRecordingId}
                 />
               )}
             </Box>


### PR DESCRIPTION
## Summary
In the studio, we want to let people go to other projects through the file browser, while in other situations we do not want to let them go above the level they start at, e.g. projects/<projectName> or /recordings/<recordingID>. Added a new prop to the panel component to optionally set a nesting directory. Tweaked the breadcrumbs logic to not show anything higher than the nesting directory.

## References
closes #_insert number here_

## QA Steps
