### PR TITLE
Changes to restrict access to user-avatar service

### DIFF
--- a/packages/server-core/src/user/avatar/avatar.hooks.ts
+++ b/packages/server-core/src/user/avatar/avatar.hooks.ts
@@ -208,7 +208,8 @@ const updateUserAvatars = async (context: HookContext<AvatarService>) => {
       {
         query: {
           avatarId: context.id?.toString() as AvatarID
-        }
+        },
+        user: context.params.user
       }
     )
   }

--- a/packages/server-core/src/user/user-avatar/user-avatar.hooks.ts
+++ b/packages/server-core/src/user/user-avatar/user-avatar.hooks.ts
@@ -24,14 +24,17 @@ Ethereal Engine. All Rights Reserved.
 */
 
 import { hooks as schemaHooks } from '@feathersjs/schema'
-import { disallow } from 'feathers-hooks-common'
+import { disallow, discardQuery, iff, iffElse, isProvider } from 'feathers-hooks-common'
 
 import {
   userAvatarDataValidator,
   userAvatarPatchValidator,
   userAvatarQueryValidator
 } from '@etherealengine/common/src/schemas/user/user-avatar.schema'
-
+import { checkScope } from '@etherealengine/engine/src/common/functions/checkScope'
+import isAction from '../../hooks/is-action'
+import setLoggedinUserInQuery from '../../hooks/set-loggedin-user-in-query'
+import verifyScope from '../../hooks/verify-scope'
 import {
   userAvatarDataResolver,
   userAvatarExternalResolver,
@@ -47,14 +50,31 @@ export default {
 
   before: {
     all: [() => schemaHooks.validateQuery(userAvatarQueryValidator), schemaHooks.resolveQuery(userAvatarQueryResolver)],
-    find: [],
+    find: [
+      iff(
+        isProvider('external'),
+        iffElse(isAction('admin'), verifyScope('user', 'read'), setLoggedinUserInQuery('userId'))
+      ),
+      discardQuery('action')
+    ],
     get: [disallow('external')],
     create: [
       disallow('external'),
       () => schemaHooks.validateData(userAvatarDataValidator),
       schemaHooks.resolveData(userAvatarDataResolver)
     ],
-    patch: [() => schemaHooks.validateData(userAvatarPatchValidator), schemaHooks.resolveData(userAvatarPatchResolver)],
+    patch: [
+      iff(
+        isProvider('external'),
+        iffElse(
+          async (context) => await checkScope(context.params.user, 'user', 'write'),
+          [],
+          [setLoggedinUserInQuery('userId')]
+        )
+      ),
+      () => schemaHooks.validateData(userAvatarPatchValidator),
+      schemaHooks.resolveData(userAvatarPatchResolver)
+    ],
     remove: [disallow('external')]
   },
 


### PR DESCRIPTION
## Summary
This PR ensures that only authorized users have access to user-avatar service, else only own data should be accessible.

## References
closes #_insert number here_

## QA Steps
