### PR TITLE
gltf-transform: fix assigning resource-specific compression parms

### DIFF
--- a/packages/engine/src/assets/classes/ModelTransform.ts
+++ b/packages/engine/src/assets/classes/ModelTransform.ts
@@ -30,6 +30,7 @@ import { OpaqueType } from '@etherealengine/common/src/interfaces/OpaqueType'
 export type ResourceID = OpaqueType<'ResourceID'> & string
 
 export type ParameterOverride<T> = OpaqueType<'ParameterOverride'> & {
+  isParameterOverride: true
   enabled: boolean
   parameters: T
 }
@@ -39,7 +40,7 @@ export function extractParameters<T>(parameters: ParameterOverride<T>) {
   if (typeof parameters.parameters === 'object' && !Array.isArray(parameters.parameters)) {
     return Object.fromEntries(
       Object.entries(parameters.parameters as object).map(([key, value]: [string, ParameterOverride<any>]) => {
-        if (value.__opaqueType === 'ParameterOverride') {
+        if (value.isParameterOverride) {
           if (value.enabled) return [key, extractParameters(value)]
           else return []
         } else return [key, value]
@@ -48,7 +49,7 @@ export function extractParameters<T>(parameters: ParameterOverride<T>) {
   } else if (Array.isArray(parameters.parameters)) {
     return [
       ...parameters.parameters.map((value) => {
-        if (value.__opaqueType === 'ParameterOverride') {
+        if (value.isParameterOverride) {
           if (value.enabled) return [extractParameters(value)]
           else return []
         } else return [value]

--- a/packages/engine/src/assets/compression/ModelTransformFunctions.ts
+++ b/packages/engine/src/assets/compression/ModelTransformFunctions.ts
@@ -61,7 +61,7 @@ import { baseName, pathJoin } from '@etherealengine/common/src/utils/miscUtils'
 import { fileBrowserPath } from '@etherealengine/engine/src/schemas/media/file-browser.schema'
 import { Engine } from '../../ecs/classes/Engine'
 import { EEMaterial, EEMaterialExtension } from './extensions/EE_MaterialTransformer'
-import { EEResourceID } from './extensions/EE_ResourceIDTransformer'
+import { EEResourceID, EEResourceIDExtension } from './extensions/EE_ResourceIDTransformer'
 import ModelTransformLoader from './ModelTransformLoader'
 
 import config from '@etherealengine/common/src/config'
@@ -537,6 +537,13 @@ export async function transformModel(args: ModelTransformParameters) {
     .listExtensionsUsed()
     .find((ext) => ext.extensionName === 'EE_material') as EEMaterialExtension
   if (eeMaterialExtension) {
+    for (let i = 0; i < eeMaterialExtension.textures.length; i++) {
+      const texture = eeMaterialExtension.textures[i]
+      const extensions = eeMaterialExtension.textureExtensions[i]
+      for (const extension of extensions) {
+        texture.setExtension(extension.extensionName, extension)
+      }
+    }
     textures.push(...eeMaterialExtension.textures)
   }
 
@@ -548,7 +555,7 @@ export async function transformModel(args: ModelTransformParameters) {
       if (!oldImg) continue
       const oldSize = texture.getSize()
       if (!oldSize) continue
-      const resourceId = texture.getExtension<EEResourceID>('EEResourceID')?.resourceId
+      const resourceId = texture.getExtension<EEResourceID>(EEResourceIDExtension.EXTENSION_NAME)?.resourceId
       const resourceParms = parms.resources.images.find(
         (resource) => resource.enabled && resource.resourceId === resourceId
       )

--- a/packages/engine/src/assets/compression/ModelTransformLoader.ts
+++ b/packages/engine/src/assets/compression/ModelTransformLoader.ts
@@ -45,6 +45,7 @@ import { MeshoptDecoder, MeshoptEncoder } from 'meshoptimizer'
 import { FileLoader } from 'three'
 
 import { EEMaterialExtension } from './extensions/EE_MaterialTransformer'
+import { EEResourceIDExtension } from './extensions/EE_ResourceIDTransformer'
 import { MOZLightmapExtension } from './extensions/MOZ_LightmapTransformer'
 
 const transformHistory: string[] = []
@@ -65,6 +66,7 @@ export default async function ModelTransformLoader() {
     KHRTextureBasisu,
     KHRTextureTransform,
     MOZLightmapExtension,
+    EEResourceIDExtension,
     EEMaterialExtension
   ])
   io.registerDependencies({

--- a/packages/engine/src/assets/compression/extensions/EE_MaterialTransformer.ts
+++ b/packages/engine/src/assets/compression/extensions/EE_MaterialTransformer.ts
@@ -194,6 +194,7 @@ export class EEMaterialExtension extends Extension {
   public static readonly EXTENSION_NAME = EXTENSION_NAME
 
   textures: Texture[] = []
+  textureExtensions: ExtensionProperty[][] = []
 
   textureInfoMap: Map<string, TextureInfo> = new Map()
   materialInfoMap: Map<string, string[]> = new Map()
@@ -239,6 +240,7 @@ export class EEMaterialExtension extends Extension {
                   texture.setExtras({ uuid })
                   textureUuidIndex++
                   this.textures.push(texture)
+                  this.textureExtensions.push(texture.listExtensions())
                 }
                 if (texture && value.extensions?.KHR_texture_transform) {
                   const extensionData = value.extensions.KHR_texture_transform

--- a/packages/engine/src/assets/compression/extensions/EE_ResourceIDTransformer.ts
+++ b/packages/engine/src/assets/compression/extensions/EE_ResourceIDTransformer.ts
@@ -35,7 +35,7 @@ import {
 
 import { ResourceID } from '@etherealengine/engine/src/assets/classes/ModelTransform'
 
-const EXTENSION_NAME = 'EE_resourceID'
+const EXTENSION_NAME = 'EE_resourceId'
 
 interface IEEResourceID extends IProperty {
   resourceId: ResourceID

--- a/packages/engine/src/scene/functions/loaders/ModelFunctions.ts
+++ b/packages/engine/src/scene/functions/loaders/ModelFunctions.ts
@@ -71,13 +71,16 @@ export function getModelResources(entity: Entity): ResourceTransforms {
       }
       return {
         resourceId: geometry.uuid as ResourceID,
+        isParameterOverride: true,
         enabled: true,
         parameters: {
           weld: {
+            isParameterOverride: true,
             enabled: false,
             parameters: 0.0001
           },
           dracoCompression: {
+            isParameterOverride: true,
             enabled: false,
             parameters: dracoParms
           }
@@ -106,26 +109,32 @@ export function getModelResources(entity: Entity): ResourceTransforms {
     const result: ImageTransformParameters[] = images.map((image) => {
       return {
         resourceId: image.id as ResourceID,
+        isParameterOverride: true,
         enabled: false,
         parameters: {
           flipY: {
             enabled: false,
+            isParameterOverride: true,
             parameters: false
           },
           maxTextureSize: {
             enabled: true,
-            parameters: 2048
+            isParameterOverride: true,
+            parameters: 1024
           },
           textureFormat: {
             enabled: true,
+            isParameterOverride: true,
             parameters: 'ktx2'
           },
           textureCompressionType: {
             enabled: false,
+            isParameterOverride: true,
             parameters: 'etc1'
           },
           textureCompressionQuality: {
             enabled: false,
+            isParameterOverride: true,
             parameters: 128
           }
         }


### PR DESCRIPTION
Implements gltf transform feature where specific compression parameters can be assigned to individual resources in the gltf model. Primarily useful for high resolution diffuse, and using UASTC compression on normal maps. Can be easily automated in the future