### PR TITLE
Fixed bug in LocationDrawer sceneId logic

### DIFF
--- a/packages/client-core/src/admin/components/Location/LocationDrawer.tsx
+++ b/packages/client-core/src/admin/components/Location/LocationDrawer.tsx
@@ -125,7 +125,7 @@ const LocationDrawer = ({ open, mode, selectedLocation, onClose }: Props) => {
         ...defaultState,
         name: selectedLocation.name,
         maxUsers: selectedLocation.maxUsersPerInstance,
-        scene: selectedLocation.sceneId,
+        scene: selectedLocation.sceneId.replace('projects/', '').replace('.scene.json', ''),
         type: selectedLocation.locationSetting?.locationType,
         videoEnabled: selectedLocation.locationSetting?.videoEnabled,
         audioEnabled: selectedLocation.locationSetting?.audioEnabled,


### PR DESCRIPTION
## Summary

Location sceneId's are now projects/<projectName>/<sceneName>.scene.json Select for sceneId is just <projectName>/<sceneName> Setting of state.scene in LocationDrawer.tsx was erroring since there were no matches, and then would prepend projects/ and append .scene.json to the sceneId if saved without touching the scene selector, which would then point the location to an invalid scene.

## References
closes #_insert number here_

## QA Steps
