### PR TITLE
Fixed a bug in uploadLocalProjectToProvider

### DIFF
--- a/packages/server-core/src/projects/project/project-helper.ts
+++ b/packages/server-core/src/projects/project/project-helper.ts
@@ -1728,12 +1728,21 @@ export const uploadLocalProjectToProvider = async (
             logger.info(`Skipping upload of static resource of class ${thisFileClass}: "${key}"`)
           } else if (existingKeySet.has(key)) {
             logger.info(`Updating static resource of class ${thisFileClass}: "${key}"`)
-            await app.service(staticResourcePath).patch(null, {
-              hash,
-              url,
-              mimeType: contentType,
-              tags: [thisFileClass]
-            })
+            await app.service(staticResourcePath).patch(
+              null,
+              {
+                hash,
+                url,
+                mimeType: contentType,
+                tags: [thisFileClass]
+              },
+              {
+                query: {
+                  key,
+                  project: projectName
+                }
+              }
+            )
           }
           {
             await app.service(staticResourcePath).create({


### PR DESCRIPTION
## Summary

If resources.json file exists for a project, the updating of static resources was being improperly applied to all resources. Added query param to restrict it to just the resource with the matching key in that project.

## References
closes #_insert number here_

## QA Steps
