### PR TITLE
Changes to pick avatar based on paginated result

### DIFF
--- a/packages/server-core/src/user/strategies/discord.ts
+++ b/packages/server-core/src/user/strategies/discord.ts
@@ -78,7 +78,7 @@ export class DiscordStrategy extends CustomOAuthStrategy {
         name: '' as UserName,
         isGuest: false,
         inviteCode: code,
-        avatarId: avatars[random(avatars.total - 1)].id,
+        avatarId: avatars.data[random(avatars.data.length - 1)].id,
         scopes: []
       })
       entity.userId = newUser.id

--- a/packages/server-core/src/user/strategies/facebook.ts
+++ b/packages/server-core/src/user/strategies/facebook.ts
@@ -78,7 +78,7 @@ export class FacebookStrategy extends CustomOAuthStrategy {
         name: '' as UserName,
         isGuest: false,
         inviteCode: code,
-        avatarId: avatars[random(avatars.total - 1)].id,
+        avatarId: avatars.data[random(avatars.data.length - 1)].id,
         scopes: []
       })
       entity.userId = newUser.id

--- a/packages/server-core/src/user/strategies/github.ts
+++ b/packages/server-core/src/user/strategies/github.ts
@@ -80,7 +80,7 @@ export class GithubStrategy extends CustomOAuthStrategy {
         name: '' as UserName,
         isGuest: false,
         inviteCode: code,
-        avatarId: avatars[random(avatars.total - 1)].id,
+        avatarId: avatars.data[random(avatars.data.length - 1)].id,
         scopes: []
       })
       entity.userId = newUser.id

--- a/packages/server-core/src/user/strategies/google.ts
+++ b/packages/server-core/src/user/strategies/google.ts
@@ -78,7 +78,7 @@ export class Googlestrategy extends CustomOAuthStrategy {
         name: '' as UserName,
         isGuest: false,
         inviteCode: code,
-        avatarId: avatars[random(avatars.total - 1)].id,
+        avatarId: avatars.data[random(avatars.data.length - 1)].id,
         scopes: []
       })
       entity.userId = newUser.id

--- a/packages/server-core/src/user/strategies/linkedin.ts
+++ b/packages/server-core/src/user/strategies/linkedin.ts
@@ -78,7 +78,7 @@ export class LinkedInStrategy extends CustomOAuthStrategy {
         name: '' as UserName,
         isGuest: false,
         inviteCode: code,
-        avatarId: avatars[random(avatars.total - 1)].id,
+        avatarId: avatars.data[random(avatars.data.length - 1)].id,
         scopes: []
       })
       entity.userId = newUser.id

--- a/packages/server-core/src/user/strategies/twitter.ts
+++ b/packages/server-core/src/user/strategies/twitter.ts
@@ -78,7 +78,7 @@ export class TwitterStrategy extends CustomOAuthStrategy {
         name: '' as UserName,
         isGuest: false,
         inviteCode: code,
-        avatarId: avatars[random(avatars.total - 1)].id,
+        avatarId: avatars.data[random(avatars.data.length - 1)].id,
         scopes: []
       })
       entity.userId = newUser.id


### PR DESCRIPTION
## Summary
It seems like the oauth strategies were picking up avatar id from wrong result object. It should have been `avatars.data` since in below referenced PR the avatar results were updated to be paginated.

## References
#9456

## QA Steps
