### PR TITLE
fix non-public avatar selection

### DIFF
--- a/packages/server-core/src/user/avatar/avatar.hooks.ts
+++ b/packages/server-core/src/user/avatar/avatar.hooks.ts
@@ -193,15 +193,7 @@ const updateUserAvatars = async (context: HookContext<AvatarService>) => {
       id: {
         $ne: context.id?.toString() as AvatarID
       },
-      $or: [
-        {
-          isPublic: true
-        },
-        {
-          isPublic: false,
-          userId: context.params.user?.id
-        }
-      ],
+      isPublic: true,
       $limit: 1000
     },
     paginate: false

--- a/packages/server-core/src/user/avatar/avatar.hooks.ts
+++ b/packages/server-core/src/user/avatar/avatar.hooks.ts
@@ -192,7 +192,17 @@ const updateUserAvatars = async (context: HookContext<AvatarService>) => {
     query: {
       id: {
         $ne: context.id?.toString() as AvatarID
-      }
+      },
+      $or: [
+        {
+          isPublic: true
+        },
+        {
+          isPublic: false,
+          userId: context.params.user?.id
+        }
+      ],
+      $limit: 1000
     },
     paginate: false
   })) as AvatarType[]

--- a/packages/server-core/src/user/strategies/discord.ts
+++ b/packages/server-core/src/user/strategies/discord.ts
@@ -70,7 +70,9 @@ export class DiscordStrategy extends CustomOAuthStrategy {
       {}
     )
     if (!entity.userId) {
-      const avatars = (await this.app.service(avatarPath).find({ isInternal: true })) as Paginated<AvatarType>
+      const avatars = (await this.app
+        .service(avatarPath)
+        .find({ isInternal: true, query: { isPublic: true, $limit: 1000 } })) as Paginated<AvatarType>
       const code = (await getFreeInviteCode(this.app)) as InviteCode
       const newUser = await this.app.service(userPath).create({
         name: '' as UserName,

--- a/packages/server-core/src/user/strategies/facebook.ts
+++ b/packages/server-core/src/user/strategies/facebook.ts
@@ -70,7 +70,9 @@ export class FacebookStrategy extends CustomOAuthStrategy {
       {}
     )
     if (!entity.userId) {
-      const avatars = (await this.app.service(avatarPath).find({ isInternal: true })) as Paginated<AvatarType>
+      const avatars = (await this.app
+        .service(avatarPath)
+        .find({ isInternal: true, query: { isPublic: true, $limit: 1000 } })) as Paginated<AvatarType>
       const code = (await getFreeInviteCode(this.app)) as InviteCode
       const newUser = await this.app.service(userPath).create({
         name: '' as UserName,

--- a/packages/server-core/src/user/strategies/github.ts
+++ b/packages/server-core/src/user/strategies/github.ts
@@ -72,7 +72,9 @@ export class GithubStrategy extends CustomOAuthStrategy {
       {}
     )
     if (!entity.userId) {
-      const avatars = (await this.app.service(avatarPath).find({ isInternal: true })) as Paginated<AvatarType>
+      const avatars = (await this.app
+        .service(avatarPath)
+        .find({ isInternal: true, query: { isPublic: true, $limit: 1000 } })) as Paginated<AvatarType>
       const code = (await getFreeInviteCode(this.app)) as InviteCode
       const newUser = await this.app.service(userPath).create({
         name: '' as UserName,

--- a/packages/server-core/src/user/strategies/google.ts
+++ b/packages/server-core/src/user/strategies/google.ts
@@ -70,7 +70,9 @@ export class Googlestrategy extends CustomOAuthStrategy {
       {}
     )
     if (!entity.userId) {
-      const avatars = (await this.app.service(avatarPath).find({ isInternal: true })) as Paginated<AvatarType>
+      const avatars = (await this.app
+        .service(avatarPath)
+        .find({ isInternal: true, query: { isPublic: true, $limit: 1000 } })) as Paginated<AvatarType>
       const code = (await getFreeInviteCode(this.app)) as InviteCode
       const newUser = await this.app.service(userPath).create({
         name: '' as UserName,

--- a/packages/server-core/src/user/strategies/linkedin.ts
+++ b/packages/server-core/src/user/strategies/linkedin.ts
@@ -70,7 +70,9 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
       {}
     )
     if (!entity.userId) {
-      const avatars = (await this.app.service(avatarPath).find({ isInternal: true })) as Paginated<AvatarType>
+      const avatars = (await this.app
+        .service(avatarPath)
+        .find({ isInternal: true, query: { isPublic: true, $limit: 1000 } })) as Paginated<AvatarType>
       const code = (await getFreeInviteCode(this.app)) as InviteCode
       const newUser = await this.app.service(userPath).create({
         name: '' as UserName,

--- a/packages/server-core/src/user/strategies/twitter.ts
+++ b/packages/server-core/src/user/strategies/twitter.ts
@@ -70,7 +70,9 @@ export class TwitterStrategy extends CustomOAuthStrategy {
       {}
     )
     if (!entity.userId) {
-      const avatars = (await this.app.service(avatarPath).find({ isInternal: true })) as Paginated<AvatarType>
+      const avatars = (await this.app
+        .service(avatarPath)
+        .find({ isInternal: true, query: { isPublic: true, $limit: 1000 } })) as Paginated<AvatarType>
       const code = (await getFreeInviteCode(this.app)) as InviteCode
       const newUser = await this.app.service(userPath).create({
         name: '' as UserName,


### PR DESCRIPTION
## Summary

- on avatar removal, only allow public avatars to be re-updated as user's avatar
- also select from public avatars in oauth identity-providers

## References
closes #9454 

## QA Steps
