### PR TITLE
add dpad support

### DIFF
--- a/packages/engine/src/avatar/systems/AvatarInputSystem.ts
+++ b/packages/engine/src/avatar/systems/AvatarInputSystem.ts
@@ -269,12 +269,18 @@ const execute = () => {
     //** touch input (only for avatar jump)*/
     const doubleClicked = isCameraAttachedToAvatar ? false : getAvatarDoubleClick(buttons)
     /** keyboard input */
-    const keyDeltaX = (buttons.KeyA?.pressed ? -1 : 0) + (buttons.KeyD?.pressed ? 1 : 0)
+    const keyDeltaX =
+      (buttons.KeyA?.pressed ? -1 : 0) +
+      (buttons.KeyD?.pressed ? 1 : 0) +
+      (buttons[StandardGamepadButton.DPadLeft]?.pressed ? -1 : 0) +
+      (buttons[StandardGamepadButton.DPadRight]?.pressed ? 1 : 0)
     const keyDeltaZ =
       (buttons.KeyW?.pressed ? -1 : 0) +
       (buttons.KeyS?.pressed ? 1 : 0) +
       (buttons.ArrowUp?.pressed ? -1 : 0) +
-      (buttons.ArrowDown?.pressed ? 1 : 0)
+      (buttons.ArrowDown?.pressed ? 1 : 0) +
+      (buttons[StandardGamepadButton.DPadUp]?.pressed ? -1 : 0) +
+      (buttons[StandardGamepadButton.DPadDown]?.pressed ? -1 : 0)
 
     controller.gamepadLocalInput.set(keyDeltaX, 0, keyDeltaZ).normalize()
 


### PR DESCRIPTION
## Summary
adds dpad to avatar controls finishing up the backbone controller

## References
closes #_insert number here_

## QA Steps
