### PR TITLE
Fixes for static-resources not updating in file-browser

### DIFF
--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -199,14 +199,14 @@ export class FileBrowserService
 
     const staticResources = (await this.app.service(staticResourcePath).find({
       query: {
-        key: { $like: isDirectory ? `%${path.join(_oldPath, data.oldName)}/%` : path.join(_oldPath, data.oldName) }
+        key: { $like: `%${path.join(_oldPath, data.oldName)}%` }
       },
       paginate: false
     })) as StaticResourceType[]
 
     if (staticResources?.length > 0) {
       for (const resource of staticResources) {
-        const newKey = resource.key.replace(path.join(_oldPath, data.oldName), path.join(_newPath, data.newName))
+        const newKey = resource.key.replace(path.join(_oldPath, data.oldName), path.join(_newPath, fileName))
         await this.app.service(staticResourcePath).patch(
           resource.id,
           {
@@ -315,15 +315,13 @@ export class FileBrowserService
     checkDirectoryInsideNesting(key, params?.nestingDirectory)
 
     const storageProvider = getStorageProvider(storageProviderName)
-    const keySplit = key.split('/')
-    const isDirectory = await storageProvider.isDirectory(keySplit.pop()!, keySplit.join('/'))
     const dirs = await storageProvider.listObjects(key, true)
     const result = await storageProvider.deleteResources([key, ...dirs.Contents.map((a) => a.Key)])
     await storageProvider.createInvalidation([key])
 
     const staticResources = (await this.app.service(staticResourcePath).find({
       query: {
-        key: { $like: isDirectory ? `%${key}/%` : key }
+        key: { $like: `%${key}%` }
       },
       paginate: false
     })) as StaticResourceType[]

--- a/packages/server-core/src/media/file-browser/file-browser.class.ts
+++ b/packages/server-core/src/media/file-browser/file-browser.class.ts
@@ -197,21 +197,24 @@ export class FileBrowserService
 
     await storageProvider.createInvalidation([_oldPath, _newPath])
 
-    const staticResource = (await this.app.service(staticResourcePath).find({
+    const staticResources = (await this.app.service(staticResourcePath).find({
       query: {
-        key: path.join(_oldPath, data.oldName),
-        $limit: 1
-      }
-    })) as Paginated<StaticResourceType>
+        key: { $like: isDirectory ? `%${path.join(_oldPath, data.oldName)}/%` : path.join(_oldPath, data.oldName) }
+      },
+      paginate: false
+    })) as StaticResourceType[]
 
-    if (staticResource?.data?.length > 0) {
-      await this.app.service(staticResourcePath).patch(
-        staticResource.data[0].id,
-        {
-          key: path.join(_newPath, data.newName)
-        },
-        { isInternal: true }
-      )
+    if (staticResources?.length > 0) {
+      for (const resource of staticResources) {
+        const newKey = resource.key.replace(path.join(_oldPath, data.oldName), path.join(_newPath, data.newName))
+        await this.app.service(staticResourcePath).patch(
+          resource.id,
+          {
+            key: newKey
+          },
+          { isInternal: true }
+        )
+      }
     }
 
     const oldNamePath = path.join(projectsRootFolder, _oldPath, data.oldName)
@@ -312,18 +315,24 @@ export class FileBrowserService
     checkDirectoryInsideNesting(key, params?.nestingDirectory)
 
     const storageProvider = getStorageProvider(storageProviderName)
+    const keySplit = key.split('/')
+    const isDirectory = await storageProvider.isDirectory(keySplit.pop()!, keySplit.join('/'))
     const dirs = await storageProvider.listObjects(key, true)
     const result = await storageProvider.deleteResources([key, ...dirs.Contents.map((a) => a.Key)])
     await storageProvider.createInvalidation([key])
 
-    const staticResource = (await this.app.service(staticResourcePath).find({
+    const staticResources = (await this.app.service(staticResourcePath).find({
       query: {
-        key: key,
-        $limit: 1
-      }
-    })) as Paginated<StaticResourceType>
+        key: { $like: isDirectory ? `%${key}/%` : key }
+      },
+      paginate: false
+    })) as StaticResourceType[]
 
-    if (staticResource?.data?.length > 0) await this.app.service(staticResourcePath).remove(staticResource?.data[0]?.id)
+    if (staticResources?.length > 0) {
+      for (const resource of staticResources) {
+        await this.app.service(staticResourcePath).remove(resource.id)
+      }
+    }
 
     if (isDev && PROJECT_FILE_REGEX.test(key)) fs.rmSync(path.resolve(projectsRootFolder, key), { recursive: true })
 


### PR DESCRIPTION
- Fixes static-resource table not removing entries of file which are inside a folder that is deleted
- Fixes static-resource table not updating paths of file which are inside a folder that is renamed or moved
